### PR TITLE
feat: Markdown support in user bio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "lettre",
  "minijinja",
  "openidconnect",
+ "pulldown-cmark",
  "rand 0.8.5",
  "reqwest 0.11.27",
  "rpassword",
@@ -2254,6 +2255,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,6 +3711,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ openidconnect = { version = "4.0.1", default-features = false, features = ["reqw
 iana-time-zone = "0.1.65"
 urlencoding = "2"
 
+# Markdown (bio rendering)
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
+
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,6 +117,77 @@ pub fn convert_event_to_tz(
     }
 }
 
+/// Render a bio string from Markdown to safe inline HTML.
+///
+/// Only allows inline elements: links, bold, italic, strikethrough, inline code.
+/// Block-level elements (headings, lists, images, code blocks) are stripped.
+/// All HTML tags in the input are escaped by pulldown-cmark.
+/// Links get `target="_blank"` and `rel="noopener noreferrer"` for safety.
+pub fn render_bio_markdown(bio: &str) -> String {
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+    let parser = Parser::new_ext(bio, Options::ENABLE_STRIKETHROUGH);
+
+    // Filter to inline-only elements
+    let filtered = parser.filter(|event| {
+        !matches!(
+            event,
+            Event::Start(
+                Tag::Heading { .. }
+                    | Tag::BlockQuote(_)
+                    | Tag::CodeBlock(_)
+                    | Tag::Image { .. }
+                    | Tag::List(_)
+                    | Tag::Item
+                    | Tag::Table(_)
+                    | Tag::TableHead
+                    | Tag::TableRow
+                    | Tag::TableCell
+                    | Tag::HtmlBlock
+            ) | Event::End(
+                TagEnd::Heading(_)
+                    | TagEnd::BlockQuote(_)
+                    | TagEnd::CodeBlock
+                    | TagEnd::Image
+                    | TagEnd::List(_)
+                    | TagEnd::Item
+                    | TagEnd::Table
+                    | TagEnd::TableHead
+                    | TagEnd::TableRow
+                    | TagEnd::TableCell
+                    | TagEnd::HtmlBlock
+            ) | Event::Html(_)
+                | Event::InlineHtml(_)
+        )
+    });
+
+    let mut html = String::new();
+    pulldown_cmark::html::push_html(&mut html, filtered);
+
+    // Add target="_blank" and rel="noopener noreferrer" to links
+    html = html.replace(
+        "<a href=",
+        "<a target=\"_blank\" rel=\"noopener noreferrer\" href=",
+    );
+
+    // Strip wrapping <p> tags to keep it inline
+    let trimmed = html.trim();
+    if trimmed.starts_with("<p>") && trimmed.ends_with("</p>") {
+        // Check if there's only one <p> block
+        let inner = &trimmed[3..trimmed.len() - 4];
+        if !inner.contains("<p>") {
+            return inner.to_string();
+        }
+    }
+
+    // Multiple paragraphs: replace </p><p> with <br> for compact display
+    html.trim()
+        .replace("</p>\n<p>", "<br>")
+        .trim_start_matches("<p>")
+        .trim_end_matches("</p>")
+        .to_string()
+}
+
 pub fn prompt(label: &str) -> String {
     print!("{}: ", label);
     io::stdout().flush().unwrap();
@@ -339,6 +410,64 @@ END:VCALENDAR";
             "Europe/Paris".parse::<Tz>().unwrap(),
         );
         assert_eq!(result, dt); // unchanged
+    }
+
+    // --- render_bio_markdown ---
+
+    #[test]
+    fn bio_plain_text() {
+        let result = render_bio_markdown("Hello world");
+        assert_eq!(result, "Hello world");
+    }
+
+    #[test]
+    fn bio_link() {
+        let result = render_bio_markdown("[My site](https://example.com)");
+        assert!(result.contains("href=\"https://example.com\""));
+        assert!(result.contains("target=\"_blank\""));
+        assert!(result.contains("rel=\"noopener noreferrer\""));
+        assert!(result.contains("My site"));
+    }
+
+    #[test]
+    fn bio_bold_italic() {
+        let result = render_bio_markdown("**bold** and *italic*");
+        assert!(result.contains("<strong>bold</strong>"));
+        assert!(result.contains("<em>italic</em>"));
+    }
+
+    #[test]
+    fn bio_strips_headings() {
+        let result = render_bio_markdown("# Heading\nSome text");
+        assert!(!result.contains("<h1>"));
+        assert!(result.contains("Some text"));
+    }
+
+    #[test]
+    fn bio_strips_images() {
+        let result = render_bio_markdown("![alt](https://evil.com/img.png)");
+        assert!(!result.contains("<img"));
+        assert!(!result.contains("evil.com"));
+    }
+
+    #[test]
+    fn bio_strips_html_tags() {
+        let result = render_bio_markdown("<script>alert('xss')</script>");
+        assert!(!result.contains("<script>"));
+    }
+
+    #[test]
+    fn bio_inline_code() {
+        let result = render_bio_markdown("Use `cargo build`");
+        assert!(result.contains("<code>cargo build</code>"));
+    }
+
+    #[test]
+    fn bio_multiple_paragraphs() {
+        let result = render_bio_markdown("Line 1\n\nLine 2");
+        assert!(result.contains("Line 1"));
+        assert!(result.contains("Line 2"));
+        assert!(result.contains("<br>"));
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6087,7 +6087,7 @@ async fn user_profile(
             host_name => &user_name,
             host_initials => compute_initials(&user_name),
             host_title => user_title,
-            host_bio => user_bio,
+            host_bio => user_bio.as_deref().map(crate::utils::render_bio_markdown),
             host_user_id => user_id,
             host_has_avatar => avatar_path.is_some(),
             username => username,

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 {% block title %}{{ host_name }} — calrs{% endblock %}
+{% block head %}
+<style>
+  .host-bio a { color: #fff; text-decoration: underline; text-underline-offset: 2px; }
+  .host-bio a:hover { opacity: 0.8; }
+  .host-bio code { background: rgba(255,255,255,0.15); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
+</style>
+{% endblock %}
 {% block content %}
 <div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
 
@@ -20,7 +27,7 @@
         {% if host_title %}<p style="color: rgba(255,255,255,0.8); font-size: 0.9rem; margin-top: 0.125rem;">{{ host_title }}</p>{% endif %}
       </div>
     </div>
-    {% if host_bio %}<p style="color: rgba(255,255,255,0.85); font-size: 0.9rem; margin-top: 0.5rem;">{{ host_bio }}</p>{% endif %}
+    {% if host_bio %}<div class="host-bio" style="color: rgba(255,255,255,0.85); font-size: 0.9rem; margin-top: 0.5rem;">{{ host_bio|safe }}</div>{% endif %}
   </div>
   <div style="padding: 1.25rem 2rem 1.5rem;">
     <p class="subtitle" style="margin-bottom: 0;">Pick an event type to book a time.</p>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -52,7 +52,7 @@
     <div class="form-group">
       <label for="bio">Bio</label>
       <textarea id="bio" name="bio" rows="3" placeholder="Tell people a bit about yourself...">{{ form_bio }}</textarea>
-      <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">Shown on your public booking page.</span>
+      <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">Shown on your public booking page. Supports Markdown: [link text](https://...), **bold**, *italic*.</span>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
## Summary
- Bio field on public profile pages now renders Markdown inline elements: `[text](url)` links, **bold**, *italic*, ~~strikethrough~~, and `inline code`
- Block elements (headings, images, lists, code blocks, raw HTML) are stripped for safety
- Links open in new tabs with `rel="noopener noreferrer"`
- Settings form shows a Markdown syntax hint
- 8 new tests (504 → 512)

## Test plan
- [x] Set bio to `Check my [website](https://example.com) and **latest project**` in Settings
- [x] Visit public profile `/u/{username}` — verify link is clickable, bold renders, link opens in new tab
- [x] Try `![img](https://evil.com/x.png)` and `<script>alert(1)</script>` in bio — verify they are stripped
- [x] Verify bio still looks correct on the gradient header (white text, underlined links)
- [x] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)