### PR TITLE
fix(docker): COPY i18n/ into the build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && r
 COPY src/ src/
 COPY migrations/ migrations/
 COPY assets/ assets/
+COPY i18n/ i18n/
 RUN touch src/main.rs && cargo build --release
 
 # Stage 2: Runtime


### PR DESCRIPTION
The release Docker image fails to build on \`main\` since #59 merged: \`include_str!\` on the embedded \`.ftl\` files can't find them at compile time because the Dockerfile only \`COPY\`'d \`src/\`, \`migrations/\`, and \`assets/\`. The new top-level \`i18n/\` directory wasn't on the build context.

Failing run for reference: https://github.com/olivierlambert/calrs/actions/runs/24960132958

\`\`\`
error: couldn't read \`src/../i18n/en/main.ftl\`: No such file or directory (os error 2)
  --> src/i18n.rs:19:23
\`\`\`

One-line fix: \`COPY i18n/ i18n/\` before the cargo build step. Local cargo builds were unaffected because they read directly from the source tree.

This same fix will also flow back into \`main\` from the \`i18n\` branch the next time it's merged (the commit was applied there too as 482e403), so cherry-picking it here is just to unblock CI immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)