### PR TITLE
feat: private event types with invite links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 | Host confirmation email | 0.19.0 | Host receives booking confirmed email (without ICS) after approving pending bookings |
 | UX polish | 0.20.0 | Clickable dashboard cards, hover animations, status badges, gradient profile header, admin search/filter |
 | ICS time fix | 0.19.0 | Correct UTC times in ICS when confirming/cancelling bookings from the database |
+| Private event types | 0.21.0 | Hide event types from public profile, accessible only via invite links |
+| Booking invites | 0.21.0 | Send tokenized invite links with pre-filled guest info, expiration, and usage limits |
 
 ## [Unreleased]
+
+## [0.21.0] - 2026-03-13
+
+### Added
+
+- **Private event types** — mark any event type as "private" to hide it from your public profile and group pages. Private event types are only accessible via invite links.
+- **Booking invites** — send personalized invite links for private event types
+  - Invite management page at `/dashboard/invites/{event_type_id}` with sent invite list and status badges (active/expired/used)
+  - Send invites with guest name, email, optional personal message, expiration (7/14/30 days or never), and single-use or multi-use toggle
+  - Invite email sent via SMTP with indigo accent color, event details, and "Choose a time" CTA button
+  - Tokenized URLs preserve the invite token through the full booking flow (slot picker → booking form → confirmation)
+  - Guest name and email auto-filled from the invite data on the booking form
+  - Token validated at every step: expired, used-up, or invalid tokens are rejected with a clear error
+  - `used_count` incremented on successful booking
+  - Works with both personal and group event types (round-robin assignment preserved)
+  - Any user with dashboard access can create invites for private event types they can see (enables sales reps to invite guests to demo team event types)
+  - New migration: `is_private` column on `event_types`, `booking_invites` table with token, expiration, usage tracking
 
 ## [0.20.4] - 2026-03-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ calrs/
 │   ├── 013_booking_email.sql     ← booking_email on users
 │   ├── 014_team_links.sql        ← team_links, team_link_members, team_link_bookings tables
 │   ├── 015_user_profile.sql      ← title, bio, avatar_path on users
-│   └── 016_booking_unique.sql    ← partial unique index for double-booking prevention
+│   ├── 016_booking_unique.sql    ← partial unique index for double-booking prevention
+│   └── 018_private_invites.sql   ← is_private on event_types, booking_invites table
 ├── templates/
 │   ├── base.html                 ← base layout + CSS (light/dark mode)
 │   ├── dashboard_base.html       ← sidebar layout (extends base.html, all dashboard pages extend this)
@@ -78,6 +79,7 @@ calrs/
 │   ├── settings.html             ← profile & settings with avatar/title/bio (extends dashboard_base)
 │   ├── admin.html                ← admin dashboard (extends dashboard_base)
 │   ├── event_type_form.html      ← create/edit event types (extends dashboard_base)
+│   ├── invite_form.html          ← invite management for private event types (extends dashboard_base)
 │   ├── source_form.html          ← add CalDAV source (extends dashboard_base)
 │   ├── source_test.html          ← connection test / sync results (extends dashboard_base)
 │   ├── team_link_form.html       ← create team link (extends dashboard_base)
@@ -135,12 +137,13 @@ Key tables:
 - **`caldav_sources`** — CalDAV server connections (URL, credentials, sync state, `write_calendar_href`). `enabled` flag, `ON DELETE CASCADE`
 - **`calendars`** — calendar collections discovered under a source; `is_busy=1` means events block availability
 - **`events`** — cached remote events from CalDAV sync; unique on `(uid, COALESCE(recurrence_id, ''))`, stores `raw_ical`, `etag`, `rrule`, `all_day`, `timezone`, `recurrence_id`, `status`
-- **`event_types`** — bookable meeting templates (slug unique per account, `duration_min`, `buffer_before`/`buffer_after`, `min_notice_min`, `location_type`/`location_value`, `requires_confirmation`, `group_id`, `created_by_user_id`, `reminder_minutes`)
+- **`event_types`** — bookable meeting templates (slug unique per account, `duration_min`, `buffer_before`/`buffer_after`, `min_notice_min`, `location_type`/`location_value`, `requires_confirmation`, `is_private`, `group_id`, `created_by_user_id`, `reminder_minutes`)
 - **`availability_rules`** — weekly recurring windows per event type (day_of_week 0=Sun…6=Sat, HH:MM times)
 - **`availability_overrides`** — date-specific exceptions (day off, special hours). `is_blocked` flag
 - **`bookings`** — bookings with `uid` (iCal), guest info, status (confirmed/pending/cancelled/declined), `cancel_token`/`reschedule_token`/`confirm_token`, `assigned_user_id` (for group round-robin), `caldav_calendar_href` (write-back tracking), `reminder_sent_at` (tracks when reminder email was sent)
 - **`smtp_config`** — SMTP server settings (host, port, credentials, sender), one per account
 - **`event_type_calendars`** — junction table linking event types to specific calendars for per-event-type calendar selection. Empty = use all `is_busy=1` calendars (backward-compatible default)
+- **`booking_invites`** — tokenized invite links for private event types: `token` (unique), `event_type_id`, `guest_name`, `guest_email`, `message`, `expires_at`, `max_uses`, `used_count`, `created_by_user_id`
 - **`groups`** / **`user_groups`** — group system synced from Keycloak OIDC; groups have `slug` for public URLs
 
 All primary keys are UUID v4 strings. Datetimes are ISO8601 strings.
@@ -221,6 +224,8 @@ File: `src/web/mod.rs`, templates in `templates/`
 **Per-event-type calendar selection:** Event type form includes calendar checkboxes (from `is_busy=1` calendars). Selected calendars are stored in `event_type_calendars` junction table. When computing busy times, if no calendars are selected all `is_busy=1` calendars are checked (backward-compatible). The filter uses `NOT EXISTS / IN` subquery on `event_type_calendars` and is applied in `fetch_busy_times_for_user()`, troubleshoot handler, and CLI commands.
 
 **Group event types:** Created under a group from the dashboard. Combined availability shows slots where ANY group member is free. Round-robin assignment picks the least-busy available member. Public URLs: `/g/{group-slug}/{slug}`.
+
+**Private event types & invites:** Event types with `is_private=1` are hidden from public profiles and group pages. Access is granted via `booking_invites` — tokenized links sent by email. The invite token is propagated through the booking flow via query params (`?invite=TOKEN`) and hidden form fields. Guest name/email are pre-filled from the invite. Token validation checks expiration and usage limits at every step. Any dashboard user can send invites for private event types. Invite management at `/dashboard/invites/{event_type_id}`. Invite emails use indigo accent (#6366f1).
 
 **On-demand sync:** Slot pages (`/u/`, `/g/`, legacy `/{slug}`) and the troubleshoot view automatically sync the host's CalDAV sources if stale (>5 minutes since last sync). Uses `sync_if_stale()` from `commands/sync.rs` which calls `fetch_events_since()` with a time-range filter (RFC 4791) to only pull future events, with fallback to full fetch for servers that don't support it.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@
 - **Public group pages** — bookable at `/g/{group-slug}/{slug}`
 - **Ad-hoc team links** — create shareable booking links across hand-picked users, no admin-managed group needed. Finds slots where ALL selected members are free. One-time use, auto-deleted after booking. CalDAV write-back to every member's calendar
 
+### Private event types & invites
+
+- **Private event types** — hide event types from your public profile; only accessible via invite links
+- **Booking invites** — send personalized invite links with guest name, email, optional message, expiration, and usage limits. Guest info auto-filled on the booking form. Works with both personal and group event types (round-robin preserved). Any dashboard user can send invites for private event types they can see.
+
 ### Authentication
 
 - **Local accounts** — email/password with Argon2 hashing, server-side sessions, HttpOnly cookies
@@ -424,6 +429,7 @@ calrs/
 │   ├── slots.html           Slot picker (timezone aware)
 │   ├── book.html            Booking form
 │   ├── confirmed.html       Confirmation / pending page
+│   ├── invite_form.html     Invite management (send + list)
 │   ├── troubleshoot.html    Availability troubleshoot timeline
 │   ├── booking_approved.html   Email approve success
 │   ├── booking_decline_form.html  Email decline form
@@ -466,6 +472,7 @@ calrs/
 - [x] Admin impersonation
 - [x] Per-event-type calendar selection
 - [x] Ad-hoc team links (shareable booking across multiple users)
+- [x] Private event types with invite links
 - [ ] Webhooks (per-event-type HTTP callbacks on new/cancelled bookings)
 - [ ] Reschedule flow (change date/time without cancelling)
 - [ ] Availability overrides (block specific dates, add special hours)

--- a/docs/src/booking-flow.md
+++ b/docs/src/booking-flow.md
@@ -2,11 +2,11 @@
 
 ## Guest experience
 
-1. **Visit the booking page** — `/u/host/meeting-slug`
+1. **Visit the booking page** — `/u/host/meeting-slug` (or via an invite link for private event types)
 2. **Pick a timezone** — auto-detected from the browser, changeable via dropdown
 3. **Browse available slots** — displayed as a week view, navigate with Previous/Next buttons
 4. **Click a slot** — opens the booking form
-5. **Fill in details** — name, email, optional notes
+5. **Fill in details** — name, email, optional notes (pre-filled from invite if applicable)
 6. **Submit** — booking is created
 7. **Confirmation page** — shows booking summary
 8. **Email** — guest receives a confirmation email with an `.ics` calendar invite attached
@@ -85,6 +85,7 @@ If SMTP is configured, calrs sends emails at these moments:
 | Booking declined | Decline notice (with optional reason) | — |
 | Booking cancelled | Cancellation + `.ics` CANCEL | Cancellation + `.ics` CANCEL |
 | Booking reminder | Reminder with cancel button | Reminder with details |
+| Invite sent | Invite email with booking link | — |
 
 All emails are sent as **HTML with plain text fallback**. They include event title, date, time, timezone, location, and notes. The HTML templates are responsive and support dark mode in email clients that honor `prefers-color-scheme`.
 

--- a/docs/src/event-types.md
+++ b/docs/src/event-types.md
@@ -84,10 +84,51 @@ The location is displayed on the public booking page, in confirmation emails, an
 
 Event types can be toggled on/off from the dashboard without deleting them. Disabled event types don't show up on your public profile and return 404 on their booking page.
 
+## Private event types
+
+Event types can be marked as **private** to hide them from your public profile page and group pages. Private event types are only accessible via invite links — guests cannot find or book them directly.
+
+### Enabling private mode
+
+In the event type form, check the **Private** checkbox under the Notifications section. Private event types show an indigo "private" badge on the dashboard.
+
+### Invite links
+
+Private event types use **booking invites** to grant access:
+
+1. Go to **Dashboard > Event Types** and click **Invite** on a private event type
+2. Fill in the guest's name, email, and an optional personal message
+3. Choose an expiration (7, 14, or 30 days, or never) and whether to allow multiple bookings
+4. Click **Send invite** — the guest receives an email with a personalized booking link
+
+The invite link takes the guest directly to the slot picker with the invite token embedded. Their name and email are pre-filled on the booking form. The token is validated at every step (expired, used-up, or invalid tokens are rejected).
+
+### Use case: sales-qualified demos
+
+A common pattern is to create a **private group event type** for a demo team:
+
+1. Create a group event type (e.g., "Product Demo") under the Demo group
+2. Mark it as private
+3. Sales reps (who have dashboard access) can send invites to qualified leads
+4. The demo is automatically assigned to the least-busy team member via round-robin
+5. The sales rep never needs to coordinate calendars manually
+
+### Invite management
+
+The invite management page (`/dashboard/invites/{event_type_id}`) shows:
+
+- A form to send new invites
+- A list of sent invites with status badges:
+  - **Active** — invite is valid and unused (or has remaining uses)
+  - **Expired** — past the expiration date
+  - **Used** — all uses consumed (for single-use invites)
+- Delete button to revoke an invite
+
 ## Public URLs
 
 ![Public profile page](images/profile.png)
 
-- **Profile:** `/u/yourname` — lists all enabled event types
+- **Profile:** `/u/yourname` — lists all enabled, non-private event types
 - **Slot picker:** `/u/yourname/slug` — shows available time slots
 - **Booking form:** `/u/yourname/slug/book?date=...&time=...` — booking form for a specific slot
+- **Invite booking:** same URLs with `?invite={token}` — for private event types accessed via invite links

--- a/migrations/018_private_invites.sql
+++ b/migrations/018_private_invites.sql
@@ -1,0 +1,20 @@
+-- Add is_private flag to event_types
+ALTER TABLE event_types ADD COLUMN is_private INTEGER NOT NULL DEFAULT 0;
+
+-- Booking invites table
+CREATE TABLE IF NOT EXISTS booking_invites (
+    id TEXT PRIMARY KEY,
+    event_type_id TEXT NOT NULL REFERENCES event_types(id) ON DELETE CASCADE,
+    token TEXT NOT NULL UNIQUE,
+    guest_name TEXT NOT NULL,
+    guest_email TEXT NOT NULL,
+    message TEXT,
+    expires_at TEXT,
+    max_uses INTEGER NOT NULL DEFAULT 1,
+    used_count INTEGER NOT NULL DEFAULT 0,
+    created_by_user_id TEXT NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_booking_invites_token ON booking_invites(token);
+CREATE INDEX IF NOT EXISTS idx_booking_invites_event_type ON booking_invites(event_type_id);

--- a/src/db.rs
+++ b/src/db.rs
@@ -93,6 +93,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "017_events_per_calendar",
             include_str!("../migrations/017_events_per_calendar.sql"),
         ),
+        (
+            "018_private_invites",
+            include_str!("../migrations/018_private_invites.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -314,6 +318,7 @@ mod tests {
             "team_links",
             "team_link_members",
             "team_link_bookings",
+            "booking_invites",
         ];
 
         for table in &expected_tables {
@@ -341,7 +346,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 17, "All 17 migrations should be tracked");
+        assert_eq!(count.0, 18, "All 18 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -355,7 +360,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 17, "Still 17 migrations after second run");
+        assert_eq!(count.0, 18, "Still 18 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -1400,6 +1400,96 @@ pub async fn send_test_email(config: &SmtpConfig, to_email: &str) -> Result<()> 
     send_email(config, email).await
 }
 
+/// Send a booking invite email to a guest
+pub async fn send_invite_email(
+    config: &SmtpConfig,
+    guest_name: &str,
+    guest_email: &str,
+    event_title: &str,
+    host_name: &str,
+    message: Option<&str>,
+    invite_url: &str,
+    expires_at: Option<&str>,
+) -> Result<()> {
+    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
+    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
+    let to = format!("{} <{}>", guest_name, guest_email).parse()?;
+
+    let expiry_note = expires_at
+        .map(|e| format!("\nThis invite expires on {}.", e))
+        .unwrap_or_default();
+    let message_note = message
+        .filter(|m| !m.trim().is_empty())
+        .map(|m| format!("\n\n\"{}\"\n", m))
+        .unwrap_or_default();
+
+    let plain = format!(
+        "Hi {},\n\n\
+         {} has invited you to book: {}\n\
+         {}\
+         Click the link below to choose a time:\n\
+         {}\n\
+         {}\n\
+         \u{2014} calrs",
+        guest_name, host_name, event_title, message_note, invite_url, expiry_note,
+    );
+
+    let mut rows = vec![
+        EmailRow {
+            label: "Event",
+            value: event_title.to_string(),
+        },
+        EmailRow {
+            label: "Invited by",
+            value: host_name.to_string(),
+        },
+    ];
+    if let Some(msg) = message.filter(|m| !m.trim().is_empty()) {
+        rows.push(EmailRow {
+            label: "Message",
+            value: msg.to_string(),
+        });
+    }
+    if let Some(exp) = expires_at {
+        rows.push(EmailRow {
+            label: "Expires",
+            value: exp.to_string(),
+        });
+    }
+
+    let actions = vec![EmailAction {
+        label: "Choose a time".to_string(),
+        url: invite_url.to_string(),
+        color: "#6366f1".to_string(),
+    }];
+
+    let html = render_html_email_with_actions(
+        &format!("Hi {},", h(guest_name)),
+        &format!(
+            "{} has invited you to book: {}",
+            h(host_name),
+            h(event_title)
+        ),
+        "#6366f1",
+        &rows,
+        None,
+        &actions,
+    );
+
+    let body = build_multipart_body(&plain, &html);
+
+    let email = Message::builder()
+        .from(from)
+        .to(to)
+        .subject(format!(
+            "{} invited you to book: {}",
+            host_name, event_title
+        ))
+        .multipart(body)?;
+
+    send_email(config, email).await
+}
+
 async fn send_email(config: &SmtpConfig, email: Message) -> Result<()> {
     let creds = Credentials::new(config.username.clone(), config.password.clone());
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -126,6 +126,22 @@ pub struct EventType {
     pub created_at: String,
     pub group_id: Option<String>,
     pub created_by_user_id: Option<String>,
+    pub is_private: bool,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct BookingInvite {
+    pub id: String,
+    pub event_type_id: String,
+    pub token: String,
+    pub guest_name: String,
+    pub guest_email: String,
+    pub message: Option<String>,
+    pub expires_at: Option<String>,
+    pub max_uses: i32,
+    pub used_count: i32,
+    pub created_by_user_id: String,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -408,6 +408,13 @@ pub fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8; 32]) 
             "/dashboard/event-types/{slug}/delete",
             post(delete_event_type),
         )
+        // Invite management
+        .route(
+            "/dashboard/invites/{event_type_id}",
+            get(invite_management_page),
+        )
+        .route("/dashboard/invites/{event_type_id}/send", post(send_invite))
+        .route("/dashboard/invites/{invite_id}/delete", post(delete_invite))
         // Calendar source management
         .route(
             "/dashboard/sources/new",
@@ -662,9 +669,10 @@ async fn dashboard_event_types(
 ) -> impl IntoResponse {
     let user = &auth_user.user;
 
-    let event_types: Vec<(String, String, i32, bool, i32, i64)> = sqlx::query_as(
-        "SELECT et.slug, et.title, et.duration_min, et.enabled, et.requires_confirmation,
-                (SELECT COUNT(*) FROM bookings b WHERE b.event_type_id = et.id AND b.status IN ('confirmed', 'pending')) as active_bookings
+    let event_types: Vec<(String, String, String, i32, bool, i32, i64, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.duration_min, et.enabled, et.requires_confirmation,
+                (SELECT COUNT(*) FROM bookings b WHERE b.event_type_id = et.id AND b.status IN ('confirmed', 'pending')) as active_bookings,
+                et.is_private
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          WHERE a.user_id = ? AND et.group_id IS NULL
@@ -675,9 +683,10 @@ async fn dashboard_event_types(
     .await
     .unwrap_or_default();
 
-    let group_event_types: Vec<(String, String, i32, bool, String, String, i64)> = sqlx::query_as(
-        "SELECT et.slug, et.title, et.duration_min, et.enabled, g.name, g.slug,
-                (SELECT COUNT(*) FROM bookings b WHERE b.event_type_id = et.id AND b.status IN ('confirmed', 'pending')) as active_bookings
+    let group_event_types: Vec<(String, String, String, i32, bool, String, String, i64, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.duration_min, et.enabled, g.name, g.slug,
+                (SELECT COUNT(*) FROM bookings b WHERE b.event_type_id = et.id AND b.status IN ('confirmed', 'pending')) as active_bookings,
+                et.is_private
          FROM event_types et
          JOIN groups g ON g.id = et.group_id
          JOIN user_groups ug ON ug.group_id = g.id
@@ -704,15 +713,15 @@ async fn dashboard_event_types(
 
     let et_ctx: Vec<minijinja::Value> = event_types
         .iter()
-        .map(|(slug, title, duration, enabled, req_conf, active_bookings)| {
-            context! { slug => slug, title => title, duration_min => duration, enabled => enabled, requires_confirmation => *req_conf != 0, active_bookings => active_bookings }
+        .map(|(id, slug, title, duration, enabled, req_conf, active_bookings, is_priv)| {
+            context! { id => id, slug => slug, title => title, duration_min => duration, enabled => enabled, requires_confirmation => *req_conf != 0, active_bookings => active_bookings, is_private => *is_priv != 0 }
         })
         .collect();
 
     let group_et_ctx: Vec<minijinja::Value> = group_event_types
         .iter()
-        .map(|(slug, title, duration, enabled, group_name, group_slug, active_bookings)| {
-            context! { slug => slug, title => title, duration_min => duration, enabled => enabled, group_name => group_name, group_slug => group_slug, active_bookings => active_bookings }
+        .map(|(id, slug, title, duration, enabled, group_name, group_slug, active_bookings, is_priv)| {
+            context! { id => id, slug => slug, title => title, duration_min => duration, enabled => enabled, group_name => group_name, group_slug => group_slug, active_bookings => active_bookings, is_private => *is_priv != 0 }
         })
         .collect();
 
@@ -1467,6 +1476,7 @@ struct EventTypeForm {
     buffer_after: Option<i32>,
     min_notice_min: Option<i32>,
     requires_confirmation: Option<String>, // checkbox: "on" or absent
+    is_private: Option<String>,            // checkbox: "on" or absent
     location_type: Option<String>,         // "link", "phone", "in_person", "custom"
     location_value: Option<String>,
     // Availability schedule
@@ -1546,6 +1556,7 @@ async fn new_event_type_form(
             form_buffer_after => 0,
             form_min_notice => 60,
             form_requires_confirmation => false,
+            form_is_private => false,
             form_location_type => "link",
             form_location_value => "",
             form_avail_days => "1,2,3,4,5",
@@ -1611,6 +1622,7 @@ async fn create_event_type(
 
     let et_id = uuid::Uuid::new_v4().to_string();
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let is_private = form.is_private.as_deref() == Some("on");
 
     let location_type = form.location_type.as_deref().unwrap_or("link");
     let location_value = form
@@ -1624,8 +1636,8 @@ async fn create_event_type(
     let reminder_minutes = form.reminder_minutes.filter(|&m| m > 0);
 
     let _ = sqlx::query(
-        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, group_id, created_by_user_id, reminder_minutes)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, group_id, created_by_user_id, reminder_minutes, is_private)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&et_id)
     .bind(&account_id)
@@ -1642,6 +1654,7 @@ async fn create_event_type(
     .bind(group_id)
     .bind(if group_id.is_some() { Some(&user.id) } else { None })
     .bind(reminder_minutes)
+    .bind(is_private as i32)
     .execute(&state.pool)
     .await;
 
@@ -1701,8 +1714,8 @@ async fn edit_event_type_form(
 ) -> impl IntoResponse {
     let user = &auth_user.user;
 
-    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, i32, String, Option<String>, Option<i32>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, et.reminder_minutes
+    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, i32, String, Option<String>, Option<i32>, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, et.reminder_minutes, et.is_private
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          WHERE a.user_id = ? AND et.slug = ?",
@@ -1726,6 +1739,7 @@ async fn edit_event_type_form(
         loc_type,
         loc_value,
         reminder_min,
+        is_private,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
@@ -1824,6 +1838,7 @@ async fn edit_event_type_form(
             form_buffer_after => buf_after,
             form_min_notice => min_notice,
             form_requires_confirmation => requires_conf != 0,
+            form_is_private => is_private != 0,
             form_location_type => loc_type,
             form_location_value => loc_value.unwrap_or_default(),
             form_avail_days => avail_days,
@@ -1871,6 +1886,7 @@ async fn update_event_type(
 
     let new_slug = form.slug.trim().to_lowercase().replace(' ', "-");
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let is_private = form.is_private.as_deref() == Some("on");
 
     // Check slug uniqueness if changed
     if new_slug != slug {
@@ -1903,7 +1919,7 @@ async fn update_event_type(
     let reminder_minutes = form.reminder_minutes.filter(|&m| m > 0);
 
     let _ = sqlx::query(
-        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ? WHERE id = ?",
+        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, is_private = ? WHERE id = ?",
     )
     .bind(&new_slug)
     .bind(form.title.trim())
@@ -1916,6 +1932,7 @@ async fn update_event_type(
     .bind(location_type)
     .bind(location_value)
     .bind(reminder_minutes)
+    .bind(is_private as i32)
     .bind(&et_id)
     .execute(&state.pool)
     .await;
@@ -3468,6 +3485,7 @@ fn render_event_type_form_error(
             form_buffer_after => form.buffer_after.unwrap_or(0),
             form_min_notice => form.min_notice_min.unwrap_or(60),
             form_requires_confirmation => form.requires_confirmation.as_deref() == Some("on"),
+            form_is_private => form.is_private.as_deref() == Some("on"),
             form_location_type => form.location_type.as_deref().unwrap_or("link"),
             form_location_value => form.location_value.as_deref().unwrap_or(""),
             form_avail_days => form.avail_days.as_deref().unwrap_or("1,2,3,4,5"),
@@ -3481,6 +3499,269 @@ fn render_event_type_form_error(
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
+}
+
+// --- Invite management handlers ---
+
+#[derive(Deserialize)]
+struct InviteForm {
+    _csrf: Option<String>,
+    guest_name: String,
+    guest_email: String,
+    message: Option<String>,
+    expires_days: Option<i32>,
+    single_use: Option<String>, // checkbox: "on" or absent
+}
+
+async fn invite_management_page(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::auth::AuthUser,
+    Path(event_type_id): Path<String>,
+) -> impl IntoResponse {
+    // Any authenticated user can see invites for any private event type
+    let et: Option<(
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )> = sqlx::query_as(
+        "SELECT et.id, et.title, et.slug,
+                CASE WHEN et.group_id IS NOT NULL THEN g.slug ELSE NULL END,
+                CASE WHEN et.group_id IS NULL THEN u.username ELSE NULL END,
+                CASE WHEN et.group_id IS NOT NULL THEN g.name ELSE u.name END
+         FROM event_types et
+         LEFT JOIN groups g ON g.id = et.group_id
+         LEFT JOIN accounts a ON a.id = et.account_id
+         LEFT JOIN users u ON u.id = a.user_id
+         WHERE et.id = ? AND et.is_private = 1",
+    )
+    .bind(&event_type_id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
+
+    let (et_id, et_title, et_slug, group_slug, username, owner_name) = match et {
+        Some(e) => e,
+        None => return Html("Private event type not found.".to_string()),
+    };
+
+    let invites: Vec<(String, String, String, Option<String>, Option<String>, i32, i32, String, String)> = sqlx::query_as(
+        "SELECT bi.id, bi.guest_name, bi.guest_email, bi.message, bi.expires_at, bi.max_uses, bi.used_count, bi.created_at, u.name
+         FROM booking_invites bi
+         JOIN users u ON u.id = bi.created_by_user_id
+         WHERE bi.event_type_id = ?
+         ORDER BY bi.created_at DESC",
+    )
+    .bind(&et_id)
+    .fetch_all(&state.pool)
+    .await
+    .unwrap_or_default();
+
+    let invites_ctx: Vec<minijinja::Value> = invites
+        .iter()
+        .map(
+            |(
+                id,
+                guest_name,
+                guest_email,
+                message,
+                expires_at,
+                max_uses,
+                used_count,
+                created_at,
+                created_by,
+            )| {
+                let is_expired = expires_at.as_ref().is_some_and(|exp| {
+                    exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string()
+                });
+                let is_used = *used_count >= *max_uses;
+                context! {
+                    id => id,
+                    guest_name => guest_name,
+                    guest_email => guest_email,
+                    message => message,
+                    expires_at => expires_at,
+                    max_uses => max_uses,
+                    used_count => used_count,
+                    created_at => created_at,
+                    created_by => created_by,
+                    is_expired => is_expired,
+                    is_used => is_used,
+                }
+            },
+        )
+        .collect();
+
+    let tmpl = match state.templates.get_template("invite_form.html") {
+        Ok(t) => t,
+        Err(e) => return Html(format!("Template error: {}", e)),
+    };
+
+    let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
+    Html(
+        tmpl.render(context! {
+            sidebar => sidebar_context(&auth_user, "event-types"),
+            impersonating => impersonating,
+            impersonating_name => impersonating_name,
+            event_type_id => et_id,
+            event_type_title => et_title,
+            event_type_slug => et_slug,
+            group_slug => group_slug,
+            username => username,
+            owner_name => owner_name,
+            invites => invites_ctx,
+            success => "",
+            error => "",
+        })
+        .unwrap_or_else(|e| format!("Template error: {}", e)),
+    )
+}
+
+async fn send_invite(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::auth::AuthUser,
+    headers: HeaderMap,
+    Path(event_type_id): Path<String>,
+    Form(form): Form<InviteForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    // Verify event type exists and is private
+    let et: Option<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT et.id, et.title,
+                CASE WHEN et.group_id IS NOT NULL THEN g.slug ELSE NULL END,
+                CASE WHEN et.group_id IS NULL THEN u.username ELSE NULL END
+         FROM event_types et
+         LEFT JOIN groups g ON g.id = et.group_id
+         LEFT JOIN accounts a ON a.id = et.account_id
+         LEFT JOIN users u ON u.id = a.user_id
+         WHERE et.id = ? AND et.is_private = 1",
+    )
+    .bind(&event_type_id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
+
+    let (et_id, et_title, group_slug, username) = match et {
+        Some(e) => e,
+        None => return Redirect::to("/dashboard/event-types").into_response(),
+    };
+
+    // Validate inputs
+    let guest_name = form.guest_name.trim();
+    let guest_email = form.guest_email.trim();
+    if guest_name.is_empty() || guest_email.is_empty() || !guest_email.contains('@') {
+        return Redirect::to(&format!("/dashboard/invites/{}", et_id)).into_response();
+    }
+
+    let token = uuid::Uuid::new_v4().to_string();
+    let single_use = form.single_use.as_deref() != Some("on");
+    let max_uses = if single_use { 1 } else { 999 };
+    let expires_at = form.expires_days.filter(|&d| d > 0).map(|days| {
+        (chrono::Utc::now() + chrono::Duration::days(days as i64))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    });
+
+    let _ = sqlx::query(
+        "INSERT INTO booking_invites (id, event_type_id, token, guest_name, guest_email, message, expires_at, max_uses, created_by_user_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(uuid::Uuid::new_v4().to_string())
+    .bind(&et_id)
+    .bind(&token)
+    .bind(guest_name)
+    .bind(guest_email)
+    .bind(form.message.as_deref().filter(|s| !s.trim().is_empty()))
+    .bind(&expires_at)
+    .bind(max_uses)
+    .bind(&auth_user.user.id)
+    .execute(&state.pool)
+    .await;
+
+    tracing::info!(event_type = %et_id, guest = %guest_email, invited_by = %auth_user.user.email, "invite created");
+
+    // Construct invite URL and send email
+    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    if !base_url.is_empty() {
+        let et_slug: Option<String> =
+            sqlx::query_scalar("SELECT slug FROM event_types WHERE id = ?")
+                .bind(&et_id)
+                .fetch_optional(&state.pool)
+                .await
+                .unwrap_or(None);
+
+        if let Some(slug) = et_slug {
+            let invite_url = if let Some(gs) = &group_slug {
+                format!("{}/g/{}/{}?invite={}", base_url, gs, slug, token)
+            } else if let Some(un) = &username {
+                format!("{}/u/{}/{}?invite={}", base_url, un, slug, token)
+            } else {
+                String::new()
+            };
+
+            if !invite_url.is_empty() {
+                if let Ok(Some(smtp_config)) =
+                    crate::email::load_smtp_config(&state.pool, &state.secret_key).await
+                {
+                    let _ = crate::email::send_invite_email(
+                        &smtp_config,
+                        guest_name,
+                        guest_email,
+                        &et_title,
+                        &auth_user.user.name,
+                        form.message.as_deref(),
+                        &invite_url,
+                        expires_at.as_deref(),
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+
+    Redirect::to(&format!("/dashboard/invites/{}", et_id)).into_response()
+}
+
+#[derive(Deserialize)]
+struct DeleteInviteForm {
+    _csrf: Option<String>,
+}
+
+async fn delete_invite(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::auth::AuthUser,
+    headers: HeaderMap,
+    Path(invite_id): Path<String>,
+    Form(form): Form<DeleteInviteForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    // Get the event_type_id before deleting for redirect
+    let et_id: Option<String> =
+        sqlx::query_scalar("SELECT event_type_id FROM booking_invites WHERE id = ?")
+            .bind(&invite_id)
+            .fetch_optional(&state.pool)
+            .await
+            .unwrap_or(None);
+
+    let _ = sqlx::query("DELETE FROM booking_invites WHERE id = ?")
+        .bind(&invite_id)
+        .execute(&state.pool)
+        .await;
+
+    tracing::info!(invite_id = %invite_id, deleted_by = %auth_user.user.email, "invite deleted");
+
+    match et_id {
+        Some(id) => Redirect::to(&format!("/dashboard/invites/{}", id)).into_response(),
+        None => Redirect::to("/dashboard/event-types").into_response(),
+    }
 }
 
 // --- Group event type handlers ---
@@ -3665,8 +3946,8 @@ async fn edit_group_event_type_form(
 ) -> impl IntoResponse {
     let user = &auth_user.user;
 
-    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, i32, String, Option<String>, Option<i32>, String)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, et.reminder_minutes, et.group_id
+    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, i32, String, Option<String>, Option<i32>, String, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, et.reminder_minutes, et.group_id, et.is_private
          FROM event_types et
          JOIN user_groups ug ON ug.group_id = et.group_id
          WHERE ug.user_id = ? AND et.slug = ? AND et.group_id IS NOT NULL",
@@ -3691,6 +3972,7 @@ async fn edit_group_event_type_form(
         loc_value,
         reminder_min,
         _group_id,
+        is_private,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
@@ -3751,6 +4033,7 @@ async fn edit_group_event_type_form(
             form_buffer_after => buf_after,
             form_min_notice => min_notice,
             form_requires_confirmation => requires_conf != 0,
+            form_is_private => is_private != 0,
             form_location_type => loc_type,
             form_location_value => loc_value.unwrap_or_default(),
             form_avail_days => avail_days,
@@ -3798,6 +4081,7 @@ async fn update_group_event_type(
 
     let new_slug = form.slug.trim().to_lowercase().replace(' ', "-");
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let is_private = form.is_private.as_deref() == Some("on");
 
     // Check slug uniqueness within the group if changed
     if new_slug != slug {
@@ -3829,7 +4113,7 @@ async fn update_group_event_type(
     let reminder_minutes = form.reminder_minutes.filter(|&m| m > 0);
 
     let _ = sqlx::query(
-        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ? WHERE id = ?",
+        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, is_private = ? WHERE id = ?",
     )
     .bind(&new_slug)
     .bind(form.title.trim())
@@ -3842,6 +4126,7 @@ async fn update_group_event_type(
     .bind(location_type)
     .bind(location_value)
     .bind(reminder_minutes)
+    .bind(is_private as i32)
     .bind(&et_id)
     .execute(&state.pool)
     .await;
@@ -3997,7 +4282,7 @@ async fn group_profile(
     let event_types: Vec<(String, String, Option<String>, i32)> = sqlx::query_as(
         "SELECT et.slug, et.title, et.description, et.duration_min
          FROM event_types et
-         WHERE et.group_id = ? AND et.enabled = 1
+         WHERE et.group_id = ? AND et.enabled = 1 AND et.is_private = 0
          ORDER BY et.created_at",
     )
     .bind(&group_id)
@@ -4032,8 +4317,8 @@ async fn show_group_slots(
     Path((group_slug, slug)): Path<(String, String)>,
     Query(query): Query<SlotsQuery>,
 ) -> impl IntoResponse {
-    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.location_type, et.location_value, g.name
+    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, String, Option<String>, String, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.location_type, et.location_value, g.name, et.is_private
          FROM event_types et
          JOIN groups g ON g.id = et.group_id
          WHERE g.slug = ? AND et.slug = ? AND et.enabled = 1",
@@ -4056,10 +4341,41 @@ async fn show_group_slots(
         loc_type,
         loc_value,
         group_name,
+        is_private,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
     };
+
+    // Validate invite token for private event types
+    if is_private != 0 {
+        let token = match &query.invite {
+            Some(t) => t,
+            None => return Html("This event type requires an invite link.".to_string()),
+        };
+        let invite: Option<(Option<String>, i32, i32)> = sqlx::query_as(
+            "SELECT expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
+        )
+        .bind(token)
+        .bind(&et_id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+
+        match invite {
+            None => return Html("Invalid invite link.".to_string()),
+            Some((expires_at, max_uses, used_count)) => {
+                if let Some(exp) = &expires_at {
+                    if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
+                        return Html("This invite link has expired.".to_string());
+                    }
+                }
+                if used_count >= max_uses {
+                    return Html("This invite link has already been used.".to_string());
+                }
+            }
+        }
+    }
 
     let guest_tz = parse_guest_tz(query.tz.as_deref());
     let host_tz = get_host_tz(&state.pool, &et_id).await;
@@ -4193,6 +4509,7 @@ async fn show_group_slots(
             range_label => range_label,
             guest_tz => guest_tz_name,
             tz_options => tz_options,
+            invite_token => query.invite.as_deref().unwrap_or(""),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -4204,8 +4521,8 @@ async fn show_group_book_form(
     Path((group_slug, slug)): Path<(String, String)>,
     Query(query): Query<BookQuery>,
 ) -> impl IntoResponse {
-    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, g.name
+    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, g.name, et.is_private
          FROM event_types et
          JOIN groups g ON g.id = et.group_id
          WHERE g.slug = ? AND et.slug = ? AND et.enabled = 1",
@@ -4216,10 +4533,48 @@ async fn show_group_book_form(
     .await
     .unwrap_or(None);
 
-    let (_et_id, et_slug, et_title, et_desc, duration, loc_type, loc_value, group_name) = match et {
-        Some(e) => e,
-        None => return Html("Event type not found.".to_string()),
-    };
+    let (et_id, et_slug, et_title, et_desc, duration, loc_type, loc_value, group_name, is_private) =
+        match et {
+            Some(e) => e,
+            None => return Html("Event type not found.".to_string()),
+        };
+
+    // Validate invite token for private event types
+    let invite_guest_name;
+    let invite_guest_email;
+    if is_private != 0 {
+        let token = match &query.invite {
+            Some(t) => t,
+            None => return Html("This event type requires an invite link.".to_string()),
+        };
+        let invite: Option<(String, String, Option<String>, i32, i32)> = sqlx::query_as(
+            "SELECT guest_name, guest_email, expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
+        )
+        .bind(token)
+        .bind(&et_id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+
+        match invite {
+            None => return Html("Invalid invite link.".to_string()),
+            Some((name, email, expires_at, max_uses, used_count)) => {
+                if let Some(exp) = &expires_at {
+                    if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
+                        return Html("This invite link has expired.".to_string());
+                    }
+                }
+                if used_count >= max_uses {
+                    return Html("This invite link has already been used.".to_string());
+                }
+                invite_guest_name = Some(name);
+                invite_guest_email = Some(email);
+            }
+        }
+    } else {
+        invite_guest_name = None;
+        invite_guest_email = None;
+    }
 
     let guest_tz = parse_guest_tz(query.tz.as_deref());
     let guest_tz_name = guest_tz.name().to_string();
@@ -4260,9 +4615,10 @@ async fn show_group_book_form(
             time_end => end_time,
             guest_tz => guest_tz_name,
             error => "",
-            form_name => "",
-            form_email => "",
+            form_name => invite_guest_name.as_deref().unwrap_or(""),
+            form_email => invite_guest_email.as_deref().unwrap_or(""),
             form_notes => "",
+            invite_token => query.invite.as_deref().unwrap_or(""),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -4296,8 +4652,8 @@ async fn handle_group_booking(
         return Html(e).into_response();
     }
 
-    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, et.group_id, et.reminder_minutes
+    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, et.group_id, et.reminder_minutes, et.is_private
          FROM event_types et
          JOIN groups g ON g.id = et.group_id
          WHERE g.slug = ? AND et.slug = ? AND et.enabled = 1",
@@ -4321,11 +4677,45 @@ async fn handle_group_booking(
         loc_value,
         group_id,
         reminder_min,
+        is_private,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
     };
     let needs_approval = requires_confirmation != 0;
+
+    // Validate invite token for private event types
+    if is_private != 0 {
+        let token = match &form.invite_token {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                return Html("This event type requires an invite link.".to_string()).into_response()
+            }
+        };
+        let invite: Option<(Option<String>, i32, i32)> = sqlx::query_as(
+            "SELECT expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
+        )
+        .bind(token)
+        .bind(&et_id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+
+        match invite {
+            None => return Html("Invalid invite link.".to_string()).into_response(),
+            Some((expires_at, max_uses, used_count)) => {
+                if let Some(exp) = &expires_at {
+                    if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
+                        return Html("This invite link has expired.".to_string()).into_response();
+                    }
+                }
+                if used_count >= max_uses {
+                    return Html("This invite link has already been used.".to_string())
+                        .into_response();
+                }
+            }
+        }
+    }
 
     let date = match NaiveDate::parse_from_str(&form.date, "%Y-%m-%d") {
         Ok(d) => d,
@@ -4438,6 +4828,17 @@ async fn handle_group_booking(
     }
 
     tracing::info!(booking_id = %id, event_type = %slug, guest = %form.email, "booking created");
+
+    // Increment invite used_count if this was an invite-based booking
+    if is_private != 0 {
+        if let Some(token) = &form.invite_token {
+            let _ = sqlx::query("UPDATE booking_invites SET used_count = used_count + 1 WHERE token = ? AND event_type_id = ?")
+                .bind(token)
+                .bind(&et_id)
+                .execute(&state.pool)
+                .await;
+        }
+    }
 
     // Send emails if SMTP is configured
     if let Ok(Some(smtp_config)) =
@@ -4564,7 +4965,7 @@ async fn user_profile(
         "SELECT et.slug, et.title, et.description, et.duration_min
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
-         WHERE a.user_id = ? AND et.enabled = 1
+         WHERE a.user_id = ? AND et.enabled = 1 AND et.is_private = 0
          ORDER BY et.created_at",
     )
     .bind(&user_id)
@@ -4606,8 +5007,8 @@ async fn show_slots_for_user(
     Path((username, slug)): Path<(String, String)>,
     Query(query): Query<SlotsQuery>,
 ) -> impl IntoResponse {
-    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, String, Option<String>, String, String, Option<String>, Option<String>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.location_type, et.location_value, u.id, u.name, u.title, u.avatar_path
+    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, String, Option<String>, String, String, Option<String>, Option<String>, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.location_type, et.location_value, u.id, u.name, u.title, u.avatar_path, et.is_private
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -4634,10 +5035,48 @@ async fn show_slots_for_user(
         host_name,
         host_title,
         host_avatar_path,
+        is_private,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
     };
+
+    // Validate invite token for private event types
+    let invite_guest_name;
+    let invite_guest_email;
+    if is_private != 0 {
+        let token = match &query.invite {
+            Some(t) => t,
+            None => return Html("This event type requires an invite link.".to_string()),
+        };
+        let invite: Option<(String, String, Option<String>, i32, i32)> = sqlx::query_as(
+            "SELECT guest_name, guest_email, expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
+        )
+        .bind(token)
+        .bind(&et_id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+
+        match invite {
+            None => return Html("Invalid invite link.".to_string()),
+            Some((name, email, expires_at, max_uses, used_count)) => {
+                if let Some(exp) = &expires_at {
+                    if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
+                        return Html("This invite link has expired.".to_string());
+                    }
+                }
+                if used_count >= max_uses {
+                    return Html("This invite link has already been used.".to_string());
+                }
+                invite_guest_name = Some(name);
+                invite_guest_email = Some(email);
+            }
+        }
+    } else {
+        invite_guest_name = None;
+        invite_guest_email = None;
+    }
 
     // Sync calendars if stale before computing availability
     crate::commands::sync::sync_if_stale(&state.pool, &state.secret_key, &host_user_id).await;
@@ -4732,6 +5171,9 @@ async fn show_slots_for_user(
             range_label => range_label,
             guest_tz => guest_tz_name,
             tz_options => tz_options,
+            invite_token => query.invite.as_deref().unwrap_or(""),
+            invite_guest_name => invite_guest_name.as_deref().unwrap_or(""),
+            invite_guest_email => invite_guest_email.as_deref().unwrap_or(""),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -4743,8 +5185,8 @@ async fn show_book_form_for_user(
     Path((username, slug)): Path<(String, String)>,
     Query(query): Query<BookQuery>,
 ) -> impl IntoResponse {
-    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value
+    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, et.is_private
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -4756,10 +5198,47 @@ async fn show_book_form_for_user(
     .await
     .unwrap_or(None);
 
-    let (_et_id, et_slug, et_title, et_desc, duration, loc_type, loc_value) = match et {
+    let (et_id, et_slug, et_title, et_desc, duration, loc_type, loc_value, is_private) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
     };
+
+    // Validate invite token for private event types
+    let invite_guest_name;
+    let invite_guest_email;
+    if is_private != 0 {
+        let token = match &query.invite {
+            Some(t) => t,
+            None => return Html("This event type requires an invite link.".to_string()),
+        };
+        let invite: Option<(String, String, Option<String>, i32, i32)> = sqlx::query_as(
+            "SELECT guest_name, guest_email, expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
+        )
+        .bind(token)
+        .bind(&et_id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+
+        match invite {
+            None => return Html("Invalid invite link.".to_string()),
+            Some((name, email, expires_at, max_uses, used_count)) => {
+                if let Some(exp) = &expires_at {
+                    if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
+                        return Html("This invite link has expired.".to_string());
+                    }
+                }
+                if used_count >= max_uses {
+                    return Html("This invite link has already been used.".to_string());
+                }
+                invite_guest_name = Some(name);
+                invite_guest_email = Some(email);
+            }
+        }
+    } else {
+        invite_guest_name = None;
+        invite_guest_email = None;
+    }
 
     let host_name: String = sqlx::query_scalar("SELECT name FROM users WHERE username = ?")
         .bind(&username)
@@ -4807,9 +5286,10 @@ async fn show_book_form_for_user(
             time_end => end_time,
             guest_tz => guest_tz_name,
             error => "",
-            form_name => "",
-            form_email => "",
+            form_name => invite_guest_name.as_deref().unwrap_or(""),
+            form_email => invite_guest_email.as_deref().unwrap_or(""),
             form_notes => "",
+            invite_token => query.invite.as_deref().unwrap_or(""),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -4843,8 +5323,8 @@ async fn handle_booking_for_user(
         return Html(e).into_response();
     }
 
-    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, u.id, et.reminder_minutes
+    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, u.id, et.reminder_minutes, et.is_private
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -4869,11 +5349,45 @@ async fn handle_booking_for_user(
         loc_value,
         host_user_id,
         reminder_min,
+        is_private,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
     };
     let needs_approval = requires_confirmation != 0;
+
+    // Validate invite token for private event types
+    if is_private != 0 {
+        let token = match &form.invite_token {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                return Html("This event type requires an invite link.".to_string()).into_response()
+            }
+        };
+        let invite: Option<(Option<String>, i32, i32)> = sqlx::query_as(
+            "SELECT expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
+        )
+        .bind(token)
+        .bind(&et_id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+
+        match invite {
+            None => return Html("Invalid invite link.".to_string()).into_response(),
+            Some((expires_at, max_uses, used_count)) => {
+                if let Some(exp) = &expires_at {
+                    if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
+                        return Html("This invite link has expired.".to_string()).into_response();
+                    }
+                }
+                if used_count >= max_uses {
+                    return Html("This invite link has already been used.".to_string())
+                        .into_response();
+                }
+            }
+        }
+    }
 
     let date = match NaiveDate::parse_from_str(&form.date, "%Y-%m-%d") {
         Ok(d) => d,
@@ -4980,6 +5494,17 @@ async fn handle_booking_for_user(
     }
 
     tracing::info!(booking_id = %id, event_type = %slug, guest = %form.email, "booking created");
+
+    // Increment invite used_count if this was an invite-based booking
+    if is_private != 0 {
+        if let Some(token) = &form.invite_token {
+            let _ = sqlx::query("UPDATE booking_invites SET used_count = used_count + 1 WHERE token = ? AND event_type_id = ?")
+                .bind(token)
+                .bind(&et_id)
+                .execute(&state.pool)
+                .await;
+        }
+    }
 
     // Send emails if SMTP is configured
     if let Ok(Some(smtp_config)) =
@@ -5548,6 +6073,8 @@ struct SlotsQuery {
     week: Option<i32>,
     #[serde(default)]
     tz: Option<String>,
+    #[serde(default)]
+    invite: Option<String>,
 }
 
 /// Parse a timezone string into a Tz, falling back to server local.
@@ -5601,8 +6128,8 @@ async fn show_slots(
     Path(slug): Path<String>,
     Query(query): Query<SlotsQuery>,
 ) -> impl IntoResponse {
-    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32)> = sqlx::query_as(
-        "SELECT id, slug, title, description, duration_min, buffer_before, buffer_after, min_notice_min
+    let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, i32)> = sqlx::query_as(
+        "SELECT id, slug, title, description, duration_min, buffer_before, buffer_after, min_notice_min, is_private
          FROM event_types WHERE slug = ? AND enabled = 1",
     )
     .bind(&slug)
@@ -5610,11 +6137,25 @@ async fn show_slots(
     .await
     .unwrap_or(None);
 
-    let (et_id, et_slug, et_title, et_desc, duration, buf_before, buf_after, min_notice) = match et
-    {
+    let (
+        et_id,
+        et_slug,
+        et_title,
+        et_desc,
+        duration,
+        buf_before,
+        buf_after,
+        min_notice,
+        is_private,
+    ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
     };
+
+    // Block private event types on legacy route (use /u/ or /g/ routes with invite token instead)
+    if is_private != 0 {
+        return Html("This event type requires an invite link.".to_string());
+    }
 
     let host_info: Option<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
         "SELECT u.id, u.name, u.title, u.avatar_path FROM users u JOIN accounts a ON a.user_id = u.id JOIN event_types et ON et.account_id = a.id WHERE et.id = ?",
@@ -5729,6 +6270,8 @@ struct BookQuery {
     time: String,
     #[serde(default)]
     tz: Option<String>,
+    #[serde(default)]
+    invite: Option<String>,
 }
 
 async fn show_book_form(
@@ -5847,6 +6390,8 @@ struct BookForm {
     notes: Option<String>,
     #[serde(default)]
     tz: Option<String>,
+    #[serde(default)]
+    invite_token: Option<String>,
 }
 
 async fn handle_booking(

--- a/templates/book.html
+++ b/templates/book.html
@@ -40,6 +40,7 @@
     <input type="hidden" name="date" value="{{ date }}">
     <input type="hidden" name="time" value="{{ time_start }}">
     {% if guest_tz is defined and guest_tz %}<input type="hidden" name="tz" value="{{ guest_tz }}">{% endif %}
+    {% if invite_token is defined and invite_token %}<input type="hidden" name="invite_token" value="{{ invite_token }}">{% endif %}
 
     <div class="form-group">
       <label for="name">Your name</label>

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -14,13 +14,17 @@
         <span style="color: var(--text-muted); font-size: 0.85rem;">&middot; {{ et.duration_min }}min</span>
         {% if not et.enabled %}<span class="badge badge-disabled">disabled</span>{% endif %}
         {% if et.requires_confirmation %}<span class="badge badge-requires">requires confirmation</span>{% endif %}
+        {% if et.is_private %}<span class="badge" style="background: rgba(99,102,241,0.1); color: #6366f1;">private</span>{% endif %}
       </div>
       <div class="et-actions">
         <a href="/dashboard/event-types/{{ et.slug }}/edit" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Edit</a>
+        {% if et.is_private %}
+        <a href="/dashboard/invites/{{ et.id }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem; color: #6366f1;">Invite</a>
+        {% endif %}
         <form method="post" action="/dashboard/event-types/{{ et.slug }}/toggle" style="margin: 0;">
           <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">{% if et.enabled %}Disable{% else %}Enable{% endif %}</button>
         </form>
-        {% if username %}
+        {% if username and not et.is_private %}
         <a href="/u/{{ username }}/{{ et.slug }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">View</a>
         {% endif %}
         {% if et.active_bookings == 0 %}
@@ -50,13 +54,18 @@
       <strong>{{ et.title }}</strong>
       <span style="color: var(--text-muted); font-size: 0.85rem;">&middot; {{ et.group_name }} &middot; {{ et.duration_min }}min</span>
       {% if not et.enabled %}<span class="badge badge-disabled">disabled</span>{% endif %}
+      {% if et.is_private %}<span class="badge" style="background: rgba(99,102,241,0.1); color: #6366f1;">private</span>{% endif %}
     </div>
     <div class="et-actions">
       <a href="/dashboard/group-event-types/{{ et.slug }}/edit" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Edit</a>
+      {% if et.is_private %}
+      <a href="/dashboard/invites/{{ et.id }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem; color: #6366f1;">Invite</a>
+      {% endif %}
       <form method="post" action="/dashboard/group-event-types/{{ et.slug }}/toggle" style="margin: 0;">
         <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">{% if et.enabled %}Disable{% else %}Enable{% endif %}</button>
       </form>
-      <a href="/g/{{ et.group_slug }}/{{ et.slug }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">View</a>
+      {% if not et.is_private %}
+      <a href="/g/{{ et.group_slug }}/{{ et.slug }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">View</a>{% endif %}
       {% if et.active_bookings == 0 %}
       <button type="button" class="slot-btn" style="font-size: 0.8rem; color: var(--error-text); cursor: pointer;" onclick="if(confirm('Delete event type \'{{ et.title }}\'? This cannot be undone.')) this.nextElementSibling.submit();">Delete</button>
       <form method="post" action="/dashboard/group-event-types/{{ et.slug }}/delete" style="display: none;"></form>

--- a/templates/event_type_form.html
+++ b/templates/event_type_form.html
@@ -152,6 +152,14 @@
           <div style="color: var(--text-muted); font-size: 0.825rem;">Bookings will be pending until you approve them from the dashboard.</div>
         </div>
       </label>
+
+      <label style="display: flex; align-items: center; gap: 0.625rem; cursor: pointer; padding: 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); transition: all 0.15s ease; margin-top: 0.5rem;">
+        <input type="checkbox" name="is_private" {% if form_is_private %}checked{% endif %} style="accent-color: #6366f1; width: 1.125rem; height: 1.125rem;">
+        <div>
+          <strong style="font-size: 0.925rem;">Private</strong>
+          <div style="color: var(--text-muted); font-size: 0.825rem;">Hidden from your public profile. Only accessible via invite links.</div>
+        </div>
+      </label>
     </div>
 
     <button type="submit" class="btn" style="margin-top: 1.5rem;">

--- a/templates/invite_form.html
+++ b/templates/invite_form.html
@@ -1,0 +1,94 @@
+{% extends "dashboard_base.html" %}
+
+{% block title %}Invites — {{ event_type_title }} — calrs{% endblock %}
+
+{% block dashboard_content %}
+
+<div class="card">
+  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
+    <h1 style="margin-bottom: 0;">Invites</h1>
+    <a href="/dashboard/event-types" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Back to event types</a>
+  </div>
+  <p style="color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1.25rem;">
+    Send invite links for <strong>{{ event_type_title }}</strong>
+    {% if owner_name is defined and owner_name %}<span style="font-size: 0.85rem;">({{ owner_name }})</span>{% endif %}
+  </p>
+
+  {% if error %}
+    <div class="error" style="margin-bottom: 1rem;">{{ error }}</div>
+  {% endif %}
+
+  <form method="POST" action="/dashboard/invites/{{ event_type_id }}/send" style="border-bottom: 1px solid var(--border); padding-bottom: 1.25rem; margin-bottom: 1.25rem;">
+    <h2 style="font-size: 1rem; margin-bottom: 0.75rem;">Send new invite</h2>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;" class="form-grid-2">
+      <div class="form-group">
+        <label for="guest_name">Guest name</label>
+        <input type="text" id="guest_name" name="guest_name" required placeholder="Jane Doe">
+      </div>
+      <div class="form-group">
+        <label for="guest_email">Guest email</label>
+        <input type="email" id="guest_email" name="guest_email" required placeholder="jane@example.com">
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="message">Personal message <span class="hint">(optional)</span></label>
+      <textarea id="message" name="message" placeholder="Looking forward to showing you a demo..." rows="2"></textarea>
+    </div>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;" class="form-grid-2">
+      <div class="form-group">
+        <label for="expires_days">Expires in</label>
+        <select id="expires_days" name="expires_days" style="padding: 0.625rem 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.925rem; font-family: inherit; background: var(--surface); color: var(--text); width: 100%;">
+          <option value="7" selected>7 days</option>
+          <option value="14">14 days</option>
+          <option value="30">30 days</option>
+          <option value="0">Never</option>
+        </select>
+      </div>
+      <div class="form-group" style="display: flex; align-items: end; padding-bottom: 0.25rem;">
+        <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
+          <input type="checkbox" name="single_use" style="accent-color: var(--accent); width: 1rem; height: 1rem;">
+          <span style="font-size: 0.9rem;">Allow multiple bookings</span>
+        </label>
+      </div>
+    </div>
+
+    <button type="submit" class="btn" style="margin-top: 0.75rem;">Send invite</button>
+  </form>
+
+  {% if invites %}
+  <h2 style="font-size: 1rem; margin-bottom: 0.75rem;">Sent invites</h2>
+  <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+    {% for inv in invites %}
+    <div style="display: flex; justify-content: space-between; align-items: center; padding: 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); {% if inv.is_expired or inv.is_used %}opacity: 0.6;{% endif %}">
+      <div>
+        <strong style="font-size: 0.9rem;">{{ inv.guest_name }}</strong>
+        <span style="color: var(--text-muted); font-size: 0.85rem;">&middot; {{ inv.guest_email }}</span>
+        {% if inv.is_expired %}
+          <span class="badge badge-disabled" style="margin-left: 0.25rem;">expired</span>
+        {% elif inv.is_used %}
+          <span class="badge badge-disabled" style="margin-left: 0.25rem;">used</span>
+        {% else %}
+          <span class="badge" style="margin-left: 0.25rem; background: rgba(99,102,241,0.1); color: #6366f1;">active</span>
+        {% endif %}
+        <div style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.25rem;">
+          Sent by {{ inv.created_by }} &middot; {{ inv.used_count }}/{{ inv.max_uses }} uses
+          {% if inv.expires_at %} &middot; Expires {{ inv.expires_at }}{% endif %}
+        </div>
+      </div>
+      <form method="POST" action="/dashboard/invites/{{ inv.id }}/delete" style="margin: 0;">
+        <button type="submit" class="slot-btn" style="font-size: 0.8rem; color: var(--error-text); cursor: pointer;" onclick="return confirm('Delete this invite?');">Delete</button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="empty" style="padding: 1.5rem 1rem;">
+    <div class="empty-icon">&#9993;</div>
+    <div class="empty-text">No invites sent yet.</div>
+  </div>
+  {% endif %}
+</div>
+{% endblock dashboard_content %}

--- a/templates/slots.html
+++ b/templates/slots.html
@@ -63,11 +63,11 @@
     <span class="range">{{ range_label }}</span>
     <div class="nav-links">
       {% if prev_week is defined and prev_week is not none %}
-        <a href="{{ base }}?week={{ prev_week }}{% if guest_tz is defined and guest_tz %}&tz={{ guest_tz }}{% endif %}">&larr;</a>
+        <a href="{{ base }}?week={{ prev_week }}{% if guest_tz is defined and guest_tz %}&tz={{ guest_tz }}{% endif %}{% if invite_token is defined and invite_token %}&invite={{ invite_token }}{% endif %}">&larr;</a>
       {% else %}
         <span class="disabled">&larr;</span>
       {% endif %}
-      <a href="{{ base }}?week={{ next_week }}{% if guest_tz is defined and guest_tz %}&tz={{ guest_tz }}{% endif %}">&rarr;</a>
+      <a href="{{ base }}?week={{ next_week }}{% if guest_tz is defined and guest_tz %}&tz={{ guest_tz }}{% endif %}{% if invite_token is defined and invite_token %}&invite={{ invite_token }}{% endif %}">&rarr;</a>
     </div>
   </div>
 
@@ -77,7 +77,7 @@
       <div class="day-label">{{ day.label }}</div>
       <div class="slots">
         {% for slot in day.slots %}
-          <a href="{{ base }}/book?date={{ slot.host_date | default(value=day.date) }}&time={{ slot.host_time | default(value=slot.start) }}{% if guest_tz is defined and guest_tz %}&tz={{ guest_tz }}{% endif %}"
+          <a href="{{ base }}/book?date={{ slot.host_date | default(value=day.date) }}&time={{ slot.host_time | default(value=slot.start) }}{% if guest_tz is defined and guest_tz %}&tz={{ guest_tz }}{% endif %}{% if invite_token is defined and invite_token %}&invite={{ invite_token }}{% endif %}"
              class="slot-btn slot-time" data-time="{{ slot.start }}">{{ slot.start }}</a>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary

- **Private event types** — new `is_private` flag hides event types from public profiles and group pages. Only accessible via tokenized invite links.
- **Booking invites** — dashboard page to send personalized invite links with guest name/email, optional message, expiration (7/14/30 days/never), and single-use or multi-use toggle. Invite email sent via SMTP with "Choose a time" CTA.
- **Token-based access control** — invite token propagated through the full booking flow (slots → book form → POST). Guest info pre-filled from invite. Token validated at every step (expired, used-up, invalid). `used_count` incremented on successful booking.
- **Works with groups** — any dashboard user can send invites for private group event types (e.g., sales rep invites a lead to a demo team's round-robin event type).
- **Documentation** — CHANGELOG, README, CLAUDE.md, mdBook docs (event-types, booking-flow), and GitHub Pages website updated.

### Changes

- New migration `018_private_invites.sql`: `is_private` on `event_types`, `booking_invites` table
- New template `invite_form.html`: send + list invites with status badges
- `src/web/mod.rs`: ~635 lines added (invite management, token validation in all slot/book handlers)
- `src/email.rs`: `send_invite_email()` with indigo accent
- `src/models.rs`: `BookingInvite` struct, `is_private` on `EventType`
- Templates updated: `slots.html`, `book.html`, `event_type_form.html`, `dashboard_event_types.html`

## Test plan

- [ ] Create a private event type from the dashboard (check "Private" checkbox)
- [ ] Verify private event type does NOT appear on public profile `/u/{username}`
- [ ] Send an invite from `/dashboard/invites/{id}` — check email received with booking link
- [ ] Click invite link — verify slot picker loads, token preserved in week navigation
- [ ] Book a slot — verify name/email pre-filled, booking succeeds, `used_count` incremented
- [ ] Try using an expired or fully-used invite — verify rejection with error message
- [ ] Test with a group event type — verify round-robin assignment still works
- [ ] Verify non-private event types are unaffected (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)