### PR TITLE
Fix XSS vulnerabilities

### DIFF
--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -58,7 +58,7 @@
             <a href="{{ et.view_url }}">View public page</a>
             {% endif %}
             {% if et.can_manage and et.active_bookings == 0 %}
-            <button type="button" class="danger" onclick="if(confirm('Delete event type \'{{ et.title }}\'? This cannot be undone.')) this.nextElementSibling.submit();">Delete</button>
+            <button type="button" class="danger" data-confirm="Delete event type '{{ et.title }}'? This cannot be undone." onclick="if(confirm(this.dataset.confirm)) this.nextElementSibling.submit();">Delete</button>
             <form method="post" action="{{ et.delete_url }}" style="display: none;"></form>
             {% endif %}
           </div>

--- a/templates/dashboard_sources.html
+++ b/templates/dashboard_sources.html
@@ -25,7 +25,7 @@
           <form method="post" action="/dashboard/sources/{{ s.id }}/test" style="margin: 0;">
             <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">Test</button>
           </form>
-          <button type="button" class="slot-btn" style="font-size: 0.8rem; color: var(--error-text); cursor: pointer;" onclick="if(confirm('Remove source \'{{ s.name }}\'? This will delete all synced events from this source.')) this.closest('div').querySelector('.remove-form').submit();">Remove</button>
+          <button type="button" class="slot-btn" style="font-size: 0.8rem; color: var(--error-text); cursor: pointer;" data-confirm="Remove source '{{ s.name }}'? This will delete all synced events from this source." onclick="if(confirm(this.dataset.confirm)) this.closest('div').querySelector('.remove-form').submit();">Remove</button>
           <form method="post" action="/dashboard/sources/{{ s.id }}/remove" class="remove-form" style="display: none;"></form>
         </div>
       </div>

--- a/templates/team_settings.html
+++ b/templates/team_settings.html
@@ -216,7 +216,7 @@
 <div class="card" style="margin-top: 2rem; border: 1px solid var(--error-text, #dc2626);">
   <h2 style="font-size: 1rem; margin-bottom: 0.75rem; color: var(--error-text);">Danger zone</h2>
   <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.75rem;">Permanently delete this team. Event types will be unlinked (not deleted). This cannot be undone.</p>
-  <button type="button" class="slot-btn" style="font-size: 0.85rem; color: var(--error-text); border-color: var(--error-text); cursor: pointer;" onclick="if(confirm('Delete team \'{{ team_name }}\'? This cannot be undone.')) this.nextElementSibling.submit();">Delete this team</button>
+  <button type="button" class="slot-btn" style="font-size: 0.85rem; color: var(--error-text); border-color: var(--error-text); cursor: pointer;" data-confirm="Delete team '{{ team_name }}'? This cannot be undone." onclick="if(confirm(this.dataset.confirm)) this.nextElementSibling.submit();">Delete this team</button>
   <form method="post" action="/dashboard/teams/{{ team_id }}/delete" style="display: none;"></form>
 </div>
 


### PR DESCRIPTION
Hi,

I came across `calrs` yesterday, when someone mentioned it in a comment on HN.

I like this and would like to use it, but am a bit too obsessive about security, and am wary due to the low count of eyes that checked the code of `calrs`.
I figured, I'd contribute some Claude tokens to do a security audit.
**I fully admit I am not an expert in Rust and know very little about frontend technology - I just want to help.**
If you appreciate the contribution, please read on, otherwise feel free to close the PR - no offense taken.

Claude identified a few vulnerabilities (I did a single round, so in my experience there might be more vulnerabilities).
This PR is, in particular, to fix a XSS vulnerability.
Below is Claude's writing on this issue.

If this PR is merged and you so wish, I will open three PRs with the other issues Claude identified:
* [high] OIDC Account Takeover via Automatic Email-Based Account Linking
* [high] Email Header Injection via Unvalidated Guest Name
* [medium] CSRF Cookie Missing `Secure` Flag

---

**Files:**
- `templates/dashboard_event_types.html:61`
- `templates/dashboard_sources.html:28`
- `templates/team_settings.html:219`

**Severity:** High
**Category:** `stored_xss`
**Confidence:** 9/10

### Description

Three dashboard templates embed user-controlled strings directly inside inline JavaScript `onclick` string literals. Minijinja's HTML auto-escaping converts `'` to `&#x27;`, but backslashes (`\`) are not HTML-encoded. The templates wrap the variable with `\'…\'` as a naïve JS-level escape, but this protection can be bypassed: because the attacker controls whether their input begins with `\`, they can cause the template's own backslash to be consumed as an escape for itself, leaving the following apostrophe unprotected.

Vulnerable pattern (identical structure in all three files):

```html
onclick="if(confirm('Delete event type \'{{ et.title }}\'? …')) …"
```

### Exploit Scenario

An authenticated user sets a resource name to `\'; alert(document.cookie)//`. Minijinja HTML-encodes the apostrophe but not the backslash:

```html
onclick="if(confirm('Delete event type \'\\&#x27;; alert(document.cookie)//\'? …'))"
```

The browser decodes HTML entities in attribute values before passing to the JavaScript engine, producing:

```javascript
if(confirm('Delete event type \'\\'; alert(document.cookie)//\'? …'))
```

JavaScript parsing:
1. `\'` — escaped apostrophe, string continues
2. `\\` — escaped backslash, produces a literal `\` in the string value; this escape is now fully consumed
3. `'` — **closes the string** (the `\\` above consumed the backslash, leaving this quote unescaped)
4. `; alert(document.cookie)//` — **executes as JavaScript**

For `dashboard_event_types.html` and `team_settings.html`, team event types and team settings are visible to all team members/admins, making this a true multi-victim stored XSS. For `dashboard_sources.html`, exploitation also impacts any admin who views the page via impersonation.

### Recommendation

Use `data-*` attributes to pass values to JavaScript instead of inline string literals:

```html
<button data-name="{{ et.title }}" data-form-id="del-{{ et.id }}"
        class="delete-btn danger">Delete</button>
<script>
document.querySelectorAll('.delete-btn').forEach(btn => {
    btn.addEventListener('click', () => {
        if (confirm('Delete "' + btn.dataset.name + '"? This cannot be undone.')) {
            document.getElementById(btn.dataset.formId).submit();
        }
    });
});
</script>
```

This eliminates all HTML/JS context confusion. Alternatively, adopt a Content Security Policy that forbids inline event handlers (`script-src 'self'`).