### PR TITLE
ci: add CI workflow (fmt, clippy, build, test, template checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features
+
+      - name: Build
+        run: cargo build --all-targets
+
+      - name: Test
+        run: cargo test
+
+  templates:
+    name: Templates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check templates for unclosed blocks
+        run: |
+          fail=0
+          while IFS= read -r -d '' f; do
+            opens=$(grep -c '{%[- ]*block ' "$f" || true)
+            closes=$(grep -c '{%[- ]*endblock' "$f" || true)
+            if [ "$opens" != "$closes" ]; then
+              echo "Unbalanced block/endblock in $f (block: $opens, endblock: $closes)"
+              fail=1
+            fi
+          done < <(find templates -name '*.html' -print0)
+          exit $fail


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` triggered on push and PR to `main`
- **check** job: `cargo fmt --check`, `cargo clippy` (warnings as errors via `RUSTFLAGS=-D warnings`), `cargo build`, `cargo test`; uses cargo cache to speed up runs
- **templates** job: checks all `.html` templates for balanced `{% block %}` / `{% endblock %}` tags (catches Jinja2 authoring errors without needing a Rust build)

## Test plan

- [ ] Verify the workflow appears under Actions on the target repo after merge
- [ ] Confirm the `check` job passes on a clean build
- [ ] Confirm the `templates` job passes with the current template set
- [ ] Introduce a deliberate `cargo fmt` violation or unbalanced block tag to verify failures are caught