### PR TITLE
fix: address 7 findings from security review

### DIFF
--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use reqwest::Client;
+use std::net::IpAddr;
 use std::time::Duration;
 
 pub struct CaldavClient {
@@ -8,6 +9,82 @@ pub struct CaldavClient {
     origin: String,
     username: String,
     password: String,
+}
+
+/// Check if an IP address is in a private/reserved range (SSRF protection).
+fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()          // 127.0.0.0/8
+                || v4.is_private()    // 10/8, 172.16/12, 192.168/16
+                || v4.is_link_local() // 169.254/16
+                || v4.is_unspecified()
+                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64/10 (CGNAT)
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()       // ::1
+                || v6.is_unspecified() // ::
+                || {
+                    let seg = v6.segments();
+                    seg[0] == 0xfe80 // fe80::/10 link-local
+                        || seg[0] == 0xfc00 || seg[0] == 0xfd00 // fc00::/7 ULA
+                }
+        }
+    }
+}
+
+/// Validate a CalDAV URL: must be http(s), must not resolve to a private IP.
+pub fn validate_caldav_url(url: &str) -> Result<()> {
+    let parsed = reqwest::Url::parse(url).map_err(|_| anyhow::anyhow!("Invalid URL: {}", url))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => bail!(
+            "URL scheme '{}' is not allowed. Only http and https are supported.",
+            scheme
+        ),
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("URL has no host"))?;
+
+    // Try parsing as IP directly
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if is_private_ip(&ip) {
+            bail!(
+                "URL resolves to a private/reserved IP address ({}). This is not allowed for security reasons.",
+                ip
+            );
+        }
+        return Ok(());
+    }
+
+    // Resolve hostname and check all resolved IPs
+    use std::net::ToSocketAddrs;
+    let port = parsed
+        .port()
+        .unwrap_or(if parsed.scheme() == "https" { 443 } else { 80 });
+    let addrs: Vec<_> = format!("{}:{}", host, port)
+        .to_socket_addrs()
+        .map_err(|e| anyhow::anyhow!("Cannot resolve hostname '{}': {}", host, e))?
+        .collect();
+
+    if addrs.is_empty() {
+        bail!("Cannot resolve hostname '{}'", host);
+    }
+
+    for addr in &addrs {
+        if is_private_ip(&addr.ip()) {
+            bail!(
+                "URL hostname '{}' resolves to a private/reserved IP address ({}). This is not allowed for security reasons.",
+                host,
+                addr.ip()
+            );
+        }
+    }
+
+    Ok(())
 }
 
 impl CaldavClient {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -693,7 +693,10 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/t/{token}", get(redirect_team_link_to_team))
         .route("/t/{token}/book", get(redirect_team_link_to_team))
         // User-scoped public booking routes
-        .route("/booking/approve/{token}", get(approve_booking_by_token))
+        .route(
+            "/booking/approve/{token}",
+            get(approve_booking_form).post(approve_booking_by_token),
+        )
         .route(
             "/booking/decline/{token}",
             get(decline_booking_form).post(decline_booking_by_token),
@@ -4383,6 +4386,11 @@ async fn create_source(
             .into_response();
     }
 
+    // Validate URL against SSRF
+    if let Err(e) = crate::caldav::validate_caldav_url(&url) {
+        return render_source_form_error(&state, &auth_user, &e.to_string(), &form).into_response();
+    }
+
     // Test connection unless skip requested
     let skip_test = form.no_test.as_deref() == Some("on");
     if !skip_test {
@@ -4940,7 +4948,7 @@ async fn invite_management_page(
     auth_user: crate::auth::AuthUser,
     Path(event_type_id): Path<String>,
 ) -> impl IntoResponse {
-    // Any authenticated user can see invites for any private event type
+    // Fetch event type with visibility check
     let et: Option<(
         String,
         String,
@@ -4948,11 +4956,13 @@ async fn invite_management_page(
         Option<String>,
         Option<String>,
         Option<String>,
+        String,
     )> = sqlx::query_as(
         "SELECT et.id, et.title, et.slug,
                 CASE WHEN et.team_id IS NOT NULL THEN t.slug ELSE NULL END,
                 CASE WHEN et.team_id IS NULL THEN u.username ELSE NULL END,
-                CASE WHEN et.team_id IS NOT NULL THEN t.name ELSE u.name END
+                CASE WHEN et.team_id IS NOT NULL THEN t.name ELSE u.name END,
+                et.visibility
          FROM event_types et
          LEFT JOIN teams t ON t.id = et.team_id
          LEFT JOIN accounts a ON a.id = et.account_id
@@ -4964,10 +4974,29 @@ async fn invite_management_page(
     .await
     .unwrap_or(None);
 
-    let (et_id, et_title, et_slug, team_slug, username, owner_name) = match et {
+    let (et_id, et_title, et_slug, team_slug, username, owner_name, visibility) = match et {
         Some(e) => e,
         None => return Html("Private event type not found.".to_string()),
     };
+
+    // Private event types: only owner or team member can view invites
+    if visibility == "private" {
+        let is_owner: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM event_types et
+             LEFT JOIN accounts a ON a.id = et.account_id
+             LEFT JOIN team_members tm ON tm.team_id = et.team_id AND tm.user_id = ?
+             WHERE et.id = ? AND (a.user_id = ? OR tm.user_id IS NOT NULL)",
+        )
+        .bind(&auth_user.user.id)
+        .bind(&et_id)
+        .bind(&auth_user.user.id)
+        .fetch_one(&state.pool)
+        .await
+        .unwrap_or(false);
+        if !is_owner {
+            return Html("Access denied.".to_string());
+        }
+    }
 
     let invites: Vec<(String, String, String, Option<String>, Option<String>, i32, i32, String, String)> = sqlx::query_as(
         "SELECT bi.id, bi.guest_name, bi.guest_email, bi.message, bi.expires_at, bi.max_uses, bi.used_count, bi.created_at, u.name
@@ -5052,11 +5081,12 @@ async fn send_invite(
         return resp;
     }
 
-    // Verify event type exists and is private
-    let et: Option<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
+    // Verify event type exists and is private/internal, with ownership check for private
+    let et: Option<(String, String, Option<String>, Option<String>, String)> = sqlx::query_as(
         "SELECT et.id, et.title,
                 CASE WHEN et.team_id IS NOT NULL THEN t.slug ELSE NULL END,
-                CASE WHEN et.team_id IS NULL THEN u.username ELSE NULL END
+                CASE WHEN et.team_id IS NULL THEN u.username ELSE NULL END,
+                et.visibility
          FROM event_types et
          LEFT JOIN teams t ON t.id = et.team_id
          LEFT JOIN accounts a ON a.id = et.account_id
@@ -5068,10 +5098,29 @@ async fn send_invite(
     .await
     .unwrap_or(None);
 
-    let (et_id, et_title, team_slug, username) = match et {
+    let (et_id, et_title, team_slug, username, visibility) = match et {
         Some(e) => e,
         None => return Redirect::to("/dashboard/event-types").into_response(),
     };
+
+    // Private event types: only owner or team member can create invites
+    if visibility == "private" {
+        let is_owner: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM event_types et
+             LEFT JOIN accounts a ON a.id = et.account_id
+             LEFT JOIN team_members tm ON tm.team_id = et.team_id AND tm.user_id = ?
+             WHERE et.id = ? AND (a.user_id = ? OR tm.user_id IS NOT NULL)",
+        )
+        .bind(&auth_user.user.id)
+        .bind(&et_id)
+        .bind(&auth_user.user.id)
+        .fetch_one(&state.pool)
+        .await
+        .unwrap_or(false);
+        if !is_owner {
+            return Redirect::to("/dashboard/event-types").into_response();
+        }
+    }
 
     // Validate inputs
     let guest_name = form.guest_name.trim();
@@ -5165,18 +5214,27 @@ async fn delete_invite(
         return resp;
     }
 
-    // Get the event_type_id before deleting for redirect
-    let et_id: Option<String> =
-        sqlx::query_scalar("SELECT event_type_id FROM booking_invites WHERE id = ?")
-            .bind(&invite_id)
-            .fetch_optional(&state.pool)
-            .await
-            .unwrap_or(None);
+    // Get the event_type_id before deleting for redirect, with ownership check
+    let et_id: Option<String> = sqlx::query_scalar(
+        "SELECT bi.event_type_id FROM booking_invites bi
+         JOIN event_types et ON et.id = bi.event_type_id
+         LEFT JOIN accounts a ON a.id = et.account_id
+         LEFT JOIN team_members tm ON tm.team_id = et.team_id AND tm.user_id = ?
+         WHERE bi.id = ? AND (a.user_id = ? OR tm.user_id IS NOT NULL)",
+    )
+    .bind(&auth_user.user.id)
+    .bind(&invite_id)
+    .bind(&auth_user.user.id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
 
-    let _ = sqlx::query("DELETE FROM booking_invites WHERE id = ?")
-        .bind(&invite_id)
-        .execute(&state.pool)
-        .await;
+    if et_id.is_some() {
+        let _ = sqlx::query("DELETE FROM booking_invites WHERE id = ?")
+            .bind(&invite_id)
+            .execute(&state.pool)
+            .await;
+    }
 
     tracing::info!(invite_id = %invite_id, deleted_by = %auth_user.user.email, "invite deleted");
 
@@ -5199,10 +5257,11 @@ async fn generate_quick_link(
         return resp;
     }
 
-    let et: Option<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
+    let et: Option<(String, String, Option<String>, Option<String>, String)> = sqlx::query_as(
         "SELECT et.id, et.slug,
                 CASE WHEN et.team_id IS NOT NULL THEN t.slug ELSE NULL END,
-                CASE WHEN et.team_id IS NULL THEN u.username ELSE NULL END
+                CASE WHEN et.team_id IS NULL THEN u.username ELSE NULL END,
+                et.visibility
          FROM event_types et
          LEFT JOIN teams t ON t.id = et.team_id
          LEFT JOIN accounts a ON a.id = et.account_id
@@ -5214,10 +5273,29 @@ async fn generate_quick_link(
     .await
     .unwrap_or(None);
 
-    let (et_id, et_slug, team_slug, username) = match et {
+    let (et_id, et_slug, team_slug, username, visibility) = match et {
         Some(e) => e,
         None => return Redirect::to("/dashboard/invite-links").into_response(),
     };
+
+    // Private event types: only owner or team member can generate quick links
+    if visibility == "private" {
+        let is_owner: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM event_types et
+             LEFT JOIN accounts a ON a.id = et.account_id
+             LEFT JOIN team_members tm ON tm.team_id = et.team_id AND tm.user_id = ?
+             WHERE et.id = ? AND (a.user_id = ? OR tm.user_id IS NOT NULL)",
+        )
+        .bind(&auth_user.user.id)
+        .bind(&et_id)
+        .bind(&auth_user.user.id)
+        .fetch_one(&state.pool)
+        .await
+        .unwrap_or(false);
+        if !is_owner {
+            return Redirect::to("/dashboard/invite-links").into_response();
+        }
+    }
 
     let token = uuid::Uuid::new_v4().to_string();
     let expires_at = (chrono::Utc::now() + chrono::Duration::days(7))
@@ -11396,6 +11474,89 @@ struct DeclineForm {
     reason: Option<String>,
 }
 
+/// Render an error page for token-based actions (shared by approve form and handler).
+fn render_token_error(
+    state: &AppState,
+    _token: &str,
+    already: Option<(String,)>,
+) -> axum::response::Response {
+    let (title, message) = match already {
+        Some((status,)) if status == "confirmed" => (
+            "Already approved",
+            "This booking has already been approved.",
+        ),
+        Some((status,)) if status == "declined" => (
+            "Already declined",
+            "This booking has already been declined.",
+        ),
+        Some((status,)) if status == "cancelled" => {
+            ("Booking cancelled", "This booking was cancelled.")
+        }
+        _ => (
+            "Invalid link",
+            "This approval link is invalid or has expired.",
+        ),
+    };
+
+    let tmpl = match state.templates.get_template("booking_action_error.html") {
+        Ok(t) => t,
+        Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
+    };
+    let rendered = tmpl
+        .render(context! { title, message })
+        .unwrap_or_else(|e| format!("Template error: {}", e));
+    Html(rendered).into_response()
+}
+
+async fn approve_booking_form(
+    State(state): State<Arc<AppState>>,
+    Path(token): Path<String>,
+) -> impl IntoResponse {
+    // Look up pending booking by confirm_token
+    let booking: Option<(String, String, String, String, String)> = sqlx::query_as(
+        "SELECT b.guest_name, b.guest_email, b.start_at, b.end_at, et.title
+         FROM bookings b
+         JOIN event_types et ON et.id = b.event_type_id
+         WHERE b.confirm_token = ? AND b.status = 'pending'",
+    )
+    .bind(&token)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
+
+    let (guest_name, guest_email, start_at, end_at, event_title) = match booking {
+        Some(b) => b,
+        None => {
+            let already: Option<(String,)> =
+                sqlx::query_as("SELECT status FROM bookings WHERE confirm_token = ?")
+                    .bind(&token)
+                    .fetch_optional(&state.pool)
+                    .await
+                    .unwrap_or(None);
+            return render_token_error(&state, &token, already);
+        }
+    };
+
+    let date_label = format_date_label(&start_at);
+    let start_time = extract_time_24h(&start_at);
+    let end_time = extract_time_24h(&end_at);
+
+    let tmpl = match state.templates.get_template("booking_approve_form.html") {
+        Ok(t) => t,
+        Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
+    };
+    tmpl.render(context! {
+        event_title,
+        date_label,
+        start_time,
+        end_time,
+        guest_name,
+        guest_email,
+    })
+    .map(|r| Html(r).into_response())
+    .unwrap_or_else(|e| Html(format!("Template error: {}", e)).into_response())
+}
+
 async fn approve_booking_by_token(
     State(state): State<Arc<AppState>>,
     Path(token): Path<String>,
@@ -11432,40 +11593,13 @@ async fn approve_booking_by_token(
     ) = match booking {
         Some(b) => b,
         None => {
-            // Check if already confirmed
             let already: Option<(String,)> =
                 sqlx::query_as("SELECT status FROM bookings WHERE confirm_token = ?")
                     .bind(&token)
                     .fetch_optional(&state.pool)
                     .await
                     .unwrap_or(None);
-
-            let (title, message) = match already {
-                Some((status,)) if status == "confirmed" => (
-                    "Already approved",
-                    "This booking has already been approved.",
-                ),
-                Some((status,)) if status == "declined" => (
-                    "Already declined",
-                    "This booking has already been declined.",
-                ),
-                Some((status,)) if status == "cancelled" => {
-                    ("Booking cancelled", "This booking was cancelled.")
-                }
-                _ => (
-                    "Invalid link",
-                    "This approval link is invalid or has expired.",
-                ),
-            };
-
-            let tmpl = match state.templates.get_template("booking_action_error.html") {
-                Ok(t) => t,
-                Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
-            };
-            let rendered = tmpl
-                .render(context! { title, message })
-                .unwrap_or_else(|e| format!("Template error: {}", e));
-            return Html(rendered).into_response();
+            return render_token_error(&state, &token, already);
         }
     };
 
@@ -15117,6 +15251,15 @@ mod tests {
             .unwrap()
     }
 
+    fn post_bare(uri: &str) -> axum::http::Request<Body> {
+        axum::http::Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(Body::empty())
+            .unwrap()
+    }
+
     // --- POST handler tests ---
 
     #[tokio::test]
@@ -15539,9 +15682,33 @@ mod tests {
             .await
             .unwrap();
 
-        // GET /booking/approve/{token} — unauthenticated
-        let response = app
+        // GET /booking/approve/{token} — shows confirmation form, does NOT approve
+        let app2 = app.clone();
+        let response = app2
             .oneshot(get(&format!("/booking/approve/{}", confirm_tok)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+        assert!(
+            body.contains("Approve booking"),
+            "GET should show approve form"
+        );
+
+        let status: Option<(String,)> = sqlx::query_as("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            status.unwrap().0,
+            "pending",
+            "Booking should still be pending after GET"
+        );
+
+        // POST /booking/approve/{token} — actually approves
+        let response = app
+            .oneshot(post_bare(&format!("/booking/approve/{}", confirm_tok)))
             .await
             .unwrap();
         assert_eq!(response.status(), 200);
@@ -15554,7 +15721,7 @@ mod tests {
         assert_eq!(
             status.unwrap().0,
             "confirmed",
-            "Booking should be confirmed via token"
+            "Booking should be confirmed via POST token"
         );
     }
 

--- a/templates/booking_approve_form.html
+++ b/templates/booking_approve_form.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}Approve booking{% endblock %}
+
+{% block content %}
+<div class="card">
+  <h1>Approve booking</h1>
+  <p class="subtitle">You are about to approve this booking request.</p>
+
+  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
+  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
+  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+</div>
+
+<div class="card">
+  <form method="post">
+    <button type="submit" class="btn">Approve booking</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/event_type_form.html
+++ b/templates/event_type_form.html
@@ -1262,7 +1262,14 @@
         }
         row.appendChild(av);
         var info = document.createElement('div');
-        info.innerHTML = '<div style="font-size:0.85rem;">' + u.name + '</div><div style="font-size:0.75rem;color:var(--text-muted);">@' + u.username + '</div>';
+        var nameDiv = document.createElement('div');
+        nameDiv.style.fontSize = '0.85rem';
+        nameDiv.textContent = u.name;
+        var usernameDiv = document.createElement('div');
+        usernameDiv.style.cssText = 'font-size:0.75rem;color:var(--text-muted);';
+        usernameDiv.textContent = '@' + u.username;
+        info.appendChild(nameDiv);
+        info.appendChild(usernameDiv);
         row.appendChild(info);
         row.onclick = function() {
           selected.push(u);

--- a/templates/team_form.html
+++ b/templates/team_form.html
@@ -235,7 +235,15 @@
         }
         row.appendChild(avatar);
         var info = document.createElement('div');
-        info.innerHTML = '<strong style="font-size:0.85rem;">' + u.name + '</strong> <span style="color:var(--text-muted);font-size:0.8rem;">' + u.email + '</span>';
+        var nameEl = document.createElement('strong');
+        nameEl.style.fontSize = '0.85rem';
+        nameEl.textContent = u.name;
+        var emailEl = document.createElement('span');
+        emailEl.style.cssText = 'color:var(--text-muted);font-size:0.8rem;';
+        emailEl.textContent = u.email;
+        info.appendChild(nameEl);
+        info.appendChild(document.createTextNode(' '));
+        info.appendChild(emailEl);
         row.appendChild(info);
         resultsEl.appendChild(row);
       });
@@ -259,11 +267,17 @@
         row.onclick = function() { selectedGroups[g.id] = g; renderPills(); syncInputs(); searchEl.value = ''; resultsEl.style.display = 'none'; };
         var info = document.createElement('div');
         info.style.cssText = 'display: flex; align-items: center; gap: 0.5rem; flex: 1;';
-        info.innerHTML = '<strong style="font-size:0.85rem;">' + g.name + '</strong>';
+        var gNameEl = document.createElement('strong');
+        gNameEl.style.fontSize = '0.85rem';
+        gNameEl.textContent = g.name;
+        info.appendChild(gNameEl);
         if (g.members && g.members.length > 0) {
           info.appendChild(stackedAvatars(g.members, g.count));
         } else {
-          info.innerHTML += ' <span style="color:var(--text-muted);font-size:0.8rem;">(' + g.count + ' member' + (g.count !== 1 ? 's' : '') + ')</span>';
+          var countEl = document.createElement('span');
+          countEl.style.cssText = 'color:var(--text-muted);font-size:0.8rem;';
+          countEl.textContent = ' (' + g.count + ' member' + (g.count !== 1 ? 's' : '') + ')';
+          info.appendChild(countEl);
         }
         row.appendChild(info);
         resultsEl.appendChild(row);

--- a/templates/team_settings.html
+++ b/templates/team_settings.html
@@ -462,7 +462,15 @@
         }
         row.appendChild(avatar);
         var info = document.createElement('div');
-        info.innerHTML = '<strong style="font-size:0.85rem;">' + u.name + '</strong> <span style="color:var(--text-muted);font-size:0.8rem;">' + u.email + '</span>';
+        var nameEl = document.createElement('strong');
+        nameEl.style.fontSize = '0.85rem';
+        nameEl.textContent = u.name;
+        var emailEl = document.createElement('span');
+        emailEl.style.cssText = 'color:var(--text-muted);font-size:0.8rem;';
+        emailEl.textContent = u.email;
+        info.appendChild(nameEl);
+        info.appendChild(document.createTextNode(' '));
+        info.appendChild(emailEl);
         row.appendChild(info);
         resultsEl.appendChild(row);
       });
@@ -486,11 +494,17 @@
         row.onclick = function() { addGroup(g); };
         var info = document.createElement('div');
         info.style.cssText = 'display: flex; align-items: center; gap: 0.5rem; flex: 1;';
-        info.innerHTML = '<strong style="font-size:0.85rem;">' + g.name + '</strong>';
+        var gNameEl = document.createElement('strong');
+        gNameEl.style.fontSize = '0.85rem';
+        gNameEl.textContent = g.name;
+        info.appendChild(gNameEl);
         if (g.members && g.members.length > 0) {
           info.appendChild(stackedAvatars(g.members, g.count));
         } else {
-          info.innerHTML += ' <span style="color:var(--text-muted);font-size:0.8rem;">(' + g.count + ' member' + (g.count !== 1 ? 's' : '') + ')</span>';
+          var countEl = document.createElement('span');
+          countEl.style.cssText = 'color:var(--text-muted);font-size:0.8rem;';
+          countEl.textContent = ' (' + g.count + ' member' + (g.count !== 1 ? 's' : '') + ')';
+          info.appendChild(countEl);
         }
         row.appendChild(info);
         resultsEl.appendChild(row);


### PR DESCRIPTION
## Summary

Fixes 7 vulnerabilities (4 High, 2 Medium, 1 template-level) identified during a full codebase security review.

### High severity

- **Stored XSS via innerHTML** — User-controlled data (`name`, `email`, `username`) was rendered via `innerHTML` in team/event-type search dropdowns. Minijinja's auto-escaping produces HTML entities (`&lt;`) which `innerHTML` decodes back to live HTML. Replaced all instances with safe DOM APIs (`textContent`, `createElement`). Affected: `team_settings.html`, `team_form.html`, `event_type_form.html`.

- **IDOR: invite deletion** — `POST /dashboard/invites/{id}/delete` had no ownership check. Any authenticated user could delete any invite. Added ownership verification via `accounts.user_id` or `team_members` membership.

- **IDOR: invite creation for private event types** — `POST /dashboard/invites/{id}/send` and `POST /dashboard/invites/{id}/quick-link` did not enforce the documented rule that private event types restrict invite creation to the owner. Added ownership check for `private` visibility; `internal` remains open to all authenticated users by design.

- **SSRF via CalDAV source URLs** — No validation on user-supplied CalDAV URLs allowed probing internal networks (cloud metadata, localhost services). Added `validate_caldav_url()` that rejects non-HTTP(S) schemes, private/reserved IP ranges (RFC 1918, loopback, link-local, CGNAT, IPv6 ULA), and resolves hostnames to check all IPs before connecting.

### Medium severity

- **IDOR: invite management page** — `GET /dashboard/invites/{id}` leaked private event type details (title, guest PII, active invite tokens) to any authenticated user. Added ownership check for `private` visibility.

- **Booking approval via GET** — `GET /booking/approve/{token}` performed irreversible side effects (confirm booking, CalDAV write-back, send emails). Email security scanners (Safe Links, Proofpoint) auto-follow links, causing unintended approvals. Changed to two-step flow matching existing decline/cancel pattern: GET renders confirmation form, POST performs mutation.

## Files changed

| File | Change |
|------|--------|
| `src/caldav/mod.rs` | `validate_caldav_url()`, `is_private_ip()` |
| `src/web/mod.rs` | Ownership checks on 4 invite handlers, approve GET→POST split, SSRF validation call, updated tests |
| `templates/event_type_form.html` | innerHTML → textContent |
| `templates/team_form.html` | innerHTML → textContent |
| `templates/team_settings.html` | innerHTML → textContent |
| `templates/booking_approve_form.html` | New confirmation form template |

## Test plan

- [x] All 508 existing tests pass
- [x] Approve test updated: verifies GET shows form without approving, POST performs approval
- [ ] Manual: register user with `<img src=x onerror=alert(1)>` as name, verify no XSS in team search
- [ ] Manual: verify CalDAV source with `http://127.0.0.1` or `http://169.254.169.254` is rejected
- [ ] Manual: verify non-owner cannot access private event type invite pages
- [ ] Manual: verify booking approval email link shows form, requires click to approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)