### PR TITLE
fix: ICS invite valid for Gmail (strip leading whitespace, use METHOD:REQUEST)

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -267,20 +267,14 @@ pub fn generate_ics(details: &BookingDetails, method: &str) -> String {
                  TRIGGER:-PT{m}M\r\n\
                  ACTION:DISPLAY\r\n\
                  DESCRIPTION:Reminder\r\n\
-                 END:VALARM\r\n\
-                 "
+                 END:VALARM\r\n"
             )
         })
         .unwrap_or_default();
     let additional_attendee_lines: String = details
         .additional_attendees
         .iter()
-        .map(|email| {
-            format!(
-                "ATTENDEE;RSVP=TRUE:mailto:{}\r\n         ",
-                sanitize_ics(email)
-            )
-        })
+        .map(|email| format!("ATTENDEE;RSVP=TRUE:mailto:{}\r\n", sanitize_ics(email)))
         .collect();
     // Convert guest-timezone times to UTC for the ICS
     let (dtstart, dtend) = convert_to_utc(
@@ -311,7 +305,7 @@ pub fn generate_ics(details: &BookingDetails, method: &str) -> String {
         method_line = if method.is_empty() {
             String::new()
         } else {
-            format!("METHOD:{method}\r\n         ")
+            format!("METHOD:{method}\r\n")
         },
         uid = details.uid,
         dtstart = dtstart,
@@ -388,7 +382,7 @@ pub async fn send_guest_confirmation_ex(
     cancel_url: Option<&str>,
     reschedule_url: Option<&str>,
 ) -> Result<()> {
-    let ics = generate_ics(details, "PUBLISH");
+    let ics = generate_ics(details, "REQUEST");
 
     let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
     let from = format!("{} <{}>", from_display, config.from_email).parse()?;
@@ -490,7 +484,7 @@ pub async fn send_guest_confirmation_ex(
 
     let ics_attachment = Attachment::new("invite.ics".to_string()).body(
         ics,
-        ContentType::parse("text/calendar; method=PUBLISH; charset=UTF-8")?,
+        ContentType::parse("text/calendar; method=REQUEST; charset=UTF-8")?,
     );
 
     let email = Message::builder()
@@ -510,7 +504,7 @@ pub async fn send_guest_confirmation_ex(
 
     // Send confirmation to additional attendees
     for attendee_email in &details.additional_attendees {
-        let ics2 = generate_ics(details, "PUBLISH");
+        let ics2 = generate_ics(details, "REQUEST");
         let from2: lettre::message::Mailbox =
             format!("{} <{}>", from_display, config.from_email).parse()?;
         let to2: lettre::message::Mailbox = attendee_email.parse()?;
@@ -567,7 +561,7 @@ pub async fn send_guest_confirmation_ex(
         let body2 = build_multipart_body(&plain2, &html2);
         let att2 = Attachment::new("invite.ics".to_string()).body(
             ics2,
-            ContentType::parse("text/calendar; method=PUBLISH; charset=UTF-8")?,
+            ContentType::parse("text/calendar; method=REQUEST; charset=UTF-8")?,
         );
         let email2 = Message::builder()
             .from(from2)
@@ -1770,7 +1764,7 @@ pub async fn send_guest_reschedule_notification(
         reminder_minutes: None,
         additional_attendees: vec![],
     };
-    let ics = generate_ics(&booking_details, "PUBLISH");
+    let ics = generate_ics(&booking_details, "REQUEST");
 
     let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
     let from = format!("{} <{}>", from_display, config.from_email).parse()?;
@@ -1865,7 +1859,7 @@ pub async fn send_guest_reschedule_notification(
 
     let ics_attachment = Attachment::new("invite.ics".to_string()).body(
         ics,
-        ContentType::parse("text/calendar; method=PUBLISH; charset=UTF-8")?,
+        ContentType::parse("text/calendar; method=REQUEST; charset=UTF-8")?,
     );
 
     let email = Message::builder()
@@ -2294,6 +2288,37 @@ mod tests {
         assert!(ics.contains("DESCRIPTION:Discuss roadmap\r\n"));
         // ORGANIZER must be its own line, not folded into LOCATION
         assert!(ics.contains("\r\nORGANIZER;"));
+    }
+
+    #[test]
+    fn generate_ics_no_line_starts_with_whitespace() {
+        // RFC 5545 §3.1: a line starting with whitespace is folded into the previous
+        // logical line. Leading spaces on any property line would make clients (Gmail,
+        // notably) fail to detect VEVENT at all.
+        let details = BookingDetails {
+            event_title: "Test".to_string(),
+            date: "2026-03-10".to_string(),
+            start_time: "09:00".to_string(),
+            end_time: "10:00".to_string(),
+            guest_name: "Bob".to_string(),
+            guest_email: "bob@test.com".to_string(),
+            guest_timezone: "UTC".to_string(),
+            host_name: "Alice".to_string(),
+            host_email: "alice@test.com".to_string(),
+            uid: "uid-fold".to_string(),
+            notes: Some("n".to_string()),
+            location: Some("https://example.com".to_string()),
+            reminder_minutes: Some(15),
+            additional_attendees: vec!["a@test.com".to_string(), "b@test.com".to_string()],
+        };
+        let ics = generate_ics(&details, "REQUEST");
+        for line in ics.split("\r\n") {
+            assert!(
+                !line.starts_with(' ') && !line.starts_with('\t'),
+                "ICS line must not start with whitespace (would be folded): {:?}",
+                line
+            );
+        }
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -14117,7 +14117,7 @@ mod tests {
 
         // Find the next Monday from now
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -14162,7 +14162,7 @@ mod tests {
 
         // Find the next Monday
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -14246,7 +14246,7 @@ mod tests {
 
         // Find the next Monday
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -14297,7 +14297,7 @@ mod tests {
         let (_, _, et_id) = seed_test_data(&pool).await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -14344,7 +14344,7 @@ mod tests {
         let (_, _, et_id) = seed_test_data(&pool).await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -14391,7 +14391,7 @@ mod tests {
         let (_, _, et_id) = seed_test_data(&pool).await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -15521,7 +15521,7 @@ mod tests {
 
         // Find the next Monday
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -15568,7 +15568,7 @@ mod tests {
 
         // Find the next Monday
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -16146,7 +16146,7 @@ mod tests {
 
         // Find next Monday for a valid slot
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -16187,7 +16187,7 @@ mod tests {
         let csrf = "test-csrf-inv-email";
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -16228,7 +16228,7 @@ mod tests {
         let csrf = "test-csrf-empty-name";
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17030,7 +17030,7 @@ mod tests {
 
         // Find next Monday
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17163,7 +17163,7 @@ mod tests {
         let csrf = "test-csrf-long-notes";
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17321,7 +17321,7 @@ mod tests {
         let csrf = "test-csrf-rate";
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17467,7 +17467,7 @@ mod tests {
             .unwrap();
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17524,7 +17524,7 @@ mod tests {
             .unwrap();
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17668,7 +17668,7 @@ mod tests {
         let (app, _, _, _) = setup_test_app().await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17694,7 +17694,7 @@ mod tests {
         let (app, _, _, _) = setup_test_app().await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17723,7 +17723,7 @@ mod tests {
             .unwrap();
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17955,7 +17955,7 @@ mod tests {
         let (app, pool, _, _) = setup_test_app().await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -17987,7 +17987,7 @@ mod tests {
         let (app, pool, _, _) = setup_test_app().await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -18291,7 +18291,7 @@ mod tests {
         let (_, _, et_id) = seed_test_data(&pool).await;
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }
@@ -18436,7 +18436,7 @@ mod tests {
         let csrf = "test-csrf-bad-time";
 
         let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
-        let mut next_monday = now.date();
+        let mut next_monday = now.date() + Duration::days(1);
         while next_monday.weekday() != chrono::Weekday::Mon {
             next_monday += Duration::days(1);
         }


### PR DESCRIPTION
Closes #36

## The problem

Two independent bugs in `generate_ics` made the calendar invite attachment unusable in Gmail — no "Add to calendar" / RSVP banner, and in some cases no event detected at all.

### 1. Leading whitespace folded lines together

Three substituted values — `method_line`, `additional_attendee_lines`, and the `valarm` block — carried trailing whitespace that leaked right before the next property line. The outer `format!` template uses `\<newline><ws>` continuations which collapse correctly, but these *values* embedded their own trailing spaces, producing output like:

```
METHOD:PUBLISH\r\n         BEGIN:VEVENT\r\n
```

Per [RFC 5545 §3.1](https://datatracker.ietf.org/doc/html/rfc5545#section-3.1), a line starting with whitespace is a folded continuation of the previous logical line. Gmail reads this as one logical line `METHOD:PUBLISHBEGIN:VEVENT UID:...` and never finds a VEVENT.

### 2. `METHOD:PUBLISH` on guest invites

Gmail (and most clients) only surface the "Add to calendar" / RSVP banner for `METHOD:REQUEST`. `PUBLISH` is for read-only feeds. Three call sites sent booking invites with PUBLISH:

- `send_guest_confirmation_ex` (main + additional-attendee loop)
- `send_guest_reschedule_notification`

Each already emitted `ORGANIZER` + `ATTENDEE;RSVP=TRUE`, so `REQUEST` is what the content already expressed — we just weren't labeling it correctly.

## What changed

- Strip trailing whitespace from the three substitutions in `generate_ics`.
- Flip the three guest-facing `generate_ics(..., "PUBLISH")` call sites to `"REQUEST"` and update their matching `Content-Type: text/calendar; method=...` header accordingly.
- Add a regression test (`generate_ics_no_line_starts_with_whitespace`) that walks every line of a fully-populated ICS (with location, reminder, multiple attendees) and fails on any line starting with a space or tab.

`send_host_notification` (already REQUEST) and `generate_cancel_ics` (CANCEL) are untouched.

## Potential risk / behavior change

Switching guest invites from PUBLISH to REQUEST may cause some clients to show an **RSVP prompt** to the guest (Accept / Decline / Maybe) where they previously just saw an informational entry. This matches the intent — the ICS has been sending `RSVP=TRUE` all along — but guests of existing deployments will see the UI nudge on *their next* confirmation or reschedule invite. Worth calling out in the release notes.

Cancellation (`METHOD:CANCEL`), host notifications (already `REQUEST`), and the stored CalDAV events are unchanged.

## Drive-by: flaky test fix

23 booking/slot tests used a `next_monday` pattern that started from `now.date()` — so when the suite ran on a Monday past the test's slot time (10:00), `next_monday` resolved to *today* and min-notice rejected the booking. Bumped the starting point to `now.date() + 1 day` so Monday is always strictly in the future. This was blocking the commit hook on today's run (2026-04-20 is a Monday).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test` — 512 tests pass (new regression test included)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual: book a meeting with a Gmail address, verify "Add to calendar" banner appears
- [ ] Manual: inspect the raw `invite.ics` — every line starts with a property name, none with whitespace
- [ ] Manual: reschedule a booking, verify guest receives an updated invite that Gmail recognizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)