### PR TITLE
feat: SMTP config via environment variables

### DIFF
--- a/migrations/052_smtp_tls_mode.sql
+++ b/migrations/052_smtp_tls_mode.sql
@@ -1,0 +1,5 @@
+-- Per-row TLS mode for the SMTP transport. NULL/'starttls' (default) means
+-- the existing STARTTLS handshake; 'tls' means implicit TLS (typically port
+-- 465), which previously caused send_email() to hang because the code path
+-- unconditionally used starttls_relay().
+ALTER TABLE smtp_config ADD COLUMN tls_mode TEXT NOT NULL DEFAULT 'starttls';

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -91,6 +91,20 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                     Some(name)
                 }
             });
+            let tls_mode = {
+                let raw = prompt("TLS mode (starttls/tls, default starttls)");
+                let normalized = raw.trim().to_ascii_lowercase();
+                match normalized.as_str() {
+                    "" | "starttls" => "starttls",
+                    "tls" => "tls",
+                    other => {
+                        anyhow::bail!(
+                            "Invalid TLS mode '{}'. Use 'starttls' (default, port 587) or 'tls' (implicit TLS, port 465).",
+                            other
+                        );
+                    }
+                }
+            };
 
             let password_enc = crate::crypto::encrypt_password(key, &password)?;
             let id = Uuid::new_v4().to_string();
@@ -99,8 +113,8 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
             sqlx::query("DELETE FROM smtp_config").execute(pool).await?;
 
             sqlx::query(
-                "INSERT INTO smtp_config (id, host, port, username, password_enc, from_email, from_name)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO smtp_config (id, host, port, username, password_enc, from_email, from_name, tls_mode)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&id)
             .bind(&host)
@@ -109,10 +123,17 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
             .bind(&password_enc)
             .bind(&from_email)
             .bind(&from_name)
+            .bind(tls_mode)
             .execute(pool)
             .await?;
 
-            println!("{} SMTP configured ({}:{})", "✓".green(), host, port);
+            println!(
+                "{} SMTP configured ({}:{}, {})",
+                "✓".green(),
+                host,
+                port,
+                tls_mode
+            );
         }
         ConfigCommands::Show => {
             let smtp: Option<(String, i32, String, String, Option<String>, bool)> = sqlx::query_as(

--- a/src/db.rs
+++ b/src/db.rs
@@ -223,6 +223,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "051_per_member_frequency_limit",
             include_str!("../migrations/051_per_member_frequency_limit.sql"),
         ),
+        (
+            "052_smtp_tls_mode",
+            include_str!("../migrations/052_smtp_tls_mode.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -804,7 +808,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 51, "All 51 migrations should be tracked");
+        assert_eq!(count.0, 52, "All 52 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -818,7 +822,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 51, "Still 51 migrations after second run");
+        assert_eq!(count.0, 52, "Still 52 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use chrono::NaiveDateTime;
 use chrono_tz::Tz;
 use fluent_bundle::{FluentArgs, FluentValue};
@@ -40,6 +40,34 @@ pub struct SmtpConfig {
     pub password: String,
     pub from_email: String,
     pub from_name: Option<String>,
+    pub tls_mode: SmtpTlsMode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SmtpTlsMode {
+    StartTls,
+    Tls,
+}
+
+impl SmtpTlsMode {
+    fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "starttls" => Ok(Self::StartTls),
+            "tls" => Ok(Self::Tls),
+            other => bail!(
+                "CALRS_SMTP_TLS_MODE must be 'starttls' or 'tls' (got '{}')",
+                other
+            ),
+        }
+    }
+}
+
+pub struct SmtpStatus {
+    pub host: String,
+    pub port: u16,
+    pub from_email: String,
+    pub enabled: bool,
+    pub from_env: bool,
 }
 
 impl SmtpConfig {
@@ -1600,8 +1628,72 @@ pub async fn send_guest_decline_notice(
 
 // --- Utility ---
 
-/// Load SMTP config from database
+const SMTP_ENV_VARS: &[&str] = &[
+    "CALRS_SMTP_HOST",
+    "CALRS_SMTP_PORT",
+    "CALRS_SMTP_TLS_MODE",
+    "CALRS_SMTP_USERNAME",
+    "CALRS_SMTP_PASSWORD",
+    "CALRS_SMTP_FROM_EMAIL",
+    "CALRS_SMTP_FROM_NAME",
+];
+
+fn required_smtp_env(name: &str) -> Result<String> {
+    match std::env::var(name) {
+        Ok(value) if !value.trim().is_empty() => Ok(value),
+        Ok(_) => bail!("{} must not be empty", name),
+        Err(_) => bail!(
+            "{} is required when SMTP is configured via environment",
+            name
+        ),
+    }
+}
+
+fn load_smtp_config_from_env() -> Result<Option<SmtpConfig>> {
+    if !SMTP_ENV_VARS
+        .iter()
+        .any(|name| std::env::var_os(name).is_some())
+    {
+        return Ok(None);
+    }
+
+    let host = required_smtp_env("CALRS_SMTP_HOST")?;
+    let username = required_smtp_env("CALRS_SMTP_USERNAME")?;
+    let password = required_smtp_env("CALRS_SMTP_PASSWORD")?;
+    let from_email = required_smtp_env("CALRS_SMTP_FROM_EMAIL")?;
+    let port = match std::env::var("CALRS_SMTP_PORT") {
+        Ok(value) if value.trim().is_empty() => bail!("CALRS_SMTP_PORT must not be empty"),
+        Ok(value) => value.trim().parse::<u16>().map_err(|_| {
+            anyhow::anyhow!("CALRS_SMTP_PORT must be a valid TCP port (got '{}')", value)
+        })?,
+        Err(_) => 587u16,
+    };
+    let tls_mode = match std::env::var("CALRS_SMTP_TLS_MODE") {
+        Ok(value) if value.trim().is_empty() => bail!("CALRS_SMTP_TLS_MODE must not be empty"),
+        Ok(value) => SmtpTlsMode::parse(&value)?,
+        Err(_) => SmtpTlsMode::StartTls,
+    };
+    let from_name = std::env::var("CALRS_SMTP_FROM_NAME")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+
+    Ok(Some(SmtpConfig {
+        host,
+        port,
+        username,
+        password,
+        from_email,
+        from_name,
+        tls_mode,
+    }))
+}
+
+/// Load SMTP config from environment or database.
 pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Option<SmtpConfig>> {
+    if let Some(config) = load_smtp_config_from_env()? {
+        return Ok(Some(config));
+    }
+
     let row: Option<(String, i32, String, String, String, Option<String>)> = sqlx::query_as(
         "SELECT host, port, username, password_enc, from_email, from_name
          FROM smtp_config WHERE enabled = 1 LIMIT 1",
@@ -1619,10 +1711,37 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
                 password,
                 from_email,
                 from_name,
+                tls_mode: SmtpTlsMode::StartTls,
             }))
         }
         None => Ok(None),
     }
+}
+
+/// Load non-secret SMTP status for admin display.
+pub async fn load_smtp_status(pool: &SqlitePool) -> Result<Option<SmtpStatus>> {
+    if let Some(config) = load_smtp_config_from_env()? {
+        return Ok(Some(SmtpStatus {
+            host: config.host,
+            port: config.port,
+            from_email: config.from_email,
+            enabled: true,
+            from_env: true,
+        }));
+    }
+
+    let row: Option<(String, i32, String, bool)> =
+        sqlx::query_as("SELECT host, port, from_email, enabled FROM smtp_config LIMIT 1")
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.map(|(host, port, from_email, enabled)| SmtpStatus {
+        host,
+        port: port as u16,
+        from_email,
+        enabled,
+        from_env: false,
+    }))
 }
 
 /// Send a test email
@@ -1744,10 +1863,18 @@ pub async fn send_invite_email(
 async fn send_email(config: &SmtpConfig, email: Message) -> Result<()> {
     let creds = Credentials::new(config.username.clone(), config.password.clone());
 
-    let mailer = AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)?
-        .port(config.port)
-        .credentials(creds)
-        .build();
+    let mailer = match config.tls_mode {
+        SmtpTlsMode::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)?
+            .port(config.port)
+            .credentials(creds)
+            .build(),
+        SmtpTlsMode::StartTls => {
+            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)?
+                .port(config.port)
+                .credentials(creds)
+                .build()
+        }
+    };
 
     let to_addrs: Vec<String> = email
         .envelope()
@@ -2322,6 +2449,49 @@ mod tests {
     use lettre::Address;
 
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static SMTP_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct SmtpEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        old_values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl SmtpEnvGuard {
+        fn new() -> Self {
+            let lock = SMTP_ENV_LOCK.lock().unwrap();
+            let old_values = SMTP_ENV_VARS
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect();
+            for name in SMTP_ENV_VARS {
+                std::env::remove_var(name);
+            }
+            Self {
+                _lock: lock,
+                old_values,
+            }
+        }
+    }
+
+    impl Drop for SmtpEnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.old_values {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    fn smtp_env_error() -> String {
+        match load_smtp_config_from_env() {
+            Ok(_) => panic!("expected SMTP env config to fail"),
+            Err(e) => e.to_string(),
+        }
+    }
 
     #[test]
     fn smtp_config_mailbox_from() {
@@ -2358,6 +2528,80 @@ mod tests {
     }
 
     // --- sanitize_ics ---
+
+    #[test]
+    fn smtp_tls_mode_parses_supported_values() {
+        assert_eq!(
+            SmtpTlsMode::parse("starttls").unwrap(),
+            SmtpTlsMode::StartTls
+        );
+        assert_eq!(SmtpTlsMode::parse(" TLS ").unwrap(), SmtpTlsMode::Tls);
+    }
+
+    #[test]
+    fn smtp_tls_mode_rejects_unknown_values() {
+        let err = SmtpTlsMode::parse("ssl").unwrap_err().to_string();
+        assert!(err.contains("CALRS_SMTP_TLS_MODE"));
+    }
+
+    #[test]
+    fn smtp_env_absent_returns_none() {
+        let _env = SmtpEnvGuard::new();
+        assert!(load_smtp_config_from_env().unwrap().is_none());
+    }
+
+    #[test]
+    fn smtp_env_complete_defaults_to_starttls() {
+        let _env = SmtpEnvGuard::new();
+        std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("CALRS_SMTP_USERNAME", "user");
+        std::env::set_var("CALRS_SMTP_PASSWORD", "secret");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+
+        let config = load_smtp_config_from_env().unwrap().unwrap();
+
+        assert_eq!(config.host, "smtp.example.com");
+        assert_eq!(config.port, 587);
+        assert_eq!(config.tls_mode, SmtpTlsMode::StartTls);
+    }
+
+    #[test]
+    fn smtp_env_partial_config_errors() {
+        let _env = SmtpEnvGuard::new();
+        std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
+
+        let err = smtp_env_error();
+
+        assert!(err.contains("CALRS_SMTP_USERNAME"));
+    }
+
+    #[test]
+    fn smtp_env_invalid_port_errors() {
+        let _env = SmtpEnvGuard::new();
+        std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("CALRS_SMTP_USERNAME", "user");
+        std::env::set_var("CALRS_SMTP_PASSWORD", "secret");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+        std::env::set_var("CALRS_SMTP_PORT", "not-a-port");
+
+        let err = smtp_env_error();
+
+        assert!(err.contains("CALRS_SMTP_PORT"));
+    }
+
+    #[test]
+    fn smtp_env_invalid_tls_mode_errors() {
+        let _env = SmtpEnvGuard::new();
+        std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("CALRS_SMTP_USERNAME", "user");
+        std::env::set_var("CALRS_SMTP_PASSWORD", "secret");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+        std::env::set_var("CALRS_SMTP_TLS_MODE", "ssl");
+
+        let err = smtp_env_error();
+
+        assert!(err.contains("CALRS_SMTP_TLS_MODE"));
+    }
 
     #[test]
     fn sanitize_strips_cr_lf() {

--- a/src/email.rs
+++ b/src/email.rs
@@ -43,6 +43,20 @@ pub struct SmtpConfig {
     pub tls_mode: SmtpTlsMode,
 }
 
+impl std::fmt::Debug for SmtpConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SmtpConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .field("from_email", &self.from_email)
+            .field("from_name", &self.from_name)
+            .field("tls_mode", &self.tls_mode)
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SmtpTlsMode {
     StartTls,
@@ -1694,16 +1708,18 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
         return Ok(Some(config));
     }
 
-    let row: Option<(String, i32, String, String, String, Option<String>)> = sqlx::query_as(
-        "SELECT host, port, username, password_enc, from_email, from_name
+    let row: Option<(String, i32, String, String, String, Option<String>, String)> =
+        sqlx::query_as(
+            "SELECT host, port, username, password_enc, from_email, from_name, tls_mode
          FROM smtp_config WHERE enabled = 1 LIMIT 1",
-    )
-    .fetch_optional(pool)
-    .await?;
+        )
+        .fetch_optional(pool)
+        .await?;
 
     match row {
-        Some((host, port, username, password_enc, from_email, from_name)) => {
+        Some((host, port, username, password_enc, from_email, from_name, tls_mode)) => {
             let password = crate::crypto::decrypt_password(key, &password_enc)?;
+            let tls_mode = SmtpTlsMode::parse(&tls_mode).unwrap_or(SmtpTlsMode::StartTls);
             Ok(Some(SmtpConfig {
                 host,
                 port: port as u16,
@@ -1711,7 +1727,7 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
                 password,
                 from_email,
                 from_name,
-                tls_mode: SmtpTlsMode::StartTls,
+                tls_mode,
             }))
         }
         None => Ok(None),
@@ -1719,6 +1735,12 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
 }
 
 /// Load non-secret SMTP status for admin display.
+///
+/// Unlike [`load_smtp_config`] this does NOT filter by `enabled = 1` — the
+/// admin panel needs to surface a disabled-but-configured row so the operator
+/// can see that SMTP exists and re-enable it. `load_smtp_config` only returns
+/// rows that are actually usable for sending, so it keeps the `WHERE enabled`
+/// guard.
 pub async fn load_smtp_status(pool: &SqlitePool) -> Result<Option<SmtpStatus>> {
     if let Some(config) = load_smtp_config_from_env()? {
         return Ok(Some(SmtpStatus {
@@ -2487,10 +2509,9 @@ mod tests {
     }
 
     fn smtp_env_error() -> String {
-        match load_smtp_config_from_env() {
-            Ok(_) => panic!("expected SMTP env config to fail"),
-            Err(e) => e.to_string(),
-        }
+        load_smtp_config_from_env()
+            .expect_err("expected SMTP env config to fail")
+            .to_string()
     }
 
     #[test]
@@ -2502,6 +2523,7 @@ mod tests {
             password: "password".to_string(),
             from_name: None,
             from_email: "username@example.com".to_string(),
+            tls_mode: SmtpTlsMode::StartTls,
         };
         assert_eq!(
             config.mailbox_from().unwrap(),
@@ -2516,6 +2538,7 @@ mod tests {
             password: "password".to_string(),
             from_name: Some("Name, With Comma".to_string()),
             from_email: "username@example.com".to_string(),
+            tls_mode: SmtpTlsMode::StartTls,
         };
         assert_eq!(
             config.mailbox_from().unwrap(),

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -12687,15 +12687,43 @@ async fn admin_dashboard(
         .map(|c| c.oidc_auto_register)
         .unwrap_or(true);
 
-    // Fetch SMTP config (first one found)
-    let smtp: Option<(String, i32, String, bool)> =
-        sqlx::query_as("SELECT host, port, from_email, enabled FROM smtp_config LIMIT 1")
-            .fetch_optional(&state.pool)
-            .await
-            .unwrap_or(None);
-
-    let smtp_configured = smtp.is_some();
-    let (smtp_host, smtp_port, smtp_from_email, smtp_enabled) = smtp.unwrap_or_default();
+    let (
+        smtp_configured,
+        smtp_host,
+        smtp_port,
+        smtp_from_email,
+        smtp_enabled,
+        smtp_from_env,
+        smtp_error,
+    ) = match crate::email::load_smtp_status(&state.pool).await {
+        Ok(Some(status)) => (
+            true,
+            status.host,
+            status.port,
+            status.from_email,
+            status.enabled,
+            status.from_env,
+            String::new(),
+        ),
+        Ok(None) => (
+            false,
+            String::new(),
+            0u16,
+            String::new(),
+            false,
+            false,
+            String::new(),
+        ),
+        Err(e) => (
+            false,
+            String::new(),
+            0u16,
+            String::new(),
+            false,
+            true,
+            e.to_string(),
+        ),
+    };
 
     let tmpl = match state.templates.get_template("admin.html") {
         Ok(t) => t,
@@ -12732,6 +12760,8 @@ async fn admin_dashboard(
             smtp_port => smtp_port,
             smtp_from_email => smtp_from_email,
             smtp_enabled => smtp_enabled,
+            smtp_from_env => smtp_from_env,
+            smtp_error => smtp_error,
             has_logo => state.data_dir.join("logo.png").exists(),
             company_link => get_company_link(&state.pool).await.unwrap_or_default(),
             current_theme => get_theme_name(&state.pool).await,

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -318,16 +318,18 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
 <!-- SMTP settings -->
 <div class="card">
   <h2>SMTP settings</h2>
-  {% if smtp_configured %}
+  {% if smtp_error %}
+  <p style="color: var(--error-text); font-size: 0.875rem;">SMTP environment configuration error: {{ smtp_error }}</p>
+  {% elif smtp_configured %}
   <div style="font-size: 0.875rem; color: var(--text-secondary); line-height: 1.8;">
-    <div>Status: <strong style="color: var(--success);">configured</strong>{% if not smtp_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %}</div>
+    <div>Status: <strong style="color: var(--success);">configured</strong>{% if not smtp_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %}{% if smtp_from_env %} <span style="color: var(--text-muted);">(via environment)</span>{% endif %}</div>
     <div>Host: <span style="color: var(--text-muted);">{{ smtp_host }}:{{ smtp_port }}</span></div>
     <div>From: <span style="color: var(--text-muted);">{{ smtp_from_email }}</span></div>
   </div>
   {% else %}
   <p style="color: var(--text-muted); font-size: 0.875rem;">SMTP is not configured.</p>
   {% endif %}
-  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 0.75rem;">SMTP configuration must be managed via the CLI (<code>calrs config smtp</code>) for security reasons.</p>
+  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 0.75rem;">Configure via environment variables: <code>CALRS_SMTP_HOST</code>, <code>CALRS_SMTP_PORT</code>, <code>CALRS_SMTP_TLS_MODE</code> (<code>starttls</code> or <code>tls</code>), <code>CALRS_SMTP_USERNAME</code>, <code>CALRS_SMTP_PASSWORD</code>, <code>CALRS_SMTP_FROM_EMAIL</code>, <code>CALRS_SMTP_FROM_NAME</code>.</p>
 </div>
 
 <script>


### PR DESCRIPTION
Adds `CALRS_SMTP_*` env vars as an alternative to `calrs config smtp`. Useful for Docker/container deployments where you want config in the environment rather than the database.

Required: `CALRS_SMTP_HOST`, `CALRS_SMTP_USERNAME`, `CALRS_SMTP_PASSWORD`, `CALRS_SMTP_FROM_EMAIL`
Optional: `CALRS_SMTP_PORT` (default 587), `CALRS_SMTP_TLS_MODE` (`starttls` or `tls`), `CALRS_SMTP_FROM_NAME`

Env vars take priority over the database. Partial config (any var set but required fields missing) errors loudly rather than silently falling through.

Also fixes a hang when using port 465 — `send_email` was unconditionally calling `starttls_relay()` which doesn't work with implicit TLS. Added `SmtpTlsMode` enum and branch on `relay()` vs `starttls_relay()` accordingly.

Admin panel shows env-sourced config status and any misconfiguration errors inline.

---
_Re-opened on a clean branch from #52 — same single commit, just isolated from later work on my fork's main._