### PR TITLE
ci: add Docker publish workflow to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` to build and push a Docker image to GitHub Container Registry (`ghcr.io`)
- Triggers on push to `main` (tagged `latest`) and on semver tags `v*.*.*`
- Multi-platform build: `linux/amd64` + `linux/arm64`
- Uses GitHub Actions cache (`type=gha`) to speed up subsequent builds
- No secrets required beyond the built-in `GITHUB_TOKEN`

## Image tags produced

| Event | Tags |
|---|---|
| Push to `main` | `ghcr.io/olivierlambert/calrs:main`, `ghcr.io/olivierlambert/calrs:latest` |
| Push tag `v0.8.6` | `ghcr.io/olivierlambert/calrs:0.8.6`, `ghcr.io/olivierlambert/calrs:0.8` |

## Test plan

- [ ] Merge and verify the workflow runs successfully in the Actions tab
- [ ] Confirm image appears at `https://github.com/olivierlambert/calrs/pkgs/container/calrs`
- [ ] Pull and run: `docker run --rm ghcr.io/olivierlambert/calrs:latest --help`