### PR TITLE
feat: company link on logo in public pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calrs"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/migrations/028_company_link.sql
+++ b/migrations/028_company_link.sql
@@ -1,0 +1,2 @@
+-- Company link URL (displayed on public pages via the logo)
+ALTER TABLE auth_config ADD COLUMN company_link TEXT;

--- a/src/db.rs
+++ b/src/db.rs
@@ -130,6 +130,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "027_calendar_sync_token",
             include_str!("../migrations/027_calendar_sync_token.sql"),
         ),
+        (
+            "028_company_link",
+            include_str!("../migrations/028_company_link.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -380,7 +384,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 27, "All 27 migrations should be tracked");
+        assert_eq!(count.0, 28, "All 28 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -394,7 +398,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 27, "Still 27 migrations after second run");
+        assert_eq!(count.0, 28, "Still 28 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -68,6 +68,7 @@ pub struct AppState {
     pub data_dir: PathBuf,
     pub secret_key: [u8; 32],
     pub theme_css: tokio::sync::RwLock<String>,
+    pub company_link: tokio::sync::RwLock<Option<String>>,
 }
 
 // --- CSRF protection (double-submit cookie pattern) ---
@@ -122,6 +123,24 @@ struct CsrfForm {
 #[derive(Deserialize)]
 struct CsrfQuery {
     _csrf: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CompanyLinkForm {
+    company_link: String,
+    _csrf: Option<String>,
+}
+
+async fn get_company_link(pool: &SqlitePool) -> Option<String> {
+    sqlx::query_scalar::<_, Option<String>>(
+        "SELECT company_link FROM auth_config WHERE id = 'singleton'",
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .flatten()
+    .filter(|s| !s.is_empty())
 }
 
 /// Background task that sends booking reminders on a 60-second tick.
@@ -504,6 +523,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
     env.set_loader(minijinja::path_loader("templates"));
 
     let initial_theme_css = build_theme_css(&pool).await;
+    let initial_company_link = get_company_link(&pool).await;
 
     let state = Arc::new(AppState {
         pool,
@@ -514,6 +534,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         secret_key,
         data_dir,
         theme_css: tokio::sync::RwLock::new(initial_theme_css),
+        company_link: tokio::sync::RwLock::new(initial_company_link),
     });
 
     Router::new()
@@ -608,6 +629,10 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/dashboard/admin/oidc", post(admin_update_oidc))
         .route("/dashboard/admin/logo", post(admin_upload_logo))
         .route("/dashboard/admin/logo/delete", post(admin_delete_logo))
+        .route(
+            "/dashboard/admin/company-link",
+            post(admin_update_company_link),
+        )
         .route("/dashboard/admin/impersonate/{id}", post(admin_impersonate))
         .route(
             "/dashboard/admin/stop-impersonate",
@@ -3250,6 +3275,7 @@ async fn show_team_link_slots(
             today_date => today_date,
             guest_tz => guest_tz_name,
             tz_options => tz_options,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -3332,6 +3358,7 @@ async fn show_team_link_book_form(
             form_email => "",
             form_notes => "",
             max_additional_guests => 0,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -3627,6 +3654,7 @@ async fn handle_team_link_booking(
             additional_attendees => additional_attendees,
             location_type => tl_location_type.as_deref().unwrap_or(""),
             location_value => tl_location.as_deref().unwrap_or(""),
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -5354,6 +5382,7 @@ async fn group_profile(
             group_name => group_name,
             group_slug => group_slug,
             event_types => et_ctx,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
@@ -5562,6 +5591,7 @@ async fn show_group_slots(
             guest_tz => guest_tz_name,
             tz_options => tz_options,
             invite_token => query.invite.as_deref().unwrap_or(""),
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -5682,6 +5712,7 @@ async fn show_group_book_form(
             form_notes => "",
             invite_token => query.invite.as_deref().unwrap_or(""),
             max_additional_guests => max_additional_guests,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -6025,6 +6056,7 @@ async fn handle_group_booking(
             location_type => loc_type,
             location_value => loc_value,
             additional_attendees => additional_attendees,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -6092,6 +6124,7 @@ async fn user_profile(
             host_has_avatar => avatar_path.is_some(),
             username => username,
             event_types => et_ctx,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
@@ -6277,6 +6310,7 @@ async fn show_slots_for_user(
             invite_token => query.invite.as_deref().unwrap_or(""),
             invite_guest_name => invite_guest_name.as_deref().unwrap_or(""),
             invite_guest_email => invite_guest_email.as_deref().unwrap_or(""),
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -6404,6 +6438,7 @@ async fn show_book_form_for_user(
             form_notes => "",
             invite_token => query.invite.as_deref().unwrap_or(""),
             max_additional_guests => max_additional_guests,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -6761,6 +6796,7 @@ async fn handle_booking_for_user(
             location_type => loc_type,
             location_value => loc_value,
             additional_attendees => additional_attendees,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -7750,6 +7786,7 @@ async fn show_slots(
             today_date => today_date,
             guest_tz => guest_tz_name,
             tz_options => tz_options,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -7840,6 +7877,7 @@ async fn show_book_form(
             form_email => "",
             form_notes => "",
             max_additional_guests => max_additional_guests,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -8255,6 +8293,7 @@ async fn handle_booking(
             notes => form.notes,
             pending => needs_approval,
             additional_attendees => additional_attendees,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -8989,6 +9028,7 @@ async fn admin_dashboard(
             smtp_from_email => smtp_from_email,
             smtp_enabled => smtp_enabled,
             has_logo => state.data_dir.join("logo.png").exists(),
+            company_link => get_company_link(&state.pool).await.unwrap_or_default(),
             current_theme => get_theme_name(&state.pool).await,
             custom_colors => {
                 let (a, ah, bg, s, t) = get_custom_colors(&state.pool).await;
@@ -9342,6 +9382,27 @@ async fn admin_delete_logo(
     }
     let logo_path = state.data_dir.join("logo.png");
     let _ = tokio::fs::remove_file(&logo_path).await;
+    Redirect::to("/dashboard/admin").into_response()
+}
+
+async fn admin_update_company_link(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<CompanyLinkForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+    let link = form.company_link.trim().to_string();
+    let link_value: Option<&str> = if link.is_empty() { None } else { Some(&link) };
+    let _ = sqlx::query(
+        "UPDATE auth_config SET company_link = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+    )
+    .bind(link_value)
+    .execute(&state.pool)
+    .await;
+    *state.company_link.write().await = if link.is_empty() { None } else { Some(link) };
     Redirect::to("/dashboard/admin").into_response()
 }
 
@@ -10228,6 +10289,7 @@ async fn guest_reschedule_slots(
                 time => time,
                 tz => guest_tz.name(),
                 back_url => back_url,
+                company_link => state.company_link.read().await.clone(),
             })
             .unwrap_or_else(|e| format!("Template error: {}", e));
         return Html(rendered).into_response();
@@ -10336,6 +10398,7 @@ async fn guest_reschedule_slots(
                 old_date => old_date,
                 old_time => old_start_time,
             },
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -10704,6 +10767,7 @@ async fn guest_reschedule_booking(
             guest_email => guest_email,
             pending => needs_approval,
             rescheduled => true,
+            company_link => state.company_link.read().await.clone(),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -25,6 +25,14 @@
     </form>
     {% endif %}
   </div>
+  <div style="margin-top: 1rem;">
+    <form method="post" action="/dashboard/admin/company-link" style="margin: 0; display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
+      <label for="company_link" style="font-size: 0.875rem; font-weight: 500; white-space: nowrap;">Company link</label>
+      <input type="url" id="company_link" name="company_link" value="{{ company_link }}" placeholder="https://yourcompany.com" style="flex: 1; min-width: 200px; padding: 0.4rem 0.75rem; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--text); font-size: 0.85rem;">
+      <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save</button>
+    </form>
+    <span style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">Logo links to this URL on public booking pages. Leave empty for no link.</span>
+  </div>
 </div>
 
 <!-- Theme -->

--- a/templates/book.html
+++ b/templates/book.html
@@ -14,7 +14,7 @@
   {% set base = "/" ~ event_type.slug %}
 {% endif %}
 
-<div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
+<div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
 <a href="{{ base }}" class="back-link">&larr; Back to times</a>
 

--- a/templates/booking_reschedule_confirm.html
+++ b/templates/booking_reschedule_confirm.html
@@ -3,7 +3,7 @@
 {% block title %}Confirm reschedule{% endblock %}
 
 {% block content %}
-<div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
+<div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
 <div class="card">
   <div style="display: flex; align-items: center; gap: 0.625rem; margin-bottom: 0.75rem;">

--- a/templates/confirmed.html
+++ b/templates/confirmed.html
@@ -3,7 +3,7 @@
 {% block title %}{% if pending %}Booking pending{% else %}Booking confirmed{% endif %}{% endblock %}
 
 {% block content %}
-<div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
+<div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
 <div class="card" style="text-align: center;">
   {% if rescheduled is defined and rescheduled and pending %}

--- a/templates/group_profile.html
+++ b/templates/group_profile.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ group_name }} — calrs{% endblock %}
 {% block content %}
-<div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
+<div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
 <div class="card">
   <h1>{{ group_name }}</h1>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -8,7 +8,7 @@
 </style>
 {% endblock %}
 {% block content %}
-<div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
+<div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
 <div class="card" style="overflow: hidden; padding: 0;">
   <div style="background: linear-gradient(135deg, var(--accent) 0%, #7c3aed 100%); padding: 2rem 2rem 1.5rem; color: #fff;">

--- a/templates/slots.html
+++ b/templates/slots.html
@@ -16,7 +16,7 @@
   {% set base = "/" ~ event_type.slug %}
 {% endif %}
 
-<div class="logo"><img src="/logo" alt="" onerror="this.parentElement.style.display='none'"></div>
+<div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
 <style>
   /* Override container width for the wider layout */


### PR DESCRIPTION
## Summary
- New **Company link** field in admin panel (below logo upload)
- When set, the company logo on all public booking pages becomes a clickable link to that URL
- Links open in a new tab with `rel="noopener noreferrer"`
- Empty = logo stays static (backward-compatible)
- Cached in `AppState` via `RwLock` — no extra DB query on public page loads

## Test plan
- [ ] Go to Admin > Company logo section, enter a URL in "Company link", click Save
- [ ] Visit any public page (`/u/{username}`, slot picker, booking form, confirmation) — logo should be clickable
- [ ] Clear the field and save — logo should no longer be a link
- [ ] Verify logo still hides gracefully when no logo is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)