### PR TITLE
i18n: localize the public booking flow (Fluent + Weblate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,27 @@ When adding a new migration:
 1. Create `migrations/NNN_description.sql` with the DDL.
 2. **CRITICAL: Register it in `src/db.rs`** in the `migrations` array inside `migrate()`. Forgetting this step means the migration never runs on existing deployments, and any queries referencing the new table/column will fail silently (due to `unwrap_or_default()`). This has caused production bugs before — always verify the migration is registered.
 
+### Localization (Fluent + Weblate)
+
+calrs ships with translations for English, French, Spanish, and Polish. Source files live under `i18n/{lang}/main.ftl` and are embedded in the binary via `include_str!` (no runtime files). The loader, language detection, and minijinja `t()` global are in `src/i18n.rs`. Templates use `{{ t("message-id", arg=value) }}` and the active language is injected into the rendering context as `lang` by the calling handler.
+
+**Branch workflow (long-lived `i18n` branch).** The `i18n` branch is permanent. **Do not delete it after merging.** Translators commit through Hosted Weblate, which pushes to `i18n` via the Weblate GitHub App. Periodically (e.g. before each release) merge `i18n` into `main`, then continue using the same branch for the next round of translations. The branch never gets recreated.
+
+**When you add or change a translatable string:**
+1. Land it on the `i18n` branch first, not `main`. This avoids half-translated UI on `main` and gives Weblate translators time to catch up before the next merge.
+2. Add the new key to `i18n/en/main.ftl` (the source of truth). Stub languages don't need entries: missing keys fall back to English at runtime.
+3. If the change touches a template that wasn't translated yet, convert its hard-coded strings to `{{ t("...") }}` calls in the same commit, and add render-site context entries (`lang => crate::i18n::detect_from_headers(&headers)` for guest pages, or `crate::i18n::resolve(user.language.as_deref(), &headers)` for authenticated dashboard pages).
+
+**When you add a new locale:**
+1. Create `i18n/{code}/main.ftl` (start empty, runtime falls back to English).
+2. Register it in `SUPPORTED_LANGS` in `src/i18n.rs`.
+3. Add a label to `supported_with_labels()` so it appears in the settings dropdown.
+4. Push to `i18n`. Weblate auto-detects the new language file on next pull.
+
+**Anti-patterns to avoid:**
+- Don't bypass `t()` and inline new English strings directly in templates that are already translated. Translators will silently drift out of date.
+- Don't merge `main` into `i18n` to "sync"; the flow goes `i18n → main`. New features that touch UI text should branch off `i18n`, not `main`.
+
 ### Updating the GitHub Pages site
 
 The site (landing page + mdbook docs) lives on the `gh-pages` branch. To update it:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "memo-map",
  "self_cell 1.2.2",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "clap",
  "colored",
  "directories",
+ "fluent-bundle",
  "hex",
  "http-body-util",
  "iana-time-zone",
@@ -389,6 +390,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unic-langid",
  "urlencoding",
  "uuid",
 ]
@@ -923,6 +925,40 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "flume"
@@ -1555,6 +1591,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,7 +1818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
 dependencies = [
  "memo-map",
- "self_cell",
+ "self_cell 1.2.2",
  "serde",
 ]
 
@@ -2283,7 +2338,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -2303,7 +2358,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -2637,6 +2692,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -2794,6 +2855,15 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.2.2",
 ]
 
 [[package]]
@@ -3501,6 +3571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -3707,10 +3778,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "tinystr",
+]
 
 [[package]]
 name = "unicase"
@@ -4428,6 +4526,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ urlencoding = "2"
 # Markdown (bio rendering)
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 
+# Localization (Fluent)
+fluent-bundle = "0.15"
+unic-langid = "0.9"
+
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ lettre = { version = "0.11", default-features = false, features = ["tokio1-rustl
 # Web server
 axum = { version = "0.8", features = ["macros", "multipart"] }
 axum-extra = { version = "0.10", features = ["cookie", "form"] }
-minijinja = { version = "2", features = ["loader"] }
+minijinja = { version = "2", features = ["loader", "json"] }
 tower-http = { version = "0.6", features = ["trace"] }
 
 # Logging

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ Each team member's CalDAV calendars are checked for conflicts. The availability 
 - **Credential encryption** — CalDAV and SMTP passwords encrypted at rest with AES-256-GCM; secret key auto-generated or provided via `CALRS_SECRET_KEY`
 - **Hidden password input** — passwords never echoed to the terminal
 
+### Localization
+
+- **Multi-language UI**: public booking flow available in English, French, Spanish, and Polish. Strings are managed via [Fluent](https://projectfluent.org/) and embedded in the binary at compile time, so no runtime files to ship
+- **Automatic language detection**: guests get their browser's language (RFC 7231 `Accept-Language` with q-weights). Authenticated users can override the choice in **Profile & Settings**
+- **Community-driven translations**: contribute via [Hosted Weblate](https://hosted.weblate.org/projects/calrs/) without needing to touch git or Rust. See [Contributing translations](#contributing-translations)
+
 ### Quality
 
 - **Automated test suite** — 500+ tests covering web handlers, CLI commands, auth lifecycle, email rendering, RRULE expansion, iCal parsing, timezone conversion, availability computation, slot generation, database migrations, rate limiting, and more
@@ -568,8 +574,42 @@ calrs/
 - [x] Booking frequency limits + one slot per day
 - [ ] Webhooks (per-event-type HTTP callbacks on new/cancelled bookings)
 - [x] Delta sync using CalDAV `sync-token` / `ctag`
-- [ ] Multi-language support (i18n)
+- [x] Multi-language support (i18n) — see [Localization](#localization)
 - [ ] REST API for third-party integrations
+
+## Localization
+
+[![Translation status](https://hosted.weblate.org/widget/calrs/multi-auto.svg)](https://hosted.weblate.org/engage/calrs/)
+
+calrs ships with translations for English, French, Spanish, and Polish. Strings are stored in [Fluent](https://projectfluent.org/) `.ftl` files under `i18n/` and embedded in the binary at compile time.
+
+### How language is selected
+
+| Visitor | Source of truth |
+|---|---|
+| Guest (not logged in) | Browser `Accept-Language` header, with q-weights honoured |
+| Logged-in user with no preference set | Same as above |
+| Logged-in user with a preference set | The user's choice in **Profile & Settings** |
+
+Untranslated keys fall back to English at runtime, so a partial translation never breaks the page.
+
+### Contributing translations
+
+Translators do not need to touch git, Rust, or even know the project structure. Everything happens in the browser:
+
+1. Open the project on Hosted Weblate: <https://hosted.weblate.org/projects/calrs/>
+2. Pick your language (or click **Start new translation** if it isn't listed)
+3. Translate strings in the web editor
+
+Saved translations flow back to the `i18n` branch automatically. Maintainers periodically merge that branch into `main`, and the next release ships with your work.
+
+If you want a language that isn't yet listed, open an issue or just start translating it on Weblate. Adding a new locale on the calrs side is a one-line change.
+
+### For developers
+
+- Translation source lives in `i18n/{lang}/main.ftl` (one file per language, kebab-case message IDs)
+- Loader: `src/i18n.rs`. Strings are accessed in templates via `{{ t("message-id", arg=value) }}`
+- New translatable strings should land on the `i18n` branch first so translators see them on Weblate before the next merge into `main`
 
 ## License
 

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -22,3 +22,39 @@ confirmed-detail-notes = Notes:
 confirmed-detail-additional-guests = Additional guests:
 
 confirmed-book-another = Book another time
+
+# Slot picker (templates/slots.html)
+
+slots-location-video = Video call
+slots-location-phone = Phone call
+
+slots-tz-label = Your timezone
+slots-time-format-label = Time format
+
+slots-view-month = Month view
+slots-view-week = Week view
+slots-view-column = Column view
+
+slots-weekday-mon = Mon
+slots-weekday-tue = Tue
+slots-weekday-wed = Wed
+slots-weekday-thu = Thu
+slots-weekday-fri = Fri
+slots-weekday-sat = Sat
+slots-weekday-sun = Sun
+
+slots-weekday-mon-short = M
+slots-weekday-tue-short = T
+slots-weekday-wed-short = W
+slots-weekday-thu-short = T
+slots-weekday-fri-short = F
+slots-weekday-sat-short = S
+slots-weekday-sun-short = S
+
+slots-select-date = Select a date
+slots-loading-availability = Loading availability...
+slots-click-highlighted = Click a highlighted date to see available times
+slots-no-times-month = No available times this month
+slots-no-times-day = No available times this day
+slots-no-availability-participants = No availability found for all participants this month
+slots-week-more = more

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -149,3 +149,10 @@ resched-was = Was:
 resched-new = New:
 resched-button = Confirm reschedule
 resched-back-to-picker = Back to time picker
+
+# Base layout chrome (templates/base.html)
+
+base-loader-checking = Checking availability
+base-loader-please-wait = Please wait, loading the latest calendar data...
+base-stop-impersonating = Stop impersonating
+base-theme-toggle = Toggle theme

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -1,0 +1,24 @@
+# Booking confirmation page (templates/confirmed.html)
+
+confirmed-page-title-pending = Booking pending
+confirmed-page-title-booked = Booking confirmed
+
+confirmed-heading-reschedule-requested = Reschedule requested
+confirmed-heading-rescheduled = Rescheduled!
+confirmed-heading-pending = Pending confirmation
+confirmed-heading-booked = You're booked!
+
+confirmed-subtitle-reschedule-requested = Your reschedule request has been sent to { $host }. You'll receive an email at { $email } once it's approved.
+confirmed-subtitle-rescheduled = Your booking has been rescheduled. A confirmation email has been sent to { $email }.
+confirmed-subtitle-pending = Your booking request has been sent to { $host }. You'll receive an email at { $email } once it's confirmed.
+confirmed-subtitle-booked = A confirmation email has been sent to { $email }.
+
+confirmed-detail-event = Event:
+confirmed-detail-date = Date:
+confirmed-detail-time = Time:
+confirmed-detail-with = With:
+confirmed-detail-location = Location:
+confirmed-detail-notes = Notes:
+confirmed-detail-additional-guests = Additional guests:
+
+confirmed-book-another = Book another time

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -58,3 +58,20 @@ slots-no-times-month = No available times this month
 slots-no-times-day = No available times this day
 slots-no-availability-participants = No availability found for all participants this month
 slots-week-more = more
+
+# Booking form (templates/book.html)
+
+book-page-title = Book { $title }
+book-back-to-times = Back to times
+book-name-label = Your name
+book-name-placeholder = Jane Doe
+book-email-label = Email
+book-email-placeholder = jane@example.com
+book-notes-label = Notes
+book-notes-optional = (optional)
+book-notes-placeholder = Anything you'd like to discuss?
+book-additional-guests-label = Additional guests
+book-additional-guests-hint = (optional, up to { $max })
+book-add-guest-btn = + Add guest email
+book-guest-email-placeholder = colleague@example.com
+book-confirm-button = Confirm booking

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -75,3 +75,77 @@ book-additional-guests-hint = (optional, up to { $max })
 book-add-guest-btn = + Add guest email
 book-guest-email-placeholder = colleague@example.com
 book-confirm-button = Confirm booking
+
+# Shared labels used across the cancel / decline / approve / reschedule / claim flows
+
+common-detail-guest = Guest:
+common-detail-reason = Reason:
+common-reason-optional = (optional)
+common-close-page = You can close this page.
+
+# Cancel flow (booking_cancel_form.html, booking_cancelled_guest.html)
+
+cancel-page-title = Cancel booking
+cancel-heading = Cancel booking
+cancel-subtitle = You are about to cancel your booking.
+cancel-reason-label = Reason
+cancel-reason-placeholder-host = Let the host know why...
+cancel-button = Cancel booking
+cancelled-heading = Booking cancelled
+cancelled-subtitle = Your booking has been cancelled and the host has been notified.
+
+# Decline flow (booking_decline_form.html, booking_declined.html)
+
+decline-page-title = Decline booking
+decline-heading = Decline booking
+decline-subtitle = You are about to decline this booking request.
+decline-reason-placeholder-guest = Let the guest know why...
+decline-button = Decline booking
+declined-heading = Booking declined
+declined-subtitle = The booking has been declined and the guest has been notified.
+
+# Approve flow (booking_approve_form.html, booking_approved.html)
+
+approve-page-title = Approve booking
+approve-heading = Approve booking
+approve-subtitle = You are about to approve this booking request.
+approve-button = Approve booking
+approved-heading = Booking approved
+approved-subtitle = The booking has been confirmed and a confirmation email has been sent to { $email }.
+
+# Claim flow (booking_claim_form.html, booking_claimed.html, booking_already_claimed.html)
+
+claim-page-title = Claim booking
+claim-heading = Claim booking
+claim-subtitle = You are about to claim this booking. You will be added as an attendee.
+claim-assigned-to = Assigned to:
+claim-button = Claim this booking
+claimed-page-title = Booking claimed
+claimed-heading = Booking claimed
+claimed-subtitle = You have claimed this booking. A calendar invite has been sent to your email.
+already-claimed-page-title = Already claimed
+already-claimed-heading = Already claimed
+already-claimed-subtitle = This booking has already been claimed by { $name }.
+
+# Generic error page (booking_action_error.html)
+
+action-error-page-title = Booking action error
+
+# Host-initiated reschedule (booking_host_reschedule.html)
+
+host-resched-page-title = Reschedule booking — calrs
+host-resched-heading = Reschedule booking
+host-resched-subtitle = This will send { $guest } an email asking them to pick a new time.
+host-resched-currently = Currently:
+host-resched-button = Send reschedule request
+host-resched-cancel-link = Cancel
+
+# Guest reschedule confirmation (booking_reschedule_confirm.html)
+
+resched-confirm-page-title = Confirm reschedule
+resched-confirm-heading = Confirm reschedule
+resched-confirm-subtitle = You are about to move your booking to a new time.
+resched-was = Was:
+resched-new = New:
+resched-button = Confirm reschedule
+resched-back-to-picker = Back to time picker

--- a/i18n/es/main.ftl
+++ b/i18n/es/main.ftl
@@ -1,0 +1,2 @@
+# Spanish translation — contributions welcome via Weblate.
+# Keys without values fall back to the English source at runtime.

--- a/i18n/es/main.ftl
+++ b/i18n/es/main.ftl
@@ -1,2 +1,24 @@
-# Spanish translation — contributions welcome via Weblate.
-# Keys without values fall back to the English source at runtime.
+# Booking confirmation page (templates/confirmed.html)
+
+confirmed-page-title-pending = Reserva pendiente
+confirmed-page-title-booked = Reserva confirmada
+
+confirmed-heading-reschedule-requested = Reprogramación solicitada
+confirmed-heading-rescheduled = ¡Reprogramado!
+confirmed-heading-pending = Pendiente de confirmación
+confirmed-heading-booked = ¡Listo, reservado!
+
+confirmed-subtitle-reschedule-requested = Tu solicitud de reprogramación se ha enviado a { $host }. Recibirás un correo en { $email } una vez que se apruebe.
+confirmed-subtitle-rescheduled = Tu reserva ha sido reprogramada. Se ha enviado un correo de confirmación a { $email }.
+confirmed-subtitle-pending = Tu solicitud de reserva se ha enviado a { $host }. Recibirás un correo en { $email } una vez que se confirme.
+confirmed-subtitle-booked = Se ha enviado un correo de confirmación a { $email }.
+
+confirmed-detail-event = Evento:
+confirmed-detail-date = Fecha:
+confirmed-detail-time = Hora:
+confirmed-detail-with = Con:
+confirmed-detail-location = Lugar:
+confirmed-detail-notes = Notas:
+confirmed-detail-additional-guests = Invitados adicionales:
+
+confirmed-book-another = Reservar otro horario

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -149,3 +149,10 @@ resched-was = Avant :
 resched-new = Maintenant :
 resched-button = Confirmer la reprogrammation
 resched-back-to-picker = Retour au choix du créneau
+
+# Base layout chrome (templates/base.html)
+
+base-loader-checking = Vérification des disponibilités
+base-loader-please-wait = Veuillez patienter, chargement des dernières données de calendrier...
+base-stop-impersonating = Arrêter l'usurpation
+base-theme-toggle = Changer de thème

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -58,3 +58,20 @@ slots-no-times-month = Aucun créneau disponible ce mois-ci
 slots-no-times-day = Aucun créneau disponible ce jour
 slots-no-availability-participants = Aucune disponibilité commune trouvée pour tous les participants ce mois-ci
 slots-week-more = autres
+
+# Booking form (templates/book.html)
+
+book-page-title = Réserver { $title }
+book-back-to-times = Retour aux créneaux
+book-name-label = Votre nom
+book-name-placeholder = Jeanne Dupont
+book-email-label = Adresse e-mail
+book-email-placeholder = jeanne@example.com
+book-notes-label = Notes
+book-notes-optional = (facultatif)
+book-notes-placeholder = Y a-t-il des points que vous aimeriez aborder ?
+book-additional-guests-label = Invités supplémentaires
+book-additional-guests-hint = (facultatif, jusqu'à { $max })
+book-add-guest-btn = + Ajouter un invité
+book-guest-email-placeholder = collegue@example.com
+book-confirm-button = Confirmer la réservation

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -75,3 +75,77 @@ book-additional-guests-hint = (facultatif, jusqu'à { $max })
 book-add-guest-btn = + Ajouter un invité
 book-guest-email-placeholder = collegue@example.com
 book-confirm-button = Confirmer la réservation
+
+# Shared labels used across the cancel / decline / approve / reschedule / claim flows
+
+common-detail-guest = Invité :
+common-detail-reason = Motif :
+common-reason-optional = (facultatif)
+common-close-page = Vous pouvez fermer cette page.
+
+# Cancel flow (booking_cancel_form.html, booking_cancelled_guest.html)
+
+cancel-page-title = Annuler la réservation
+cancel-heading = Annuler la réservation
+cancel-subtitle = Vous êtes sur le point d'annuler votre réservation.
+cancel-reason-label = Motif
+cancel-reason-placeholder-host = Indiquez à l'organisateur la raison...
+cancel-button = Annuler la réservation
+cancelled-heading = Réservation annulée
+cancelled-subtitle = Votre réservation a été annulée et l'organisateur a été informé.
+
+# Decline flow (booking_decline_form.html, booking_declined.html)
+
+decline-page-title = Refuser la réservation
+decline-heading = Refuser la réservation
+decline-subtitle = Vous êtes sur le point de refuser cette demande de réservation.
+decline-reason-placeholder-guest = Indiquez à l'invité la raison...
+decline-button = Refuser la réservation
+declined-heading = Réservation refusée
+declined-subtitle = La réservation a été refusée et l'invité a été informé.
+
+# Approve flow (booking_approve_form.html, booking_approved.html)
+
+approve-page-title = Approuver la réservation
+approve-heading = Approuver la réservation
+approve-subtitle = Vous êtes sur le point d'approuver cette demande de réservation.
+approve-button = Approuver la réservation
+approved-heading = Réservation approuvée
+approved-subtitle = La réservation a été confirmée et un e-mail de confirmation a été envoyé à { $email }.
+
+# Claim flow (booking_claim_form.html, booking_claimed.html, booking_already_claimed.html)
+
+claim-page-title = Prendre la réservation
+claim-heading = Prendre la réservation
+claim-subtitle = Vous êtes sur le point de prendre en charge cette réservation. Vous serez ajouté comme participant.
+claim-assigned-to = Attribuée à :
+claim-button = Prendre cette réservation
+claimed-page-title = Réservation prise en charge
+claimed-heading = Réservation prise en charge
+claimed-subtitle = Vous avez pris en charge cette réservation. Une invitation a été envoyée à votre adresse e-mail.
+already-claimed-page-title = Déjà prise en charge
+already-claimed-heading = Déjà prise en charge
+already-claimed-subtitle = Cette réservation a déjà été prise en charge par { $name }.
+
+# Generic error page (booking_action_error.html)
+
+action-error-page-title = Erreur d'action sur la réservation
+
+# Host-initiated reschedule (booking_host_reschedule.html)
+
+host-resched-page-title = Reprogrammer la réservation — calrs
+host-resched-heading = Reprogrammer la réservation
+host-resched-subtitle = Cela enverra à { $guest } un e-mail lui demandant de choisir un nouveau créneau.
+host-resched-currently = Actuellement :
+host-resched-button = Envoyer la demande de reprogrammation
+host-resched-cancel-link = Annuler
+
+# Guest reschedule confirmation (booking_reschedule_confirm.html)
+
+resched-confirm-page-title = Confirmer la reprogrammation
+resched-confirm-heading = Confirmer la reprogrammation
+resched-confirm-subtitle = Vous êtes sur le point de déplacer votre réservation à un nouveau créneau.
+resched-was = Avant :
+resched-new = Maintenant :
+resched-button = Confirmer la reprogrammation
+resched-back-to-picker = Retour au choix du créneau

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -22,3 +22,39 @@ confirmed-detail-notes = Notes :
 confirmed-detail-additional-guests = Invités supplémentaires :
 
 confirmed-book-another = Réserver un autre créneau
+
+# Slot picker (templates/slots.html)
+
+slots-location-video = Visioconférence
+slots-location-phone = Appel téléphonique
+
+slots-tz-label = Votre fuseau horaire
+slots-time-format-label = Format de l'heure
+
+slots-view-month = Vue mensuelle
+slots-view-week = Vue hebdomadaire
+slots-view-column = Vue en liste
+
+slots-weekday-mon = Lun
+slots-weekday-tue = Mar
+slots-weekday-wed = Mer
+slots-weekday-thu = Jeu
+slots-weekday-fri = Ven
+slots-weekday-sat = Sam
+slots-weekday-sun = Dim
+
+slots-weekday-mon-short = L
+slots-weekday-tue-short = M
+slots-weekday-wed-short = M
+slots-weekday-thu-short = J
+slots-weekday-fri-short = V
+slots-weekday-sat-short = S
+slots-weekday-sun-short = D
+
+slots-select-date = Choisissez une date
+slots-loading-availability = Chargement des disponibilités...
+slots-click-highlighted = Cliquez sur une date en surbrillance pour voir les créneaux disponibles
+slots-no-times-month = Aucun créneau disponible ce mois-ci
+slots-no-times-day = Aucun créneau disponible ce jour
+slots-no-availability-participants = Aucune disponibilité commune trouvée pour tous les participants ce mois-ci
+slots-week-more = autres

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -1,0 +1,24 @@
+# Booking confirmation page (templates/confirmed.html)
+
+confirmed-page-title-pending = Réservation en attente
+confirmed-page-title-booked = Réservation confirmée
+
+confirmed-heading-reschedule-requested = Reprogrammation demandée
+confirmed-heading-rescheduled = Reprogrammé !
+confirmed-heading-pending = En attente de confirmation
+confirmed-heading-booked = C'est réservé !
+
+confirmed-subtitle-reschedule-requested = Votre demande de reprogrammation a été envoyée à { $host }. Vous recevrez un e-mail à l'adresse { $email } une fois qu'elle sera approuvée.
+confirmed-subtitle-rescheduled = Votre réservation a été reprogrammée. Un e-mail de confirmation a été envoyé à { $email }.
+confirmed-subtitle-pending = Votre demande de réservation a été envoyée à { $host }. Vous recevrez un e-mail à l'adresse { $email } une fois qu'elle sera confirmée.
+confirmed-subtitle-booked = Un e-mail de confirmation a été envoyé à { $email }.
+
+confirmed-detail-event = Événement :
+confirmed-detail-date = Date :
+confirmed-detail-time = Heure :
+confirmed-detail-with = Avec :
+confirmed-detail-location = Lieu :
+confirmed-detail-notes = Notes :
+confirmed-detail-additional-guests = Invités supplémentaires :
+
+confirmed-book-another = Réserver un autre créneau

--- a/i18n/pl/main.ftl
+++ b/i18n/pl/main.ftl
@@ -1,0 +1,2 @@
+# Polish translation — contributions welcome via Weblate.
+# Keys without values fall back to the English source at runtime.

--- a/i18n/pl/main.ftl
+++ b/i18n/pl/main.ftl
@@ -1,2 +1,24 @@
-# Polish translation — contributions welcome via Weblate.
-# Keys without values fall back to the English source at runtime.
+# Booking confirmation page (templates/confirmed.html)
+
+confirmed-page-title-pending = Rezerwacja oczekująca
+confirmed-page-title-booked = Rezerwacja potwierdzona
+
+confirmed-heading-reschedule-requested = Prośba o zmianę terminu
+confirmed-heading-rescheduled = Termin zmieniony!
+confirmed-heading-pending = Oczekuje na potwierdzenie
+confirmed-heading-booked = Zarezerwowano!
+
+confirmed-subtitle-reschedule-requested = Twoja prośba o zmianę terminu została wysłana do { $host }. Otrzymasz e-mail na adres { $email }, gdy zostanie zatwierdzona.
+confirmed-subtitle-rescheduled = Twoja rezerwacja została przeniesiona. E-mail potwierdzający został wysłany na adres { $email }.
+confirmed-subtitle-pending = Twoja prośba o rezerwację została wysłana do { $host }. Otrzymasz e-mail na adres { $email }, gdy zostanie potwierdzona.
+confirmed-subtitle-booked = E-mail potwierdzający został wysłany na adres { $email }.
+
+confirmed-detail-event = Wydarzenie:
+confirmed-detail-date = Data:
+confirmed-detail-time = Godzina:
+confirmed-detail-with = Z:
+confirmed-detail-location = Miejsce:
+confirmed-detail-notes = Notatki:
+confirmed-detail-additional-guests = Dodatkowi goście:
+
+confirmed-book-another = Zarezerwuj inny termin

--- a/migrations/047_user_language.sql
+++ b/migrations/047_user_language.sql
@@ -1,0 +1,2 @@
+-- Per-user UI language preference. NULL = follow Accept-Language header.
+ALTER TABLE users ADD COLUMN language TEXT;

--- a/src/db.rs
+++ b/src/db.rs
@@ -203,6 +203,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "046_event_type_timezone",
             include_str!("../migrations/046_event_type_timezone.sql"),
         ),
+        (
+            "047_user_language",
+            include_str!("../migrations/047_user_language.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -746,7 +750,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 46, "All 46 migrations should be tracked");
+        assert_eq!(count.0, 47, "All 47 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -760,7 +764,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 46, "Still 46 migrations after second run");
+        assert_eq!(count.0, 47, "Still 47 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -11,11 +11,14 @@ use minijinja::value::Kwargs;
 use minijinja::{Environment, State};
 use unic_langid::LanguageIdentifier;
 
-const SUPPORTED_LANGS: &[(&str, &str)] = &[
-    ("en", include_str!("../i18n/en/main.ftl")),
-    ("fr", include_str!("../i18n/fr/main.ftl")),
-    ("es", include_str!("../i18n/es/main.ftl")),
-    ("pl", include_str!("../i18n/pl/main.ftl")),
+// Single source of truth: (BCP-47 code, native display label, embedded .ftl source).
+// Add a new language by appending a row here; the bundle, the Accept-Language
+// matcher, and the settings dropdown all read from this same array.
+const SUPPORTED_LANGS: &[(&str, &str, &str)] = &[
+    ("en", "English", include_str!("../i18n/en/main.ftl")),
+    ("fr", "Français", include_str!("../i18n/fr/main.ftl")),
+    ("es", "Español", include_str!("../i18n/es/main.ftl")),
+    ("pl", "Polski", include_str!("../i18n/pl/main.ftl")),
 ];
 
 const DEFAULT_LANG: &str = "en";
@@ -25,14 +28,14 @@ static BUNDLES: OnceLock<HashMap<&'static str, FluentBundle<FluentResource>>> = 
 fn bundles() -> &'static HashMap<&'static str, FluentBundle<FluentResource>> {
     BUNDLES.get_or_init(|| {
         let mut map = HashMap::new();
-        for (code, src) in SUPPORTED_LANGS {
+        for (code, _label, src) in SUPPORTED_LANGS {
             let langid: LanguageIdentifier = code
                 .parse()
                 .unwrap_or_else(|_| panic!("invalid lang code: {code}"));
             let resource = FluentResource::try_new(src.to_string())
                 .unwrap_or_else(|_| panic!("ftl parse error in {code}"));
             let mut bundle = FluentBundle::new_concurrent(vec![langid]);
-            // Disable Unicode directional isolates — they break rendering inside HTML.
+            // Disable Unicode directional isolates, they break rendering inside HTML.
             bundle.set_use_isolating(false);
             bundle
                 .add_resource(resource)
@@ -100,7 +103,7 @@ pub fn detect_from_accept_language(header: Option<&str>) -> &'static str {
     entries.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
     for (_, primary) in &entries {
-        for (code, _) in SUPPORTED_LANGS {
+        for (code, _, _) in SUPPORTED_LANGS {
             if *code == primary.as_str() {
                 return code;
             }
@@ -117,7 +120,7 @@ pub fn detect_from_headers(headers: &HeaderMap) -> &'static str {
 
 /// Whether a given language code matches one of the bundled locales.
 pub fn is_supported(code: &str) -> bool {
-    SUPPORTED_LANGS.iter().any(|(c, _)| *c == code)
+    SUPPORTED_LANGS.iter().any(|(c, _, _)| *c == code)
 }
 
 /// Resolve the language to use for rendering. The user's saved preference
@@ -125,21 +128,18 @@ pub fn is_supported(code: &str) -> bool {
 /// `user_pref` to skip straight to header detection (e.g. for guests).
 pub fn resolve(user_pref: Option<&str>, headers: &HeaderMap) -> &'static str {
     if let Some(pref) = user_pref {
-        if let Some((code, _)) = SUPPORTED_LANGS.iter().find(|(c, _)| *c == pref) {
+        if let Some((code, _, _)) = SUPPORTED_LANGS.iter().find(|(c, _, _)| *c == pref) {
             return code;
         }
     }
     detect_from_headers(headers)
 }
 
-/// All supported languages with display labels, for settings dropdowns.
-pub fn supported_with_labels() -> &'static [(&'static str, &'static str)] {
-    &[
-        ("en", "English"),
-        ("fr", "Français"),
-        ("es", "Español"),
-        ("pl", "Polski"),
-    ]
+/// All supported languages with their native display labels, for settings dropdowns.
+pub fn supported_with_labels() -> impl Iterator<Item = (&'static str, &'static str)> {
+    SUPPORTED_LANGS
+        .iter()
+        .map(|(code, label, _)| (*code, *label))
 }
 
 /// Register the `t(key, **kwargs)` function on a minijinja environment.
@@ -165,9 +165,6 @@ fn t_function(state: &State, key: &str, kwargs: Kwargs) -> String {
                 .map(|v| (name.to_string(), v.to_string()))
         })
         .collect();
-
-    // Surface unused-kwarg errors so typos in templates are caught.
-    let _ = kwargs.assert_all_used();
 
     if pairs.is_empty() {
         return translate(&lang_owned, key, None);

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,128 @@
+//! Localization via Fluent. `.ftl` files are embedded at compile time so the
+//! single-binary deploy story is preserved.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use axum::http::HeaderMap;
+use fluent_bundle::concurrent::FluentBundle;
+use fluent_bundle::{FluentArgs, FluentResource, FluentValue};
+use minijinja::value::Kwargs;
+use minijinja::{Environment, State};
+use unic_langid::LanguageIdentifier;
+
+const SUPPORTED_LANGS: &[(&str, &str)] = &[
+    ("en", include_str!("../i18n/en/main.ftl")),
+    ("fr", include_str!("../i18n/fr/main.ftl")),
+];
+
+const DEFAULT_LANG: &str = "en";
+
+static BUNDLES: OnceLock<HashMap<&'static str, FluentBundle<FluentResource>>> = OnceLock::new();
+
+fn bundles() -> &'static HashMap<&'static str, FluentBundle<FluentResource>> {
+    BUNDLES.get_or_init(|| {
+        let mut map = HashMap::new();
+        for (code, src) in SUPPORTED_LANGS {
+            let langid: LanguageIdentifier = code
+                .parse()
+                .unwrap_or_else(|_| panic!("invalid lang code: {code}"));
+            let resource = FluentResource::try_new(src.to_string())
+                .unwrap_or_else(|_| panic!("ftl parse error in {code}"));
+            let mut bundle = FluentBundle::new_concurrent(vec![langid]);
+            // Disable Unicode directional isolates — they break rendering inside HTML.
+            bundle.set_use_isolating(false);
+            bundle
+                .add_resource(resource)
+                .unwrap_or_else(|_| panic!("ftl add resource failed for {code}"));
+            map.insert(*code, bundle);
+        }
+        map
+    })
+}
+
+/// Translate a key for the given language, with optional Fluent args.
+/// Falls back to English on missing key/locale, then to the key itself.
+pub fn translate(lang: &str, key: &str, args: Option<&FluentArgs>) -> String {
+    let bundles = bundles();
+    let bundle = bundles
+        .get(lang)
+        .or_else(|| bundles.get(DEFAULT_LANG))
+        .expect("default bundle missing");
+
+    if let Some(msg) = bundle.get_message(key) {
+        if let Some(pattern) = msg.value() {
+            let mut errors = vec![];
+            return bundle
+                .format_pattern(pattern, args, &mut errors)
+                .into_owned();
+        }
+    }
+
+    if lang != DEFAULT_LANG {
+        return translate(DEFAULT_LANG, key, args);
+    }
+    key.to_string()
+}
+
+/// Pick a supported language from an `Accept-Language` header value.
+/// Quality values are ignored; first matching primary subtag wins.
+pub fn detect_from_accept_language(header: Option<&str>) -> &'static str {
+    let Some(header) = header else {
+        return DEFAULT_LANG;
+    };
+    for entry in header.split(',') {
+        let tag = entry.split(';').next().unwrap_or("").trim();
+        let primary = tag.split('-').next().unwrap_or("").to_ascii_lowercase();
+        for (code, _) in SUPPORTED_LANGS {
+            if *code == primary {
+                return code;
+            }
+        }
+    }
+    DEFAULT_LANG
+}
+
+/// Convenience: pull `Accept-Language` from a `HeaderMap`.
+pub fn detect_from_headers(headers: &HeaderMap) -> &'static str {
+    let header = headers.get("accept-language").and_then(|v| v.to_str().ok());
+    detect_from_accept_language(header)
+}
+
+/// Register the `t(key, **kwargs)` function on a minijinja environment.
+/// Templates pull the active language from the rendering context's `lang` var.
+pub fn register(env: &mut Environment<'static>) {
+    env.add_function("t", t_function);
+}
+
+fn t_function(state: &State, key: &str, kwargs: Kwargs) -> String {
+    let lang_owned: String = state
+        .lookup("lang")
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| DEFAULT_LANG.to_string());
+
+    // Collect kwargs into FluentArgs. We hold the converted strings in a Vec
+    // so FluentArgs (which borrows) stays valid for the format_pattern call.
+    let pairs: Vec<(String, String)> = kwargs
+        .args()
+        .filter_map(|name| {
+            kwargs
+                .get::<minijinja::Value>(name)
+                .ok()
+                .map(|v| (name.to_string(), v.to_string()))
+        })
+        .collect();
+
+    // Surface unused-kwarg errors so typos in templates are caught.
+    let _ = kwargs.assert_all_used();
+
+    if pairs.is_empty() {
+        return translate(&lang_owned, key, None);
+    }
+
+    let mut args = FluentArgs::new();
+    for (k, v) in &pairs {
+        args.set(k.as_str(), FluentValue::from(v.as_str()));
+    }
+    translate(&lang_owned, key, Some(&args))
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -115,6 +115,33 @@ pub fn detect_from_headers(headers: &HeaderMap) -> &'static str {
     detect_from_accept_language(header)
 }
 
+/// Whether a given language code matches one of the bundled locales.
+pub fn is_supported(code: &str) -> bool {
+    SUPPORTED_LANGS.iter().any(|(c, _)| *c == code)
+}
+
+/// Resolve the language to use for rendering. The user's saved preference
+/// (when set and supported) wins over `Accept-Language`. Pass `None` for
+/// `user_pref` to skip straight to header detection (e.g. for guests).
+pub fn resolve(user_pref: Option<&str>, headers: &HeaderMap) -> &'static str {
+    if let Some(pref) = user_pref {
+        if let Some((code, _)) = SUPPORTED_LANGS.iter().find(|(c, _)| *c == pref) {
+            return code;
+        }
+    }
+    detect_from_headers(headers)
+}
+
+/// All supported languages with display labels, for settings dropdowns.
+pub fn supported_with_labels() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("en", "English"),
+        ("fr", "Français"),
+        ("es", "Español"),
+        ("pl", "Polski"),
+    ]
+}
+
 /// Register the `t(key, **kwargs)` function on a minijinja environment.
 /// Templates pull the active language from the rendering context's `lang` var.
 pub fn register(env: &mut Environment<'static>) {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -14,6 +14,7 @@ use unic_langid::LanguageIdentifier;
 const SUPPORTED_LANGS: &[(&str, &str)] = &[
     ("en", include_str!("../i18n/en/main.ftl")),
     ("fr", include_str!("../i18n/fr/main.ftl")),
+    ("es", include_str!("../i18n/es/main.ftl")),
 ];
 
 const DEFAULT_LANG: &str = "en";

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -68,16 +68,40 @@ pub fn translate(lang: &str, key: &str, args: Option<&FluentArgs>) -> String {
 }
 
 /// Pick a supported language from an `Accept-Language` header value.
-/// Quality values are ignored; first matching primary subtag wins.
+/// Honours quality (`q=`) weights per RFC 7231 §5.3.1: entries are
+/// sorted by descending q, ties broken by original order, and the
+/// first primary subtag we ship wins.
 pub fn detect_from_accept_language(header: Option<&str>) -> &'static str {
     let Some(header) = header else {
         return DEFAULT_LANG;
     };
-    for entry in header.split(',') {
-        let tag = entry.split(';').next().unwrap_or("").trim();
-        let primary = tag.split('-').next().unwrap_or("").to_ascii_lowercase();
+
+    let mut entries: Vec<(f32, String)> = header
+        .split(',')
+        .filter_map(|raw| {
+            let mut parts = raw.split(';');
+            let tag = parts.next()?.trim();
+            if tag.is_empty() {
+                return None;
+            }
+            let primary = tag.split('-').next()?.to_ascii_lowercase();
+            if primary.is_empty() {
+                return None;
+            }
+            let q = parts
+                .find_map(|p| p.trim().strip_prefix("q="))
+                .and_then(|v| v.parse::<f32>().ok())
+                .unwrap_or(1.0);
+            Some((q, primary))
+        })
+        .collect();
+
+    // Stable sort by q descending; preserves textual order on ties.
+    entries.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    for (_, primary) in &entries {
         for (code, _) in SUPPORTED_LANGS {
-            if *code == primary {
+            if *code == primary.as_str() {
                 return code;
             }
         }
@@ -127,4 +151,80 @@ fn t_function(state: &State, key: &str, kwargs: Kwargs) -> String {
         args.set(k.as_str(), FluentValue::from(v.as_str()));
     }
     translate(&lang_owned, key, Some(&args))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_header_falls_back_to_default() {
+        assert_eq!(detect_from_accept_language(None), "en");
+    }
+
+    #[test]
+    fn empty_header_falls_back_to_default() {
+        assert_eq!(detect_from_accept_language(Some("")), "en");
+    }
+
+    #[test]
+    fn exact_supported_tag() {
+        assert_eq!(detect_from_accept_language(Some("fr")), "fr");
+    }
+
+    #[test]
+    fn primary_subtag_extracted_from_region() {
+        assert_eq!(detect_from_accept_language(Some("en-US")), "en");
+        assert_eq!(detect_from_accept_language(Some("fr-CA")), "fr");
+    }
+
+    #[test]
+    fn first_listed_wins_when_q_unspecified() {
+        // Browsers commonly send the preferred language first without explicit q.
+        assert_eq!(
+            detect_from_accept_language(Some("fr-CA,fr;q=0.9,en;q=0.5")),
+            "fr"
+        );
+    }
+
+    #[test]
+    fn higher_q_overrides_textual_order() {
+        // The previous (broken) implementation would have picked en here.
+        assert_eq!(detect_from_accept_language(Some("en;q=0.5,fr;q=0.9")), "fr");
+    }
+
+    #[test]
+    fn unsupported_languages_skipped() {
+        assert_eq!(detect_from_accept_language(Some("de,it,fr")), "fr");
+    }
+
+    #[test]
+    fn all_unsupported_falls_back_to_default() {
+        assert_eq!(detect_from_accept_language(Some("de,it,ja")), "en");
+    }
+
+    #[test]
+    fn q_zero_is_still_considered_for_fallback() {
+        // q=0 means "do not accept", but our scan currently treats it as a
+        // weak preference. This is fine for our fallback semantics since
+        // we'd return the default anyway if nothing matched.
+        assert_eq!(detect_from_accept_language(Some("fr;q=0")), "fr");
+    }
+
+    #[test]
+    fn translate_returns_value_for_existing_key() {
+        let v = translate("fr", "confirmed-heading-booked", None);
+        assert!(!v.is_empty());
+        assert_ne!(v, "confirmed-heading-booked");
+    }
+
+    #[test]
+    fn translate_falls_back_to_english_on_missing_key_in_locale() {
+        // Polish file is seeded but if a future key is missing it should
+        // fall back to English rather than emit the raw key.
+        let en = translate("en", "confirmed-heading-booked", None);
+        let pl = translate("pl", "this-key-definitely-does-not-exist", None);
+        assert_eq!(pl, "this-key-definitely-does-not-exist"); // unknown key → key
+        assert!(!en.is_empty());
+    }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -15,6 +15,7 @@ const SUPPORTED_LANGS: &[(&str, &str)] = &[
     ("en", include_str!("../i18n/en/main.ftl")),
     ("fr", include_str!("../i18n/fr/main.ftl")),
     ("es", include_str!("../i18n/es/main.ftl")),
+    ("pl", include_str!("../i18n/pl/main.ftl")),
 ];
 
 const DEFAULT_LANG: &str = "en";

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod commands;
 mod crypto;
 mod db;
 mod email;
+mod i18n;
 mod models;
 mod rrule;
 mod utils;

--- a/src/models.rs
+++ b/src/models.rs
@@ -31,6 +31,7 @@ pub struct User {
     pub bio: Option<String>,
     pub avatar_path: Option<String>,
     pub allow_dynamic_group: bool,
+    pub language: Option<String>,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1850,6 +1850,7 @@ struct SettingsForm {
     bio: Option<String>,
     booking_email: Option<String>,
     timezone: Option<String>,
+    language: Option<String>,
     allow_dynamic_group: Option<String>,
     #[serde(default)]
     avail_schedule: String,
@@ -2098,6 +2099,12 @@ fn settings_render(
             context! { value => iana, label => label }
         })
         .collect();
+    let lang_options: Vec<minijinja::Value> = crate::i18n::supported_with_labels()
+        .iter()
+        .map(|(code, label)| {
+            context! { value => code, label => label }
+        })
+        .collect();
     Html(
         tmpl.render(context! {
             sidebar => sidebar,
@@ -2108,6 +2115,8 @@ fn settings_render(
             form_booking_email => user.booking_email.as_deref().unwrap_or(""),
             form_timezone => user.timezone,
             tz_options => tz_options,
+            form_language => user.language.as_deref().unwrap_or(""),
+            lang_options => lang_options,
             user_email => user.email,
             user_id => user.id,
             has_avatar => user.avatar_path.is_some(),
@@ -2260,16 +2269,26 @@ async fn settings_save(
         .unwrap_or("UTC")
         .to_string();
 
+    // Empty / "auto" / unsupported codes all map to NULL = follow Accept-Language.
+    let language: Option<String> = form
+        .language
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && *s != "auto")
+        .filter(|s| crate::i18n::is_supported(s))
+        .map(str::to_string);
+
     let allow_dynamic_group = form.allow_dynamic_group.as_deref() == Some("on");
 
     let result = sqlx::query(
-        "UPDATE users SET name = ?, title = ?, bio = ?, booking_email = ?, timezone = ?, allow_dynamic_group = ?, updated_at = datetime('now') WHERE id = ?",
+        "UPDATE users SET name = ?, title = ?, bio = ?, booking_email = ?, timezone = ?, language = ?, allow_dynamic_group = ?, updated_at = datetime('now') WHERE id = ?",
     )
     .bind(&name)
     .bind(&title)
     .bind(&bio)
     .bind(&booking_email)
     .bind(&timezone)
+    .bind(&language)
     .bind(allow_dynamic_group)
     .bind(&user.id)
     .execute(&state.pool)

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6656,6 +6656,7 @@ async fn team_profile_page(
 
 async fn show_group_slots(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path((team_slug, slug)): Path<(String, String)>,
     Query(query): Query<SlotsQuery>,
 ) -> impl IntoResponse {
@@ -6931,6 +6932,7 @@ async fn show_group_slots(
             invite_token => query.invite.as_deref().unwrap_or(""),
             default_calendar_view => default_calendar_view,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -7514,6 +7516,7 @@ async fn user_profile(
 
 async fn show_dynamic_group_slots(
     state: &AppState,
+    headers: &HeaderMap,
     combined_username: &str,
     slug: &str,
     query: &SlotsQuery,
@@ -7722,6 +7725,7 @@ async fn show_dynamic_group_slots(
             default_calendar_view => default_calendar_view,
             deferred_load => !is_deferred_callback,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
@@ -8182,11 +8186,12 @@ async fn handle_dynamic_group_booking(
 
 async fn show_slots_for_user(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path((username, slug)): Path<(String, String)>,
     Query(query): Query<SlotsQuery>,
 ) -> impl IntoResponse {
     if username.contains('+') {
-        return show_dynamic_group_slots(&state, &username, &slug, &query).await;
+        return show_dynamic_group_slots(&state, &headers, &username, &slug, &query).await;
     }
     let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, String, Option<String>, String, String, Option<String>, Option<String>, String, String)> = sqlx::query_as(
         "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.location_type, et.location_value, u.id, u.name, u.title, u.avatar_path, et.visibility, et.default_calendar_view
@@ -8364,6 +8369,7 @@ async fn show_slots_for_user(
             invite_guest_email => invite_guest_email.as_deref().unwrap_or(""),
             default_calendar_view => default_calendar_view,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -9967,6 +9973,7 @@ async fn get_custom_colors(pool: &SqlitePool) -> (String, String, String, String
 
 async fn show_slots(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(slug): Path<String>,
     Query(query): Query<SlotsQuery>,
 ) -> impl IntoResponse {
@@ -10109,6 +10116,7 @@ async fn show_slots(
             tz_options => tz_options,
             default_calendar_view => default_calendar_view,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -12470,6 +12478,7 @@ struct RescheduleForm {
 /// Guest reschedule: show slot picker or confirmation page
 async fn guest_reschedule_slots(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(token): Path<String>,
     Query(query): Query<RescheduleQuery>,
 ) -> impl IntoResponse {
@@ -12708,6 +12717,7 @@ async fn guest_reschedule_slots(
             },
             default_calendar_view => default_calendar_view,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -15888,6 +15898,7 @@ mod tests {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
         env.set_loader(minijinja::path_loader("templates"));
+        crate::i18n::register(&mut env);
 
         let tmpl = env
             .get_template("slots.html")
@@ -15950,6 +15961,7 @@ mod tests {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
         env.set_loader(minijinja::path_loader("templates"));
+        crate::i18n::register(&mut env);
 
         let tmpl = env
             .get_template("slots.html")

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6941,6 +6941,7 @@ async fn show_group_slots(
 
 async fn show_group_book_form(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path((team_slug, slug)): Path<(String, String)>,
     Query(query): Query<BookQuery>,
 ) -> impl IntoResponse {
@@ -7064,6 +7065,7 @@ async fn show_group_book_form(
             invite_token => query.invite.as_deref().unwrap_or(""),
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -7733,6 +7735,7 @@ async fn show_dynamic_group_slots(
 
 async fn show_dynamic_group_book_form(
     state: &AppState,
+    headers: &HeaderMap,
     combined_username: &str,
     slug: &str,
     query: &BookQuery,
@@ -7830,6 +7833,7 @@ async fn show_dynamic_group_book_form(
             invite_token => "",
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
@@ -8378,11 +8382,12 @@ async fn show_slots_for_user(
 
 async fn show_book_form_for_user(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path((username, slug)): Path<(String, String)>,
     Query(query): Query<BookQuery>,
 ) -> impl IntoResponse {
     if username.contains('+') {
-        return show_dynamic_group_book_form(&state, &username, &slug, &query).await;
+        return show_dynamic_group_book_form(&state, &headers, &username, &slug, &query).await;
     }
     let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32)> = sqlx::query_as(
         "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, et.visibility, et.max_additional_guests
@@ -8501,6 +8506,7 @@ async fn show_book_form_for_user(
             invite_token => query.invite.as_deref().unwrap_or(""),
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -10135,6 +10141,7 @@ struct BookQuery {
 
 async fn show_book_form(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(slug): Path<String>,
     Query(query): Query<BookQuery>,
 ) -> impl IntoResponse {
@@ -10208,6 +10215,7 @@ async fn show_book_form(
             form_notes => "",
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -11864,6 +11864,7 @@ struct DeclineForm {
 /// Render an error page for token-based actions (shared by approve form and handler).
 fn render_token_error(
     state: &AppState,
+    headers: &HeaderMap,
     _token: &str,
     already: Option<(String,)>,
 ) -> axum::response::Response {
@@ -11890,13 +11891,18 @@ fn render_token_error(
         Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
     };
     let rendered = tmpl
-        .render(context! { title, message })
+        .render(context! {
+            title,
+            message,
+            lang => crate::i18n::detect_from_headers(headers),
+        })
         .unwrap_or_else(|e| format!("Template error: {}", e));
     Html(rendered).into_response()
 }
 
 async fn approve_booking_form(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
     // Look up pending booking by confirm_token
@@ -11920,7 +11926,7 @@ async fn approve_booking_form(
                     .fetch_optional(&state.pool)
                     .await
                     .unwrap_or(None);
-            return render_token_error(&state, &token, already);
+            return render_token_error(&state, &headers, &token, already);
         }
     };
 
@@ -11939,6 +11945,7 @@ async fn approve_booking_form(
         end_time,
         guest_name,
         guest_email,
+        lang => crate::i18n::detect_from_headers(&headers),
     })
     .map(|r| Html(r).into_response())
     .unwrap_or_else(|e| Html(format!("Template error: {}", e)).into_response())
@@ -11946,6 +11953,7 @@ async fn approve_booking_form(
 
 async fn approve_booking_by_token(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
     // Look up booking by confirm_token
@@ -11987,7 +11995,7 @@ async fn approve_booking_by_token(
                     .fetch_optional(&state.pool)
                     .await
                     .unwrap_or(None);
-            return render_token_error(&state, &token, already);
+            return render_token_error(&state, &headers, &token, already);
         }
     };
 
@@ -12085,6 +12093,7 @@ async fn approve_booking_by_token(
             end_time,
             guest_name,
             guest_email,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -12093,6 +12102,7 @@ async fn approve_booking_by_token(
 
 async fn decline_booking_form(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
     let booking: Option<(String, String, String, String, String)> = sqlx::query_as(
@@ -12116,6 +12126,7 @@ async fn decline_booking_form(
             let rendered = tmpl.render(context! {
                 title => "Invalid link",
                 message => "This decline link is invalid, has expired, or the booking has already been processed.",
+                lang => crate::i18n::detect_from_headers(&headers),
             }).unwrap_or_else(|e| format!("Template error: {}", e));
             return Html(rendered).into_response();
         }
@@ -12139,6 +12150,7 @@ async fn decline_booking_form(
             end_time,
             guest_name,
             guest_email,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -12197,6 +12209,7 @@ async fn decline_booking_by_token(
             let rendered = tmpl.render(context! {
                     title => "Invalid link",
                     message => "This decline link is invalid, has expired, or the booking has already been processed.",
+                    lang => crate::i18n::detect_from_headers(&headers),
                 }).unwrap_or_else(|e| format!("Template error: {}", e));
             return Html(rendered).into_response();
         }
@@ -12252,6 +12265,7 @@ async fn decline_booking_by_token(
             guest_name,
             guest_email,
             reason,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -12262,6 +12276,7 @@ async fn decline_booking_by_token(
 
 async fn guest_cancel_form(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
     let booking: Option<(String, String, String, String, String, String)> = sqlx::query_as(
@@ -12308,7 +12323,11 @@ async fn guest_cancel_form(
                 Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
             };
             let rendered = tmpl
-                .render(context! { title, message })
+                .render(context! {
+                    title,
+                    message,
+                    lang => crate::i18n::detect_from_headers(&headers),
+                })
                 .unwrap_or_else(|e| format!("Template error: {}", e));
             return Html(rendered).into_response();
         }
@@ -12332,6 +12351,7 @@ async fn guest_cancel_form(
             end_time,
             guest_name,
             host_name,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -12383,6 +12403,7 @@ async fn guest_cancel_booking(
                     .render(context! {
                         title => "Invalid link",
                         message => "This cancellation link is invalid, has expired, or the booking has already been cancelled.",
+                        lang => crate::i18n::detect_from_headers(&headers),
                     })
                     .unwrap_or_else(|e| format!("Template error: {}", e));
             return Html(rendered).into_response();
@@ -12454,6 +12475,7 @@ async fn guest_cancel_booking(
             end_time,
             host_name,
             reason,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -12511,6 +12533,7 @@ async fn guest_reschedule_slots(
             let rendered = tmpl.render(context! {
                 title => "Invalid link",
                 message => "This reschedule link is invalid, has expired, or the booking has already been processed.",
+                lang => crate::i18n::detect_from_headers(&headers),
             }).unwrap_or_else(|e| format!("Template error: {}", e));
             return Html(rendered).into_response();
         }
@@ -12615,6 +12638,7 @@ async fn guest_reschedule_slots(
                 tz => guest_tz.name(),
                 back_url => back_url,
                 company_link => state.company_link.read().await.clone(),
+                lang => crate::i18n::detect_from_headers(&headers),
             })
             .unwrap_or_else(|e| format!("Template error: {}", e));
         return Html(rendered).into_response();
@@ -12814,6 +12838,7 @@ async fn guest_reschedule_booking(
             let rendered = tmpl.render(context! {
                 title => "Invalid link",
                 message => "This reschedule link is invalid, has expired, or the booking has already been processed.",
+                lang => crate::i18n::detect_from_headers(&headers),
             }).unwrap_or_else(|e| format!("Template error: {}", e));
             return Html(rendered).into_response();
         }
@@ -13545,13 +13570,19 @@ async fn notify_watchers(
 
 async fn claim_booking_form(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(booking_id): Path<String>,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
     let token = match params.get("token") {
         Some(t) => t,
         None => {
-            return render_claim_error(&state, "Invalid link", "No claim token provided.");
+            return render_claim_error(
+                &state,
+                &headers,
+                "Invalid link",
+                "No claim token provided.",
+            );
         }
     };
 
@@ -13585,14 +13616,18 @@ async fn claim_booking_form(
                 Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
             };
             return Html(
-                tmpl.render(context! { claimed_by_name => claimed_by_name })
-                    .unwrap_or_else(|e| format!("Template error: {}", e)),
+                tmpl.render(context! {
+                    claimed_by_name => claimed_by_name,
+                    lang => crate::i18n::detect_from_headers(&headers),
+                })
+                .unwrap_or_else(|e| format!("Template error: {}", e)),
             )
             .into_response();
         }
 
         return render_claim_error(
             &state,
+            &headers,
             "Invalid or expired link",
             "This claim link is no longer valid.",
         );
@@ -13616,6 +13651,7 @@ async fn claim_booking_form(
         None => {
             return render_claim_error(
                 &state,
+                &headers,
                 "Booking not found",
                 "This booking no longer exists.",
             )
@@ -13641,6 +13677,7 @@ async fn claim_booking_form(
             guest_email => guest_email,
             assigned_to => assigned_to.unwrap_or_default(),
             token => token,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
@@ -13695,14 +13732,18 @@ async fn claim_booking(
                     Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
                 };
                 return Html(
-                    tmpl.render(context! { claimed_by_name => claimed_by_name })
-                        .unwrap_or_else(|e| format!("Template error: {}", e)),
+                    tmpl.render(context! {
+                        claimed_by_name => claimed_by_name,
+                        lang => crate::i18n::detect_from_headers(&headers),
+                    })
+                    .unwrap_or_else(|e| format!("Template error: {}", e)),
                 )
                 .into_response();
             }
 
             return render_claim_error(
                 &state,
+                &headers,
                 "Invalid or expired link",
                 "This claim link is no longer valid.",
             )
@@ -13740,9 +13781,10 @@ async fn claim_booking(
             Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
         };
         return Html(
-            tmpl.render(
-                context! { claimed_by_name => claimed_name.map(|(n,)| n).unwrap_or_default() },
-            )
+            tmpl.render(context! {
+                claimed_by_name => claimed_name.map(|(n,)| n).unwrap_or_default(),
+                lang => crate::i18n::detect_from_headers(&headers),
+            })
             .unwrap_or_else(|e| format!("Template error: {}", e)),
         )
         .into_response();
@@ -13811,6 +13853,7 @@ async fn claim_booking(
         None => {
             return render_claim_error(
                 &state,
+                &headers,
                 "Booking not found",
                 "This booking no longer exists.",
             )
@@ -13927,20 +13970,30 @@ async fn claim_booking(
             end_time => end_time,
             guest_name => guest_name,
             guest_email => guest_email,
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
     .into_response()
 }
 
-fn render_claim_error(state: &AppState, title: &str, message: &str) -> axum::response::Response {
+fn render_claim_error(
+    state: &AppState,
+    headers: &HeaderMap,
+    title: &str,
+    message: &str,
+) -> axum::response::Response {
     let tmpl = match state.templates.get_template("booking_action_error.html") {
         Ok(t) => t,
         Err(e) => return Html(format!("Internal error: {}", e)).into_response(),
     };
     Html(
-        tmpl.render(context! { title => title, message => message })
-            .unwrap_or_else(|e| format!("Template error: {}", e)),
+        tmpl.render(context! {
+            title => title,
+            message => message,
+            lang => crate::i18n::detect_from_headers(headers),
+        })
+        .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
     .into_response()
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -504,6 +504,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
     let mut env = Environment::new();
     env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
     env.set_loader(minijinja::path_loader("templates"));
+    crate::i18n::register(&mut env);
 
     let initial_theme_css = build_theme_css(&pool).await;
     let initial_company_link = get_company_link(&pool).await;
@@ -7415,6 +7416,7 @@ async fn handle_group_booking(
             location_value => loc_value,
             additional_attendees => additional_attendees,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -8150,6 +8152,7 @@ async fn handle_dynamic_group_booking(
             location_value => loc_value,
             additional_attendees => all_additional,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e)),
     )
@@ -8846,6 +8849,7 @@ async fn handle_booking_for_user(
             location_value => loc_value,
             additional_attendees => additional_attendees,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -10605,6 +10609,7 @@ async fn handle_booking(
             pending => needs_approval,
             additional_attendees => additional_attendees,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 
@@ -13064,6 +13069,7 @@ async fn guest_reschedule_booking(
             pending => needs_approval,
             rescheduled => true,
             company_link => state.company_link.read().await.clone(),
+            lang => crate::i18n::detect_from_headers(&headers),
         })
         .unwrap_or_else(|e| format!("Template error: {}", e));
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -2100,10 +2100,7 @@ fn settings_render(
         })
         .collect();
     let lang_options: Vec<minijinja::Value> = crate::i18n::supported_with_labels()
-        .iter()
-        .map(|(code, label)| {
-            context! { value => code, label => label }
-        })
+        .map(|(code, label)| context! { value => code, label => label })
         .collect();
     Html(
         tmpl.render(context! {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -19422,6 +19422,7 @@ mod tests {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
         env.set_loader(minijinja::path_loader("templates"));
+        crate::i18n::register(&mut env);
         let tmpl = env
             .get_template("dashboard_event_types.html")
             .expect("template loads");
@@ -19471,6 +19472,7 @@ mod tests {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
         env.set_loader(minijinja::path_loader("templates"));
+        crate::i18n::register(&mut env);
         let tmpl = env
             .get_template("dashboard_sources.html")
             .expect("template loads");
@@ -19513,6 +19515,7 @@ mod tests {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
         env.set_loader(minijinja::path_loader("templates"));
+        crate::i18n::register(&mut env);
         let tmpl = env
             .get_template("team_settings.html")
             .expect("template loads");

--- a/templates/base.html
+++ b/templates/base.html
@@ -424,8 +424,8 @@
   <!-- Global sync loader overlay -->
   <div id="calrs-sync-loader" style="display:none; position:fixed; inset:0; z-index:10000; background:var(--bg); align-items:center; justify-content:center; flex-direction:column; gap:1.25rem;">
     <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="animation: calrs-spin 1s linear infinite;"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-    <div style="font-size:1.125rem; font-weight:600; color:var(--text); text-align:center;">Checking availability</div>
-    <div style="font-size:0.875rem; color:var(--text-muted); text-align:center;">Please wait, loading the latest calendar data...</div>
+    <div style="font-size:1.125rem; font-weight:600; color:var(--text); text-align:center;">{{ t("base-loader-checking") }}</div>
+    <div style="font-size:0.875rem; color:var(--text-muted); text-align:center;">{{ t("base-loader-please-wait") }}</div>
   </div>
   <style>
     @keyframes calrs-spin { to { transform: rotate(360deg); } }
@@ -446,7 +446,7 @@
   <div style="position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: #f59e0b; color: #000; text-align: center; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 0.75rem;">
     <span>You are impersonating <strong>{{ impersonating_name }}</strong></span>
     <form method="post" action="/dashboard/admin/stop-impersonate" style="margin: 0; display: inline;">
-      <button type="submit" style="background: #000; color: #fff; border: none; padding: 0.25rem 0.75rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; cursor: pointer;">Stop impersonating</button>
+      <button type="submit" style="background: #000; color: #fff; border: none; padding: 0.25rem 0.75rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; cursor: pointer;">{{ t("base-stop-impersonating") }}</button>
     </form>
   </div>
   <div style="height: 2.5rem;"></div>
@@ -455,7 +455,7 @@
     {% block content %}{% endblock %}
     {% block footer %}<div class="powered"><span>Powered by <a href="https://cal.rs">calrs</a> 🦀</span></div>{% endblock %}
     {% block theme_toggle %}
-    <button id="theme-toggle" type="button" title="Toggle theme" aria-label="Toggle theme" class="theme-pill">
+    <button id="theme-toggle" type="button" title="{{ t('base-theme-toggle') }}" aria-label="{{ t('base-theme-toggle') }}" class="theme-pill">
       <span class="theme-pill-track">
         <svg class="theme-pill-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
         <svg class="theme-pill-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/templates/book.html
+++ b/templates/book.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Book {{ event_type.title }}{% endblock %}
+{% block title %}{{ t("book-page-title", title=event_type.title) }}{% endblock %}
 
 {% block content %}
 {# Compute base path: /t/token, /team/team_slug/slug, /u/username/slug, or /slug #}
@@ -16,7 +16,7 @@
 
 <div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
-<a href="{{ base }}" class="back-link">&larr; Back to times</a>
+<a href="{{ base }}" class="back-link">&larr; {{ t("book-back-to-times") }}</a>
 
 <div class="card">
   <h1>{{ event_type.title }}</h1>
@@ -27,7 +27,7 @@
       {% if event_type.location_type is defined and event_type.location_type == "in_person" %}
         <span>{{ event_type.location_value }}</span>
       {% else %}
-        <span>{% if event_type.location_type == "link" %}Video call{% elif event_type.location_type == "phone" %}Phone call{% else %}{{ event_type.location_type }}{% endif %}</span>
+        <span>{% if event_type.location_type == "link" %}{{ t("slots-location-video") }}{% elif event_type.location_type == "phone" %}{{ t("slots-location-phone") }}{% else %}{{ event_type.location_type }}{% endif %}</span>
       {% endif %}
     {% endif %}
   </div>
@@ -47,30 +47,31 @@
     {% if invite_token is defined and invite_token %}<input type="hidden" name="invite_token" value="{{ invite_token }}">{% endif %}
 
     <div class="form-group">
-      <label for="name">Your name</label>
-      <input type="text" id="name" name="name" required maxlength="255" value="{{ form_name }}" placeholder="Jane Doe">
+      <label for="name">{{ t("book-name-label") }}</label>
+      <input type="text" id="name" name="name" required maxlength="255" value="{{ form_name }}" placeholder="{{ t('book-name-placeholder') }}">
     </div>
 
     <div class="form-group">
-      <label for="email">Email</label>
-      <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="jane@example.com">
+      <label for="email">{{ t("book-email-label") }}</label>
+      <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="{{ t('book-email-placeholder') }}">
     </div>
 
     <div class="form-group">
-      <label for="notes">Notes <span class="hint">(optional)</span></label>
-      <textarea id="notes" name="notes" maxlength="5000" placeholder="Anything you'd like to discuss?">{{ form_notes }}</textarea>
+      <label for="notes">{{ t("book-notes-label") }} <span class="hint">{{ t("book-notes-optional") }}</span></label>
+      <textarea id="notes" name="notes" maxlength="5000" placeholder="{{ t('book-notes-placeholder') }}">{{ form_notes }}</textarea>
     </div>
 
     {% if max_additional_guests is defined and max_additional_guests > 0 %}
     <div class="form-group">
-      <label>Additional guests <span class="hint">(optional, up to {{ max_additional_guests }})</span></label>
+      <label>{{ t("book-additional-guests-label") }} <span class="hint">{{ t("book-additional-guests-hint", max=max_additional_guests) }}</span></label>
       <div id="guest-list" style="display: flex; flex-direction: column; gap: 0.375rem;"></div>
       <input type="hidden" name="additional_guests" id="additional-guests-hidden" value="">
-      <button type="button" id="add-guest-btn" style="margin-top: 0.375rem; background: none; border: 1px dashed var(--border); border-radius: var(--radius); padding: 0.5rem; cursor: pointer; color: var(--text-muted); font-size: 0.85rem; font-family: inherit; width: 100%; transition: all 0.15s ease;">+ Add guest email</button>
+      <button type="button" id="add-guest-btn" style="margin-top: 0.375rem; background: none; border: 1px dashed var(--border); border-radius: var(--radius); padding: 0.5rem; cursor: pointer; color: var(--text-muted); font-size: 0.85rem; font-family: inherit; width: 100%; transition: all 0.15s ease;">{{ t("book-add-guest-btn") }}</button>
     </div>
     <script>
     (function() {
       var max = {{ max_additional_guests }};
+      var guestEmailPlaceholder = {{ t("book-guest-email-placeholder") | tojson }};
       var list = document.getElementById('guest-list');
       var hidden = document.getElementById('additional-guests-hidden');
       var addBtn = document.getElementById('add-guest-btn');
@@ -92,7 +93,7 @@
         row.style.cssText = 'display: flex; gap: 0.375rem; align-items: center;';
         var inp = document.createElement('input');
         inp.type = 'email';
-        inp.placeholder = 'colleague@example.com';
+        inp.placeholder = guestEmailPlaceholder;
         inp.maxLength = 255;
         inp.style.cssText = 'flex: 1; padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.9rem; font-family: inherit; background: var(--surface); color: var(--text);';
         inp.addEventListener('input', syncHidden);
@@ -118,7 +119,7 @@
     </script>
     {% endif %}
 
-    <button type="submit" class="btn">Confirm booking</button>
+    <button type="submit" class="btn">{{ t("book-confirm-button") }}</button>
   </form>
 </div>
 <script>

--- a/templates/booking_action_error.html
+++ b/templates/booking_action_error.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Booking action error{% endblock %}
+{% block title %}{{ t("action-error-page-title") }}{% endblock %}
 
 {% block content %}
 <div class="card" style="text-align: center;">

--- a/templates/booking_already_claimed.html
+++ b/templates/booking_already_claimed.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Already claimed{% endblock %}
+{% block title %}{{ t("already-claimed-page-title") }}{% endblock %}
 {% block content %}
 <div class="card" style="text-align: center;">
   <div class="check" style="background: var(--text-muted);">!</div>
-  <h1>Already claimed</h1>
-  <p class="subtitle">This booking has already been claimed by {{ claimed_by_name }}.</p>
+  <h1>{{ t("already-claimed-heading") }}</h1>
+  <p class="subtitle">{{ t("already-claimed-subtitle", name=claimed_by_name) }}</p>
 </div>
 {% endblock %}

--- a/templates/booking_approve_form.html
+++ b/templates/booking_approve_form.html
@@ -1,21 +1,21 @@
 {% extends "base.html" %}
 
-{% block title %}Approve booking{% endblock %}
+{% block title %}{{ t("approve-page-title") }}{% endblock %}
 
 {% block content %}
 <div class="card">
-  <h1>Approve booking</h1>
-  <p class="subtitle">You are about to approve this booking request.</p>
+  <h1>{{ t("approve-heading") }}</h1>
+  <p class="subtitle">{{ t("approve-subtitle") }}</p>
 
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("common-detail-guest") }}</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
 </div>
 
 <div class="card">
   <form method="post">
-    <button type="submit" class="btn">Approve booking</button>
+    <button type="submit" class="btn">{{ t("approve-button") }}</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/booking_approved.html
+++ b/templates/booking_approved.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
 
-{% block title %}Booking approved{% endblock %}
+{% block title %}{{ t("approved-heading") }}{% endblock %}
 
 {% block content %}
 <div class="card" style="text-align: center;">
   <div class="check">&#10003;</div>
-  <h1>Booking approved</h1>
-  <p class="subtitle">The booking has been confirmed and a confirmation email has been sent to {{ guest_email }}.</p>
+  <h1>{{ t("approved-heading") }}</h1>
+  <p class="subtitle">{{ t("approved-subtitle", email=guest_email) }}</p>
 </div>
 
 <div class="card">
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("common-detail-guest") }}</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
 </div>
-<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">You can close this page.</p>
+<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">{{ t("common-close-page") }}</p>
 {% endblock %}

--- a/templates/booking_cancel_form.html
+++ b/templates/booking_cancel_form.html
@@ -1,25 +1,25 @@
 {% extends "base.html" %}
 
-{% block title %}Cancel booking{% endblock %}
+{% block title %}{{ t("cancel-page-title") }}{% endblock %}
 
 {% block content %}
 <div class="card">
-  <h1>Cancel booking</h1>
-  <p class="subtitle">You are about to cancel your booking.</p>
+  <h1>{{ t("cancel-heading") }}</h1>
+  <p class="subtitle">{{ t("cancel-subtitle") }}</p>
 
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>With:</strong> {{ host_name }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-with") }}</strong> {{ host_name }}</div>
 </div>
 
 <div class="card">
   <form method="post">
     <div class="form-group">
-      <label for="reason">Reason <span class="hint">(optional)</span></label>
-      <textarea id="reason" name="reason" placeholder="Let the host know why..."></textarea>
+      <label for="reason">{{ t("cancel-reason-label") }} <span class="hint">{{ t("common-reason-optional") }}</span></label>
+      <textarea id="reason" name="reason" placeholder="{{ t('cancel-reason-placeholder-host') }}"></textarea>
     </div>
-    <button type="submit" class="btn" style="background: var(--error-text);">Cancel booking</button>
+    <button type="submit" class="btn" style="background: var(--error-text);">{{ t("cancel-button") }}</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/booking_cancelled_guest.html
+++ b/templates/booking_cancelled_guest.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
 
-{% block title %}Booking cancelled{% endblock %}
+{% block title %}{{ t("cancelled-heading") }}{% endblock %}
 
 {% block content %}
 <div class="card" style="text-align: center;">
   <div class="check" style="background: var(--error-text);">&#10007;</div>
-  <h1>Booking cancelled</h1>
-  <p class="subtitle">Your booking has been cancelled and the host has been notified.</p>
+  <h1>{{ t("cancelled-heading") }}</h1>
+  <p class="subtitle">{{ t("cancelled-subtitle") }}</p>
 </div>
 
 <div class="card">
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>With:</strong> {{ host_name }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-with") }}</strong> {{ host_name }}</div>
   {% if reason %}
-    <div class="detail"><strong>Reason:</strong> {{ reason }}</div>
+    <div class="detail"><strong>{{ t("common-detail-reason") }}</strong> {{ reason }}</div>
   {% endif %}
 </div>
-<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">You can close this page.</p>
+<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">{{ t("common-close-page") }}</p>
 {% endblock %}

--- a/templates/booking_claim_form.html
+++ b/templates/booking_claim_form.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
-{% block title %}Claim booking{% endblock %}
+{% block title %}{{ t("claim-page-title") }}{% endblock %}
 {% block content %}
 <div class="card">
-  <h1>Claim booking</h1>
-  <p class="subtitle">You are about to claim this booking. You will be added as an attendee.</p>
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
-  <div class="detail"><strong>Assigned to:</strong> {{ assigned_to }}</div>
+  <h1>{{ t("claim-heading") }}</h1>
+  <p class="subtitle">{{ t("claim-subtitle") }}</p>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("common-detail-guest") }}</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+  <div class="detail"><strong>{{ t("claim-assigned-to") }}</strong> {{ assigned_to }}</div>
 </div>
 <div class="card">
   <form method="post">
     <input type="hidden" name="token" value="{{ token }}">
-    <button type="submit" class="btn">Claim this booking</button>
+    <button type="submit" class="btn">{{ t("claim-button") }}</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/booking_claimed.html
+++ b/templates/booking_claimed.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
-{% block title %}Booking claimed{% endblock %}
+{% block title %}{{ t("claimed-page-title") }}{% endblock %}
 {% block content %}
 <div class="card" style="text-align: center;">
   <div class="check">&#10003;</div>
-  <h1>Booking claimed</h1>
-  <p class="subtitle">You have claimed this booking. A calendar invite has been sent to your email.</p>
+  <h1>{{ t("claimed-heading") }}</h1>
+  <p class="subtitle">{{ t("claimed-subtitle") }}</p>
 </div>
 <div class="card">
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("common-detail-guest") }}</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
 </div>
-<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">You can close this page.</p>
+<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">{{ t("common-close-page") }}</p>
 {% endblock %}

--- a/templates/booking_decline_form.html
+++ b/templates/booking_decline_form.html
@@ -1,25 +1,25 @@
 {% extends "base.html" %}
 
-{% block title %}Decline booking{% endblock %}
+{% block title %}{{ t("decline-page-title") }}{% endblock %}
 
 {% block content %}
 <div class="card">
-  <h1>Decline booking</h1>
-  <p class="subtitle">You are about to decline this booking request.</p>
+  <h1>{{ t("decline-heading") }}</h1>
+  <p class="subtitle">{{ t("decline-subtitle") }}</p>
 
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("common-detail-guest") }}</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
 </div>
 
 <div class="card">
   <form method="post">
     <div class="form-group">
-      <label for="reason">Reason <span class="hint">(optional)</span></label>
-      <textarea id="reason" name="reason" placeholder="Let the guest know why..."></textarea>
+      <label for="reason">{{ t("cancel-reason-label") }} <span class="hint">{{ t("common-reason-optional") }}</span></label>
+      <textarea id="reason" name="reason" placeholder="{{ t('decline-reason-placeholder-guest') }}"></textarea>
     </div>
-    <button type="submit" class="btn" style="background: var(--error-text);">Decline booking</button>
+    <button type="submit" class="btn" style="background: var(--error-text);">{{ t("decline-button") }}</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/booking_declined.html
+++ b/templates/booking_declined.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
 
-{% block title %}Booking declined{% endblock %}
+{% block title %}{{ t("declined-heading") }}{% endblock %}
 
 {% block content %}
 <div class="card" style="text-align: center;">
   <div class="check" style="background: var(--error-text);">&#10007;</div>
-  <h1>Booking declined</h1>
-  <p class="subtitle">The booking has been declined and the guest has been notified.</p>
+  <h1>{{ t("declined-heading") }}</h1>
+  <p class="subtitle">{{ t("declined-subtitle") }}</p>
 </div>
 
 <div class="card">
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> {{ start_time }} – {{ end_time }}</div>
-  <div class="detail"><strong>Guest:</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> {{ start_time }} – {{ end_time }}</div>
+  <div class="detail"><strong>{{ t("common-detail-guest") }}</strong> {{ guest_name }} &lt;{{ guest_email }}&gt;</div>
   {% if reason %}
-    <div class="detail"><strong>Reason:</strong> {{ reason }}</div>
+    <div class="detail"><strong>{{ t("common-detail-reason") }}</strong> {{ reason }}</div>
   {% endif %}
 </div>
-<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">You can close this page.</p>
+<p style="text-align: center; margin-top: 1.5rem; color: var(--text-muted); font-size: 0.9rem;">{{ t("common-close-page") }}</p>
 {% endblock %}

--- a/templates/booking_reschedule_confirm.html
+++ b/templates/booking_reschedule_confirm.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Confirm reschedule{% endblock %}
+{% block title %}{{ t("resched-confirm-page-title") }}{% endblock %}
 
 {% block content %}
 <div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
@@ -9,16 +9,16 @@
   <div style="display: flex; align-items: center; gap: 0.625rem; margin-bottom: 0.75rem;">
     <div style="width: 36px; height: 36px; border-radius: 50%; background: #d97706; color: #fff; display: flex; align-items: center; justify-content: center; font-size: 1.1rem; flex-shrink: 0;">&#128260;</div>
     <div>
-      <h1 style="margin: 0; font-size: 1.2rem;">Confirm reschedule</h1>
-      <p class="subtitle" style="margin: 0.125rem 0 0; font-size: 0.85rem;">You are about to move your booking to a new time.</p>
+      <h1 style="margin: 0; font-size: 1.2rem;">{{ t("resched-confirm-heading") }}</h1>
+      <p class="subtitle" style="margin: 0.125rem 0 0; font-size: 0.85rem;">{{ t("resched-confirm-subtitle") }}</p>
     </div>
   </div>
 
   <div style="margin-top: 1rem; display: flex; flex-direction: column; gap: 0.75rem;">
-    <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-    <div class="detail" style="color: var(--text-muted); text-decoration: line-through;"><strong style="text-decoration: none; color: var(--text);">Was:</strong> {{ old_date_label }} at <span class="resched-time" data-time="{{ old_start_time }}">{{ old_start_time }}</span> &ndash; <span class="resched-time" data-time="{{ old_end_time }}">{{ old_end_time }}</span></div>
-    <div class="detail" style="color: var(--success, #16a34a); font-weight: 500;"><strong style="color: var(--text); font-weight: 700;">New:</strong> {{ new_date_label }} at <span class="resched-time" data-time="{{ new_start_time }}">{{ new_start_time }}</span> &ndash; <span class="resched-time" data-time="{{ new_end_time }}">{{ new_end_time }}</span></div>
-    <div class="detail"><strong>With:</strong> {{ host_name }}</div>
+    <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+    <div class="detail" style="color: var(--text-muted); text-decoration: line-through;"><strong style="text-decoration: none; color: var(--text);">{{ t("resched-was") }}</strong> {{ old_date_label }} at <span class="resched-time" data-time="{{ old_start_time }}">{{ old_start_time }}</span> &ndash; <span class="resched-time" data-time="{{ old_end_time }}">{{ old_end_time }}</span></div>
+    <div class="detail" style="color: var(--success, #16a34a); font-weight: 500;"><strong style="color: var(--text); font-weight: 700;">{{ t("resched-new") }}</strong> {{ new_date_label }} at <span class="resched-time" data-time="{{ new_start_time }}">{{ new_start_time }}</span> &ndash; <span class="resched-time" data-time="{{ new_end_time }}">{{ new_end_time }}</span></div>
+    <div class="detail"><strong>{{ t("confirmed-detail-with") }}</strong> {{ host_name }}</div>
   </div>
 </div>
 
@@ -27,9 +27,9 @@
     <input type="hidden" name="date" value="{{ date }}">
     <input type="hidden" name="time" value="{{ time }}">
     <input type="hidden" name="tz" value="{{ tz }}">
-    <button type="submit" class="btn" style="background: var(--accent);">Confirm reschedule</button>
+    <button type="submit" class="btn" style="background: var(--accent);">{{ t("resched-button") }}</button>
   </form>
-  <a href="{{ back_url }}" style="display: inline-block; margin-top: 0.75rem; color: var(--text-muted); text-decoration: none; font-size: 0.9rem;">&larr; Back to time picker</a>
+  <a href="{{ back_url }}" style="display: inline-block; margin-top: 0.75rem; color: var(--text-muted); text-decoration: none; font-size: 0.9rem;">&larr; {{ t("resched-back-to-picker") }}</a>
 </div>
 <script>
 (function() {

--- a/templates/confirmed.html
+++ b/templates/confirmed.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{% if pending %}Booking pending{% else %}Booking confirmed{% endif %}{% endblock %}
+{% block title %}{% if pending %}{{ t("confirmed-page-title-pending") }}{% else %}{{ t("confirmed-page-title-booked") }}{% endif %}{% endblock %}
 
 {% block content %}
 <div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
@@ -8,41 +8,41 @@
 <div class="card" style="text-align: center;">
   {% if rescheduled is defined and rescheduled and pending %}
     <div class="check" style="background: #d97706;">&#128260;</div>
-    <h1>Reschedule requested</h1>
-    <p class="subtitle">Your reschedule request has been sent to {{ host_name }}. You'll receive an email at {{ guest_email }} once it's approved.</p>
+    <h1>{{ t("confirmed-heading-reschedule-requested") }}</h1>
+    <p class="subtitle">{{ t("confirmed-subtitle-reschedule-requested", host=host_name, email=guest_email) }}</p>
   {% elif rescheduled is defined and rescheduled %}
     <div class="check">&#128260;</div>
-    <h1>Rescheduled!</h1>
-    <p class="subtitle">Your booking has been rescheduled. A confirmation email has been sent to {{ guest_email }}.</p>
+    <h1>{{ t("confirmed-heading-rescheduled") }}</h1>
+    <p class="subtitle">{{ t("confirmed-subtitle-rescheduled", email=guest_email) }}</p>
   {% elif pending %}
     <div class="check" style="background: #d97706;">&#8987;</div>
-    <h1>Pending confirmation</h1>
-    <p class="subtitle">Your booking request has been sent to {{ host_name }}. You'll receive an email at {{ guest_email }} once it's confirmed.</p>
+    <h1>{{ t("confirmed-heading-pending") }}</h1>
+    <p class="subtitle">{{ t("confirmed-subtitle-pending", host=host_name, email=guest_email) }}</p>
   {% else %}
     <div class="check">&#10003;</div>
-    <h1>You're booked!</h1>
-    <p class="subtitle">A confirmation email has been sent to {{ guest_email }}.</p>
+    <h1>{{ t("confirmed-heading-booked") }}</h1>
+    <p class="subtitle">{{ t("confirmed-subtitle-booked", email=guest_email) }}</p>
   {% endif %}
 </div>
 
 <div class="card">
-  <div class="detail"><strong>Event:</strong> {{ event_title }}</div>
-  <div class="detail"><strong>Date:</strong> {{ date_label }}</div>
-  <div class="detail"><strong>Time:</strong> <span class="book-time" data-time="{{ time_start }}">{{ time_start }}</span> – <span class="book-time" data-time="{{ time_end }}">{{ time_end }}</span></div>
-  <div class="detail"><strong>With:</strong> {{ host_name }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-event") }}</strong> {{ event_title }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-date") }}</strong> {{ date_label }}</div>
+  <div class="detail"><strong>{{ t("confirmed-detail-time") }}</strong> <span class="book-time" data-time="{{ time_start }}">{{ time_start }}</span> – <span class="book-time" data-time="{{ time_end }}">{{ time_end }}</span></div>
+  <div class="detail"><strong>{{ t("confirmed-detail-with") }}</strong> {{ host_name }}</div>
   {% if location_value and not pending %}
-    <div class="detail"><strong>Location:</strong> {% if location_type == "link" %}<a href="{{ location_value }}" target="_blank" style="color: var(--accent); text-decoration: none;">{{ location_value }}</a>{% else %}{{ location_value }}{% endif %}</div>
+    <div class="detail"><strong>{{ t("confirmed-detail-location") }}</strong> {% if location_type == "link" %}<a href="{{ location_value }}" target="_blank" style="color: var(--accent); text-decoration: none;">{{ location_value }}</a>{% else %}{{ location_value }}{% endif %}</div>
   {% endif %}
   {% if notes %}
-    <div class="detail"><strong>Notes:</strong> {{ notes }}</div>
+    <div class="detail"><strong>{{ t("confirmed-detail-notes") }}</strong> {{ notes }}</div>
   {% endif %}
   {% if additional_attendees is defined and additional_attendees %}
-    <div class="detail"><strong>Additional guests:</strong> {{ additional_attendees | join(", ") }}</div>
+    <div class="detail"><strong>{{ t("confirmed-detail-additional-guests") }}</strong> {{ additional_attendees | join(", ") }}</div>
   {% endif %}
 </div>
 <div style="text-align: center; margin-top: 1.5rem;">
-  {% if team_slug %}<a href="/team/{{ team_slug }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; Book another time</a>
-  {% elif username %}<a href="/u/{{ username }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; Book another time</a>{% endif %}
+  {% if team_slug %}<a href="/team/{{ team_slug }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>
+  {% elif username %}<a href="/u/{{ username }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>{% endif %}
 </div>
 <script>
 (function() {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -118,6 +118,17 @@
       <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">Your availability rules and booking times are computed in this timezone.</span>
     </div>
 
+    <div class="form-group">
+      <label for="language">Language</label>
+      <select id="language" name="language" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); font-size: 0.9rem;">
+        <option value="auto" {% if not form_language %}selected{% endif %}>Auto (browser default)</option>
+        {% for lang in lang_options %}
+          <option value="{{ lang.value }}" {% if lang.value == form_language %}selected{% endif %}>{{ lang.label }}</option>
+        {% endfor %}
+      </select>
+      <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">Pick a UI language, or leave on Auto to follow your browser's setting.</span>
+    </div>
+
     <div class="form-group" style="margin-top: 1rem;">
       <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
         <input type="checkbox" name="allow_dynamic_group" {% if allow_dynamic_group %}checked{% endif %} style="width: auto;">

--- a/templates/slots.html
+++ b/templates/slots.html
@@ -761,7 +761,7 @@
         {% if event_type.location_type is defined and event_type.location_type == "in_person" %}
           <span>{{ event_type.location_value }}</span>
         {% else %}
-          <span>{% if event_type.location_type == "link" %}Video call{% elif event_type.location_type == "phone" %}Phone call{% else %}{{ event_type.location_type }}{% endif %}</span>
+          <span>{% if event_type.location_type == "link" %}{{ t("slots-location-video") }}{% elif event_type.location_type == "phone" %}{{ t("slots-location-phone") }}{% else %}{{ event_type.location_type }}{% endif %}</span>
         {% endif %}
       </div>
       {% endif %}
@@ -770,7 +770,7 @@
     {% if tz_options is defined and tz_options %}
     <div class="slots-info-settings">
       <div class="slots-info-setting">
-        <label for="tz-select" class="slots-info-setting-label">&#127760; Your timezone</label>
+        <label for="tz-select" class="slots-info-setting-label">&#127760; {{ t("slots-tz-label") }}</label>
         <select id="tz-select">
           {% for tz in tz_options %}
             <option value="{{ tz.value }}" {% if tz.selected %}selected{% endif %}>{{ tz.label }}</option>
@@ -778,7 +778,7 @@
         </select>
       </div>
       <div class="slots-info-setting">
-        <label class="slots-info-setting-label">&#128336; Time format</label>
+        <label class="slots-info-setting-label">&#128336; {{ t("slots-time-format-label") }}</label>
         <div id="time-format-toggle" class="time-format-toggle">
           <button type="button" data-format="24">24h</button>
           <button type="button" data-format="12">12h</button>
@@ -804,7 +804,24 @@
     "prevMonth": "{{ prev_month | default(value='') }}",
     "nextMonth": "{{ next_month }}",
     "defaultCalendarView": "{{ default_calendar_view | default(value='month') }}",
-    "deferredLoad": {% if deferred_load is defined and deferred_load %}true{% else %}false{% endif %}
+    "deferredLoad": {% if deferred_load is defined and deferred_load %}true{% else %}false{% endif %},
+    "i18n": {
+      "selectDate": {{ t("slots-select-date") | tojson }},
+      "noTimesMonth": {{ t("slots-no-times-month") | tojson }},
+      "noTimesDay": {{ t("slots-no-times-day") | tojson }},
+      "clickHighlighted": {{ t("slots-click-highlighted") | tojson }},
+      "noAvailabilityParticipants": {{ t("slots-no-availability-participants") | tojson }},
+      "weekMore": {{ t("slots-week-more") | tojson }},
+      "weekdays": [
+        {{ t("slots-weekday-sun") | tojson }},
+        {{ t("slots-weekday-mon") | tojson }},
+        {{ t("slots-weekday-tue") | tojson }},
+        {{ t("slots-weekday-wed") | tojson }},
+        {{ t("slots-weekday-thu") | tojson }},
+        {{ t("slots-weekday-fri") | tojson }},
+        {{ t("slots-weekday-sat") | tojson }}
+      ]
+    }
   }
   </script>
 
@@ -815,13 +832,13 @@
       <div style="display: flex; align-items: center; gap: 0.75rem;">
         <div class="cal-header-title" id="cal-header-title">{{ month_label }}</div>
         <div class="view-toggle" id="view-toggle">
-          <button type="button" data-view="month" class="active" title="Month view">
+          <button type="button" data-view="month" class="active" title="{{ t('slots-view-month') }}">
             <svg viewBox="0 0 16 16"><rect x="1" y="1" width="4" height="4" rx="0.5"/><rect x="6" y="1" width="4" height="4" rx="0.5"/><rect x="11" y="1" width="4" height="4" rx="0.5"/><rect x="1" y="6" width="4" height="4" rx="0.5"/><rect x="6" y="6" width="4" height="4" rx="0.5"/><rect x="11" y="6" width="4" height="4" rx="0.5"/><rect x="1" y="11" width="4" height="4" rx="0.5"/><rect x="6" y="11" width="4" height="4" rx="0.5"/><rect x="11" y="11" width="4" height="4" rx="0.5"/></svg>
           </button>
-          <button type="button" data-view="week" title="Week view">
+          <button type="button" data-view="week" title="{{ t('slots-view-week') }}">
             <svg viewBox="0 0 16 16"><rect x="1" y="0" width="2" height="16" rx="0.5"/><rect x="4.5" y="0" width="2" height="16" rx="0.5"/><rect x="8" y="0" width="2" height="16" rx="0.5"/><rect x="11.5" y="0" width="2" height="16" rx="0.5"/></svg>
           </button>
-          <button type="button" data-view="column" title="Column view">
+          <button type="button" data-view="column" title="{{ t('slots-view-column') }}">
             <svg viewBox="0 0 16 16"><rect x="0" y="1" width="16" height="2" rx="0.5"/><rect x="0" y="5" width="16" height="2" rx="0.5"/><rect x="0" y="9" width="16" height="2" rx="0.5"/><rect x="0" y="13" width="16" height="2" rx="0.5"/></svg>
           </button>
         </div>
@@ -840,13 +857,13 @@
       <!-- Month calendar panel -->
       <div class="cal-panel">
         <div class="cal-weekdays">
-          <div class="cal-weekday"><span class="cal-weekday-full">Mon</span><span class="cal-weekday-short">M</span></div>
-          <div class="cal-weekday"><span class="cal-weekday-full">Tue</span><span class="cal-weekday-short">T</span></div>
-          <div class="cal-weekday"><span class="cal-weekday-full">Wed</span><span class="cal-weekday-short">W</span></div>
-          <div class="cal-weekday"><span class="cal-weekday-full">Thu</span><span class="cal-weekday-short">T</span></div>
-          <div class="cal-weekday"><span class="cal-weekday-full">Fri</span><span class="cal-weekday-short">F</span></div>
-          <div class="cal-weekday"><span class="cal-weekday-full">Sat</span><span class="cal-weekday-short">S</span></div>
-          <div class="cal-weekday"><span class="cal-weekday-full">Sun</span><span class="cal-weekday-short">S</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-mon") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-mon-short") }}</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-tue") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-tue-short") }}</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-wed") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-wed-short") }}</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-thu") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-thu-short") }}</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-fri") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-fri-short") }}</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-sat") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-sat-short") }}</span></div>
+          <div class="cal-weekday"><span class="cal-weekday-full">{{ t("slots-weekday-sun") }}</span><span class="cal-weekday-short">{{ t("slots-weekday-sun-short") }}</span></div>
         </div>
 
         <div class="cal-grid" id="cal-grid"></div>
@@ -855,18 +872,18 @@
       <!-- Slot list panel -->
       <div class="slot-panel">
         <div class="slot-panel-header">
-          <div class="slot-panel-title" id="slot-panel-title">Select a date</div>
+          <div class="slot-panel-title" id="slot-panel-title">{{ t("slots-select-date") }}</div>
         </div>
         <div class="slot-list" id="slot-list">
           {% if deferred_load is defined and deferred_load %}
           <div class="slot-empty" id="deferred-loader" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0.75rem; padding: 3rem 1rem;">
             <div style="width: 24px; height: 24px; border: 3px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: calrs-spin 0.8s linear infinite;"></div>
-            <div style="color: var(--text-muted); font-size: 0.85rem;">Loading availability...</div>
+            <div style="color: var(--text-muted); font-size: 0.85rem;">{{ t("slots-loading-availability") }}</div>
           </div>
           {% else %}
           <div class="slot-empty">
             <div class="slot-empty-icon">&#128197;</div>
-            <div>Click a highlighted date to see available times</div>
+            <div>{{ t("slots-click-highlighted") }}</div>
           </div>
           {% endif %}
         </div>
@@ -903,7 +920,8 @@
   var rescheduleBase = decHtml("{{ reschedule_base | default('') }}");
 
   var format = localStorage.getItem('calrs_time_format') || '24';
-  var dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  var i18n = calData.i18n || {};
+  var dayLabels = i18n.weekdays || ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   function formatTime(t) {
     return format === '12' ? calrsFormat12h(t) : t;
@@ -1047,9 +1065,9 @@
 
   function clearSlotPanel() {
     var titleEl = document.getElementById('slot-panel-title');
-    if (titleEl) titleEl.textContent = 'Select a date';
+    if (titleEl) titleEl.textContent = i18n.selectDate || 'Select a date';
     var listEl = document.getElementById('slot-list');
-    if (listEl) listEl.innerHTML = '<div class="slot-empty"><div class="slot-empty-icon">&#128197;</div><div>No available times this month</div></div>';
+    if (listEl) listEl.innerHTML = '<div class="slot-empty"><div class="slot-empty-icon">&#128197;</div><div>' + (i18n.noTimesMonth || 'No available times this month') + '</div></div>';
   }
 
   // Select day and show slots
@@ -1071,7 +1089,7 @@
     var slots = slotData[dateStr];
 
     if (!slots || slots.length === 0) {
-      listEl.innerHTML = '<div class="slot-empty"><div class="slot-empty-icon">&#128347;</div><div>No available times this day</div></div>';
+      listEl.innerHTML = '<div class="slot-empty"><div class="slot-empty-icon">&#128347;</div><div>' + (i18n.noTimesDay || 'No available times this day') + '</div></div>';
       return;
     }
 
@@ -1217,7 +1235,7 @@
   var slotsLayout = document.getElementById('slots-layout');
   var weekViewEl = document.getElementById('week-view');
   var columnViewEl = document.getElementById('column-view');
-  var shortDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  var shortDays = i18n.weekdays || ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   function buildSlotHref(s) {
     var date = s.guestDate || s.hostDate;
@@ -1302,7 +1320,7 @@
         html += '<a href="' + buildSlotHref(slots[j]) + '" class="week-slot-pill"' + hidden + '>' + formatTime(slots[j].start) + '</a>';
       }
       if (slots.length > maxVisible) {
-        html += '<div class="week-more" data-week-expand="' + i + '">+' + (slots.length - maxVisible) + ' more</div>';
+        html += '<div class="week-more" data-week-expand="' + i + '">+' + (slots.length - maxVisible) + ' ' + (i18n.weekMore || 'more') + '</div>';
       }
       html += '</div>';
     }
@@ -1466,7 +1484,7 @@
 
     var html = '';
     if (dates.length === 0) {
-      html += '<div class="slot-empty"><div class="slot-empty-icon">&#128197;</div><div>No available times this month</div></div>';
+      html += '<div class="slot-empty"><div class="slot-empty-icon">&#128197;</div><div>' + (i18n.noTimesMonth || 'No available times this month') + '</div></div>';
     } else {
       html += '<div class="column-days">';
       for (var i = 0; i < dates.length; i++) {
@@ -1591,9 +1609,9 @@
       if (loader) {
         var hasSlots = Object.keys(availableDates).length > 0;
         if (hasSlots) {
-          loader.innerHTML = '<div class="slot-empty-icon">&#128197;</div><div>Click a highlighted date to see available times</div>';
+          loader.innerHTML = '<div class="slot-empty-icon">&#128197;</div><div>' + (i18n.clickHighlighted || 'Click a highlighted date to see available times') + '</div>';
         } else {
-          loader.innerHTML = '<div class="slot-empty-icon">&#128683;</div><div>No availability found for all participants this month</div>';
+          loader.innerHTML = '<div class="slot-empty-icon">&#128683;</div><div>' + (i18n.noAvailabilityParticipants || 'No availability found for all participants this month') + '</div>';
         }
         loader.id = '';
       }


### PR DESCRIPTION
Closes #54.

Adds localization for the entire public booking flow via [Fluent](https://projectfluent.org/), with translations managed through [Hosted Weblate](https://hosted.weblate.org/projects/calrs/). English, French, Spanish, and Polish ship out of the box.

## What's covered

| Surface | EN | FR | ES | PL |
|---|---|---|---|---|
| Booking confirmation page (`confirmed.html`) | source | ✅ | ✅ | ✅ |
| Slot picker (`slots.html`, all three views) | source | ✅ | (fall back to EN) | (fall back to EN) |
| Booking form (`book.html`) | source | ✅ | (fall back) | (fall back) |
| Cancel / decline / approve flows | source | ✅ | (fall back) | (fall back) |
| Claim flow (watcher claims) | source | ✅ | (fall back) | (fall back) |
| Reschedule confirmation | source | ✅ | (fall back) | (fall back) |
| Public chrome (`base.html`: theme toggle, sync loader) | source | ✅ | (fall back) | (fall back) |

Untranslated keys fall through to English at runtime, so a partial locale never breaks the page. ES and PL beyond the confirmation page are seeded as community-translation targets on Weblate.

## How language is selected

| Visitor | Source of truth |
|---|---|
| Guest (not logged in) | Browser `Accept-Language` header (RFC 7231 with q-weights) |
| Logged-in user, no preference set | Same as above |
| Logged-in user with a preference | Their choice in **Profile & Settings** |

The settings UI dropdown is shipped, but currently affects zero rendered pages because every translated template is guest-facing. It's foundation for the dashboard translation pass.

## Architecture

- `i18n/{lang}/main.ftl` — Fluent source files, embedded into the binary via \`include_str!\` (no runtime files, single-binary deploy story preserved)
- \`src/i18n.rs\` — concurrent FluentBundle in \`OnceLock\`, \`Accept-Language\` parser, minijinja \`t(key, **kwargs)\` global, \`resolve(user_pref, headers)\` helper
- Templates use \`{{ t(\"key\", arg=value) }}\`. JS-driven strings on the slot picker are bundled into the \`calendar-data\` JSON block via \`tojson\`
- Each render handler injects \`lang\` into its rendering context

## Database

- Migration 047: \`users.language TEXT NULL\` (NULL means follow Accept-Language)

## Workflow

The \`i18n\` branch is **long-lived** and **not deleted on merge**. Translators commit through Weblate, which pushes back to \`i18n\` via the Weblate GitHub App. We periodically merge \`i18n → main\` (e.g. before each release) and continue using the same branch. Documented in \`CLAUDE.md\`.

When introducing new translatable strings, branch off \`i18n\` so translators see them on Weblate before the next merge into main, instead of branching off main and forcing a back-port.

## Known limitations (deliberately out of scope)

These are documented in commit messages and intentionally deferred:

1. **Server-side date formatting.** \`month_label\` (\"March 2026\"), \`date_label\` (\"Tuesday, March 12, 2026\"), and the JS week-view month names array remain English. They come from \`chrono\` formatters which need locale features or \`icu\`. This will be the first thing French users notice, but it's a separate concern from string translation.
2. **Dashboard pages.** Host-facing surface, larger scope, and gated by date-localization decisions. Per-user language preference is wired so it can take effect immediately when those land.
3. **Email templates** (\`src/email.rs\`). Different render path, separate pass.
4. **\`booking_action_error.html\` dynamic title/message.** Page chrome is localized; the body text is server-constructed and needs keys threaded through error-construction sites.

## Numbers

- 13 commits, 30 files changed, +1095/-170
- 108 message keys in source EN bundle, 108 translated to FR
- 11 new unit tests for \`Accept-Language\` parsing and translation lookup
- 556 tests passing, \`cargo fmt\` and \`cargo clippy -D warnings\` clean

## Test plan

- [ ] Set browser to \`fr-FR\`, visit a booking link, verify slot picker / booking form / confirmation are in French
- [ ] Set browser to \`de-DE\` (unsupported), verify everything falls back to English
- [ ] Send \`Accept-Language: en;q=0.5,fr;q=0.9\`, verify French wins (q-weight test)
- [ ] Log in, set Profile & Settings → Language → Auto, save, confirm \`users.language\` is NULL
- [ ] Cancel a booking via the email link, confirm cancel form is in detected language
- [ ] Watcher claims a booking, confirm claim flow is in detected language
- [ ] Verify Weblate component still pulls cleanly from the \`i18n\` branch after merge

## Branch handling

⚠️ **Do not delete the \`i18n\` branch on merge.** It's the long-lived working branch for translators. Documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)