### PR TITLE
i18n: translate guest emails (confirmation, reminder, cancellation) + capture guest language

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && r
 COPY src/ src/
 COPY migrations/ migrations/
 COPY assets/ assets/
+COPY i18n/ i18n/
 RUN touch src/main.rs && cargo build --release
 
 # Stage 2: Runtime

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -204,13 +204,6 @@ email-confirm-ics-attached-plain = A calendar invite is attached.
 email-confirm-ics-attached-html = A calendar invite is attached to this email.
 email-confirm-need-to-cancel = Need to cancel? { $url }
 
-# Email: additional attendee variant of the confirmation
-
-email-attendee-greeting = Hi,
-email-attendee-headline = You've been added as an attendee to a booking.
-email-attendee-detail-organizer = Organizer:
-email-attendee-detail-booked-by = Booked by:
-
 # Email: guest reminder
 
 email-reminder-subject = Reminder: { $event } at { $time }
@@ -221,7 +214,5 @@ email-reminder-headline = Your meeting is coming up.
 email-cancel-subject = Cancelled: { $event } — { $date }
 email-cancel-headline-by-host = Your booking has been cancelled by { $host }.
 email-cancel-headline-by-guest = Your booking has been cancelled.
-email-cancel-reason-line = Reason: { $reason }
-email-cancel-no-action-needed = No further action needed.
 email-cancel-ics-attached-plain = A calendar cancellation is attached.
 email-cancel-ics-attached-html = A calendar cancellation is attached to this email.

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -188,3 +188,40 @@ common-weekday-long-sun = Sunday
 #   ES: abril 2026  /  martes, 12 de marzo de 2026
 common-format-month-year = { $month } { $year }
 common-format-long-date = { $weekday }, { $month } { $day }, { $year }
+
+# Email signatures and shared bits (src/email.rs)
+
+email-signature = — calrs
+email-action-reschedule = Reschedule
+email-action-cancel-booking = Cancel booking
+
+# Email: guest booking confirmation
+
+email-confirm-subject = Confirmed: { $event } — { $date }
+email-confirm-greeting = Hi { $name },
+email-confirm-headline = Your booking has been confirmed!
+email-confirm-ics-attached-plain = A calendar invite is attached.
+email-confirm-ics-attached-html = A calendar invite is attached to this email.
+email-confirm-need-to-cancel = Need to cancel? { $url }
+
+# Email: additional attendee variant of the confirmation
+
+email-attendee-greeting = Hi,
+email-attendee-headline = You've been added as an attendee to a booking.
+email-attendee-detail-organizer = Organizer:
+email-attendee-detail-booked-by = Booked by:
+
+# Email: guest reminder
+
+email-reminder-subject = Reminder: { $event } at { $time }
+email-reminder-headline = Your meeting is coming up.
+
+# Email: guest cancellation
+
+email-cancel-subject = Cancelled: { $event } — { $date }
+email-cancel-headline-by-host = Your booking has been cancelled by { $host }.
+email-cancel-headline-by-guest = Your booking has been cancelled.
+email-cancel-reason-line = Reason: { $reason }
+email-cancel-no-action-needed = No further action needed.
+email-cancel-ics-attached-plain = A calendar cancellation is attached.
+email-cancel-ics-attached-html = A calendar cancellation is attached to this email.

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -199,13 +199,6 @@ email-confirm-ics-attached-plain = Une invitation est jointe à cet e-mail.
 email-confirm-ics-attached-html = Une invitation est jointe à cet e-mail.
 email-confirm-need-to-cancel = Besoin d'annuler ? { $url }
 
-# Email: additional attendee variant of the confirmation
-
-email-attendee-greeting = Bonjour,
-email-attendee-headline = Vous avez été ajouté comme participant à une réservation.
-email-attendee-detail-organizer = Organisateur :
-email-attendee-detail-booked-by = Réservé par :
-
 # Email: guest reminder
 
 email-reminder-subject = Rappel : { $event } à { $time }
@@ -216,7 +209,5 @@ email-reminder-headline = Votre rendez-vous approche.
 email-cancel-subject = Annulée : { $event } — { $date }
 email-cancel-headline-by-host = Votre réservation a été annulée par { $host }.
 email-cancel-headline-by-guest = Votre réservation a été annulée.
-email-cancel-reason-line = Motif : { $reason }
-email-cancel-no-action-needed = Aucune autre action n'est nécessaire.
 email-cancel-ics-attached-plain = Une annulation de calendrier est jointe.
 email-cancel-ics-attached-html = Une annulation de calendrier est jointe à cet e-mail.

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -183,3 +183,40 @@ common-weekday-long-sun = dimanche
 # French dates: no comma, day before month, lowercase day/month names.
 common-format-month-year = { $month } { $year }
 common-format-long-date = { $weekday } { $day } { $month } { $year }
+
+# Email signatures and shared bits (src/email.rs)
+
+email-signature = — calrs
+email-action-reschedule = Reprogrammer
+email-action-cancel-booking = Annuler la réservation
+
+# Email: guest booking confirmation
+
+email-confirm-subject = Réservation confirmée : { $event } — { $date }
+email-confirm-greeting = Bonjour { $name },
+email-confirm-headline = Votre réservation est confirmée !
+email-confirm-ics-attached-plain = Une invitation est jointe à cet e-mail.
+email-confirm-ics-attached-html = Une invitation est jointe à cet e-mail.
+email-confirm-need-to-cancel = Besoin d'annuler ? { $url }
+
+# Email: additional attendee variant of the confirmation
+
+email-attendee-greeting = Bonjour,
+email-attendee-headline = Vous avez été ajouté comme participant à une réservation.
+email-attendee-detail-organizer = Organisateur :
+email-attendee-detail-booked-by = Réservé par :
+
+# Email: guest reminder
+
+email-reminder-subject = Rappel : { $event } à { $time }
+email-reminder-headline = Votre rendez-vous approche.
+
+# Email: guest cancellation
+
+email-cancel-subject = Annulée : { $event } — { $date }
+email-cancel-headline-by-host = Votre réservation a été annulée par { $host }.
+email-cancel-headline-by-guest = Votre réservation a été annulée.
+email-cancel-reason-line = Motif : { $reason }
+email-cancel-no-action-needed = Aucune autre action n'est nécessaire.
+email-cancel-ics-attached-plain = Une annulation de calendrier est jointe.
+email-cancel-ics-attached-html = Une annulation de calendrier est jointe à cet e-mail.

--- a/migrations/048_booking_language.sql
+++ b/migrations/048_booking_language.sql
@@ -1,0 +1,5 @@
+-- Per-booking language tag, captured from the guest's Accept-Language at
+-- booking time. Used to render guest-facing emails (confirmation, reminder,
+-- cancellation, ...) in the same language they saw the booking page in.
+-- NULL means "no signal", which falls back to English at send time.
+ALTER TABLE bookings ADD COLUMN language TEXT;

--- a/src/commands/booking.rs
+++ b/src/commands/booking.rs
@@ -259,6 +259,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                         location: None,
                         reminder_minutes: None,
                         additional_attendees: vec![],
+                        ..Default::default()
                     };
 
                     print!(
@@ -411,6 +412,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                                 uid,
                                 reason,
                                 cancelled_by_host: true,
+                                ..Default::default()
                             };
 
                             print!(

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -616,6 +616,7 @@ async fn cancel_orphaned_booking(pool: &SqlitePool, key: &[u8; 32], uid: &str) {
         uid: booking_uid,
         reason: Some("The calendar event was deleted by the host.".to_string()),
         cancelled_by_host: true,
+        ..Default::default()
     };
 
     if let Err(e) = crate::email::send_guest_cancellation(&smtp_config, &details).await {

--- a/src/db.rs
+++ b/src/db.rs
@@ -207,6 +207,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "047_user_language",
             include_str!("../migrations/047_user_language.sql"),
         ),
+        (
+            "048_booking_language",
+            include_str!("../migrations/048_booking_language.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -750,7 +754,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 47, "All 47 migrations should be tracked");
+        assert_eq!(count.0, 48, "All 48 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -764,7 +768,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 47, "Still 47 migrations after second run");
+        assert_eq!(count.0, 48, "Still 48 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,11 +1,37 @@
 use anyhow::Result;
 use chrono::NaiveDateTime;
 use chrono_tz::Tz;
+use fluent_bundle::{FluentArgs, FluentValue};
 use lettre::message::header::ContentType;
 use lettre::message::{Attachment, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 use sqlx::SqlitePool;
+
+/// Translate a Fluent message id with no arguments. Local helper so call
+/// sites stay readable.
+fn t(lang: &str, key: &str) -> String {
+    crate::i18n::translate(lang, key, None)
+}
+
+/// Translate with named arguments. Each tuple is `(arg_name, value)`.
+fn ta<const N: usize>(lang: &str, key: &str, args: [(&str, &str); N]) -> String {
+    let mut fa = FluentArgs::new();
+    for (k, v) in args.iter() {
+        fa.set(*k, FluentValue::from(*v));
+    }
+    crate::i18n::translate(lang, key, Some(&fa))
+}
+
+/// Resolve guest language from booking details, falling back to English.
+fn guest_lang(details: &BookingDetails) -> &str {
+    details.guest_language.as_deref().unwrap_or("en")
+}
+
+#[allow(dead_code)]
+fn host_lang(details: &BookingDetails) -> &str {
+    details.host_language.as_deref().unwrap_or("en")
+}
 
 pub struct SmtpConfig {
     pub host: String,
@@ -398,6 +424,7 @@ pub async fn send_guest_confirmation_ex(
     reschedule_url: Option<&str>,
 ) -> Result<()> {
     let ics = generate_ics(details, "REQUEST");
+    let lang = guest_lang(details);
 
     let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
     let from = format!("{} <{}>", from_display, config.from_email).parse()?;
@@ -408,64 +435,90 @@ pub async fn send_guest_confirmation_ex(
         details.start_time, details.end_time, details.guest_timezone
     );
 
+    let greeting = ta(
+        lang,
+        "email-confirm-greeting",
+        [("name", &details.guest_name)],
+    );
+    let headline = t(lang, "email-confirm-headline");
+    let label_event = t(lang, "confirmed-detail-event");
+    let label_date = t(lang, "confirmed-detail-date");
+    let label_time = t(lang, "confirmed-detail-time");
+    let label_with = t(lang, "confirmed-detail-with");
+    let label_location = t(lang, "confirmed-detail-location");
+    let label_notes = t(lang, "confirmed-detail-notes");
+    let ics_attached_plain = t(lang, "email-confirm-ics-attached-plain");
+    let ics_attached_html = t(lang, "email-confirm-ics-attached-html");
+    let signature = t(lang, "email-signature");
+
     let plain = format!(
-        "Hi {},\n\n\
-         Your booking has been confirmed!\n\n\
-         Event: {}\n\
-         Date: {}\n\
-         Time: {}\n\
-         With: {}\n\
+        "{}\n\n\
+         {}\n\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
          {}{}\
-         A calendar invite is attached.\n\
          {}\n\
-         \u{2014} calrs",
-        details.guest_name,
+         {}\n\
+         {}",
+        greeting,
+        headline,
+        label_event,
         details.event_title,
+        label_date,
         details.date,
+        label_time,
         time_display,
+        label_with,
         details.host_name,
         details
             .location
             .as_ref()
-            .map(|l| format!("Location: {}\n", l))
+            .map(|l| format!("{} {}\n", label_location, l))
             .unwrap_or_default(),
         details
             .notes
             .as_ref()
-            .map(|n| format!("Notes: {}\n", n))
+            .map(|n| format!("{} {}\n", label_notes, n))
             .unwrap_or_default(),
+        ics_attached_plain,
         cancel_url
-            .map(|u| format!("\nNeed to cancel? {}\n", u))
+            .map(|u| format!(
+                "\n{}\n",
+                ta(lang, "email-confirm-need-to-cancel", [("url", u)])
+            ))
             .unwrap_or_default(),
+        signature,
     );
 
     let mut rows = vec![
         EmailRow {
-            label: "Event".to_string(),
+            label: label_event.clone(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date".to_string(),
+            label: label_date.clone(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time".to_string(),
+            label: label_time.clone(),
             value: time_display,
         },
         EmailRow {
-            label: "With".to_string(),
+            label: label_with.clone(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location".to_string(),
+            label: label_location.clone(),
             value: loc.clone(),
         });
     }
     if let Some(notes) = &details.notes {
         rows.push(EmailRow {
-            label: "Notes".to_string(),
+            label: label_notes.clone(),
             value: notes.clone(),
         });
     }
@@ -473,25 +526,25 @@ pub async fn send_guest_confirmation_ex(
     let mut actions: Vec<EmailAction> = Vec::new();
     if let Some(u) = reschedule_url {
         actions.push(EmailAction {
-            label: "Reschedule".to_string(),
+            label: t(lang, "email-action-reschedule"),
             url: u.to_string(),
             color: "#3b82f6".to_string(),
         });
     }
     if let Some(u) = cancel_url {
         actions.push(EmailAction {
-            label: "Cancel booking".to_string(),
+            label: t(lang, "email-action-cancel-booking"),
             url: u.to_string(),
             color: "#dc2626".to_string(),
         });
     }
 
     let html = render_html_email_with_actions(
-        &format!("Hi {},", h(&details.guest_name)),
-        "Your booking has been confirmed!",
+        &h(&greeting),
+        &headline,
         "#16a34a",
         &rows,
-        Some("A calendar invite is attached to this email."),
+        Some(&ics_attached_html),
         &actions,
     );
 
@@ -502,13 +555,15 @@ pub async fn send_guest_confirmation_ex(
         ContentType::parse("text/calendar; method=REQUEST; charset=UTF-8")?,
     );
 
+    let subject = ta(
+        lang,
+        "email-confirm-subject",
+        [("event", &details.event_title), ("date", &details.date)],
+    );
     let email = Message::builder()
         .from(from)
         .to(to)
-        .subject(format!(
-            "Confirmed: {} \u{2014} {}",
-            details.event_title, details.date
-        ))
+        .subject(subject)
         .multipart(
             MultiPart::mixed()
                 .multipart(body)
@@ -778,6 +833,7 @@ pub async fn send_guest_reminder(
     details: &BookingDetails,
     cancel_url: Option<&str>,
 ) -> Result<()> {
+    let lang = guest_lang(details);
     let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
     let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
@@ -787,51 +843,73 @@ pub async fn send_guest_reminder(
         details.start_time, details.end_time, details.guest_timezone
     );
 
+    let greeting = ta(
+        lang,
+        "email-confirm-greeting",
+        [("name", &details.guest_name)],
+    );
+    let headline = t(lang, "email-reminder-headline");
+    let label_event = t(lang, "confirmed-detail-event");
+    let label_date = t(lang, "confirmed-detail-date");
+    let label_time = t(lang, "confirmed-detail-time");
+    let label_with = t(lang, "confirmed-detail-with");
+    let label_location = t(lang, "confirmed-detail-location");
+    let signature = t(lang, "email-signature");
+
     let plain = format!(
-        "Hi {},\n\n\
-         Reminder: you have an upcoming booking.\n\n\
-         Event: {}\n\
-         Date: {}\n\
-         Time: {}\n\
-         With: {}\n\
+        "{}\n\n\
+         {}\n\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
          {}{}\n\
-         \u{2014} calrs",
-        details.guest_name,
+         {}",
+        greeting,
+        headline,
+        label_event,
         details.event_title,
+        label_date,
         details.date,
+        label_time,
         time_display,
+        label_with,
         details.host_name,
         details
             .location
             .as_ref()
-            .map(|l| format!("Location: {}\n", l))
+            .map(|l| format!("{} {}\n", label_location, l))
             .unwrap_or_default(),
         cancel_url
-            .map(|u| format!("\nNeed to cancel? {}\n", u))
+            .map(|u| format!(
+                "\n{}\n",
+                ta(lang, "email-confirm-need-to-cancel", [("url", u)])
+            ))
             .unwrap_or_default(),
+        signature,
     );
 
     let mut rows = vec![
         EmailRow {
-            label: "Event".to_string(),
+            label: label_event.clone(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date".to_string(),
+            label: label_date.clone(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time".to_string(),
+            label: label_time.clone(),
             value: time_display,
         },
         EmailRow {
-            label: "With".to_string(),
+            label: label_with.clone(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location".to_string(),
+            label: label_location.clone(),
             value: loc.clone(),
         });
     }
@@ -839,31 +917,30 @@ pub async fn send_guest_reminder(
     let actions: Vec<EmailAction> = cancel_url
         .map(|u| {
             vec![EmailAction {
-                label: "Cancel booking".to_string(),
+                label: t(lang, "email-action-cancel-booking"),
                 url: u.to_string(),
                 color: "#dc2626".to_string(),
             }]
         })
         .unwrap_or_default();
 
-    let html = render_html_email_with_actions(
-        &format!("Hi {},", h(&details.guest_name)),
-        "Reminder: you have an upcoming booking.",
-        "#3b82f6",
-        &rows,
-        None,
-        &actions,
-    );
+    let html =
+        render_html_email_with_actions(&h(&greeting), &headline, "#3b82f6", &rows, None, &actions);
 
     let body = build_multipart_body(&plain, &html);
 
+    let subject = ta(
+        lang,
+        "email-reminder-subject",
+        [
+            ("event", &details.event_title),
+            ("time", &details.start_time),
+        ],
+    );
     let email = Message::builder()
         .from(from)
         .to(to)
-        .subject(format!(
-            "Reminder: {} \u{2014} {}",
-            details.event_title, details.date
-        ))
+        .subject(subject)
         .multipart(body)?;
 
     send_email(config, email).await
@@ -947,79 +1024,99 @@ pub async fn send_guest_cancellation(
     details: &CancellationDetails,
 ) -> Result<()> {
     let ics = generate_cancel_ics(details);
+    let lang = details.guest_language.as_deref().unwrap_or("en");
 
     let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
     let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+
+    let greeting = ta(
+        lang,
+        "email-confirm-greeting",
+        [("name", &details.guest_name)],
+    );
+    let headline = if details.cancelled_by_host {
+        ta(
+            lang,
+            "email-cancel-headline-by-host",
+            [("host", &details.host_name)],
+        )
+    } else {
+        t(lang, "email-cancel-headline-by-guest")
+    };
+    let label_event = t(lang, "confirmed-detail-event");
+    let label_date = t(lang, "confirmed-detail-date");
+    let label_time = t(lang, "confirmed-detail-time");
+    let label_with = t(lang, "confirmed-detail-with");
+    let label_reason = t(lang, "common-detail-reason");
+    let ics_attached_plain = t(lang, "email-cancel-ics-attached-plain");
+    let ics_attached_html = t(lang, "email-cancel-ics-attached-html");
+    let signature = t(lang, "email-signature");
+
     let reason_text = details
         .reason
         .as_ref()
-        .map(|r| format!("Reason: {}\n\n", r))
+        .map(|r| format!("{} {}\n\n", label_reason, r))
         .unwrap_or_default();
 
     let plain = format!(
-        "Hi {},\n\n\
-         Your booking has been cancelled{}.\n\n\
-         Event: {}\n\
-         Date: {}\n\
-         Time: {}\n\
-         With: {}\n\n\
+        "{}\n\n\
+         {}\n\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\n\
          {}\
-         A calendar cancellation is attached.\n\n\
-         \u{2014} calrs",
-        details.guest_name,
-        if details.cancelled_by_host {
-            format!(" by {}", details.host_name)
-        } else {
-            String::new()
-        },
+         {}\n\n\
+         {}",
+        greeting,
+        headline,
+        label_event,
         details.event_title,
+        label_date,
         details.date,
+        label_time,
         time_display,
+        label_with,
         details.host_name,
         reason_text,
+        ics_attached_plain,
+        signature,
     );
 
     let mut rows = vec![
         EmailRow {
-            label: "Event".to_string(),
+            label: label_event.clone(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date".to_string(),
+            label: label_date.clone(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time".to_string(),
+            label: label_time.clone(),
             value: time_display,
         },
         EmailRow {
-            label: "With".to_string(),
+            label: label_with.clone(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(reason) = &details.reason {
         rows.push(EmailRow {
-            label: "Reason".to_string(),
+            label: label_reason.clone(),
             value: reason.clone(),
         });
     }
 
     let html = render_html_email(
-        &format!("Hi {},", h(&details.guest_name)),
-        &if details.cancelled_by_host {
-            format!(
-                "Your booking has been cancelled by {}.",
-                h(&details.host_name)
-            )
-        } else {
-            "Your booking has been cancelled.".to_string()
-        },
+        &h(&greeting),
+        &headline,
         "#dc2626",
         &rows,
-        Some("A calendar cancellation is attached to this email."),
+        Some(&ics_attached_html),
     );
 
     let body = build_multipart_body(&plain, &html);
@@ -1029,13 +1126,15 @@ pub async fn send_guest_cancellation(
         ContentType::parse("text/calendar; method=CANCEL; charset=UTF-8")?,
     );
 
+    let subject = ta(
+        lang,
+        "email-cancel-subject",
+        [("event", &details.event_title), ("date", &details.date)],
+    );
     let email = Message::builder()
         .from(from)
         .to(to)
-        .subject(format!(
-            "Cancelled: {} \u{2014} {}",
-            details.event_title, details.date
-        ))
+        .subject(subject)
         .multipart(
             MultiPart::mixed()
                 .multipart(body)

--- a/src/email.rs
+++ b/src/email.rs
@@ -16,7 +16,7 @@ pub struct SmtpConfig {
     pub from_name: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct BookingDetails {
     pub event_title: String,
     pub date: String,
@@ -32,8 +32,15 @@ pub struct BookingDetails {
     pub location: Option<String>,
     pub reminder_minutes: Option<i32>,
     pub additional_attendees: Vec<String>,
+    /// Guest's preferred language at booking time (from `bookings.language`).
+    /// `None` falls back to English at send time.
+    pub guest_language: Option<String>,
+    /// Host's saved UI-language preference (from `users.language`).
+    /// `None` falls back to English at send time.
+    pub host_language: Option<String>,
 }
 
+#[derive(Default)]
 pub struct CancellationDetails {
     pub event_title: String,
     pub date: String,
@@ -47,6 +54,8 @@ pub struct CancellationDetails {
     pub uid: String,
     pub reason: Option<String>,
     pub cancelled_by_host: bool,
+    pub guest_language: Option<String>,
+    pub host_language: Option<String>,
 }
 
 // --- HTML email template helpers ---
@@ -59,7 +68,7 @@ fn h(s: &str) -> String {
 }
 
 struct EmailRow {
-    label: &'static str,
+    label: String,
     value: String,
 }
 
@@ -432,31 +441,31 @@ pub async fn send_guest_confirmation_ex(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "With",
+            label: "With".to_string(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
     if let Some(notes) = &details.notes {
         rows.push(EmailRow {
-            label: "Notes",
+            label: "Notes".to_string(),
             value: notes.clone(),
         });
     }
@@ -539,26 +548,26 @@ pub async fn send_guest_confirmation_ex(
             "#16a34a",
             &[
                 EmailRow {
-                    label: "Event",
+                    label: "Event".to_string(),
                     value: details.event_title.clone(),
                 },
                 EmailRow {
-                    label: "Date",
+                    label: "Date".to_string(),
                     value: details.date.clone(),
                 },
                 EmailRow {
-                    label: "Time",
+                    label: "Time".to_string(),
                     value: format!(
                         "{} \u{2013} {} ({})",
                         details.start_time, details.end_time, details.guest_timezone
                     ),
                 },
                 EmailRow {
-                    label: "Organizer",
+                    label: "Organizer".to_string(),
                     value: details.host_name.clone(),
                 },
                 EmailRow {
-                    label: "Booked by",
+                    label: "Booked by".to_string(),
                     value: format!("{} <{}>", details.guest_name, details.guest_email),
                 },
             ],
@@ -623,31 +632,31 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
     if let Some(notes) = &details.notes {
         rows.push(EmailRow {
-            label: "Notes",
+            label: "Notes".to_string(),
             value: notes.clone(),
         });
     }
@@ -718,25 +727,25 @@ pub async fn send_host_booking_confirmed(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
@@ -804,25 +813,25 @@ pub async fn send_guest_reminder(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "With",
+            label: "With".to_string(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
@@ -890,19 +899,19 @@ pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -
 
     let rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
@@ -975,25 +984,25 @@ pub async fn send_guest_cancellation(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "With",
+            label: "With".to_string(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(reason) = &details.reason {
         rows.push(EmailRow {
-            label: "Reason",
+            label: "Reason".to_string(),
             value: reason.clone(),
         });
     }
@@ -1073,25 +1082,25 @@ pub async fn send_host_cancellation(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
     if let Some(reason) = &details.reason {
         rows.push(EmailRow {
-            label: "Reason",
+            label: "Reason".to_string(),
             value: reason.clone(),
         });
     }
@@ -1184,25 +1193,25 @@ pub async fn send_guest_pending_notice_ex(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Host",
+            label: "Host".to_string(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(notes) = &details.notes {
         rows.push(EmailRow {
-            label: "Notes",
+            label: "Notes".to_string(),
             value: notes.clone(),
         });
     }
@@ -1313,31 +1322,31 @@ pub async fn send_host_approval_request(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
     if let Some(notes) = &details.notes {
         rows.push(EmailRow {
-            label: "Notes",
+            label: "Notes".to_string(),
             value: notes.clone(),
         });
     }
@@ -1416,25 +1425,25 @@ pub async fn send_guest_decline_notice(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "With",
+            label: "With".to_string(),
             value: details.host_name.clone(),
         },
     ];
     if let Some(reason) = &details.reason {
         rows.push(EmailRow {
-            label: "Reason",
+            label: "Reason".to_string(),
             value: reason.clone(),
         });
     }
@@ -1551,23 +1560,23 @@ pub async fn send_invite_email(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: event_title.to_string(),
         },
         EmailRow {
-            label: "Invited by",
+            label: "Invited by".to_string(),
             value: host_name.to_string(),
         },
     ];
     if let Some(msg) = message.filter(|m| !m.trim().is_empty()) {
         rows.push(EmailRow {
-            label: "Message",
+            label: "Message".to_string(),
             value: msg.to_string(),
         });
     }
     if let Some(exp) = expires_at {
         rows.push(EmailRow {
-            label: "Expires",
+            label: "Expires".to_string(),
             value: exp.to_string(),
         });
     }
@@ -1689,15 +1698,15 @@ pub async fn send_guest_pick_new_time(
 
     let rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Originally",
+            label: "Originally".to_string(),
             value: format!("{} at {}", details.date, time_display),
         },
         EmailRow {
-            label: "Host",
+            label: "Host".to_string(),
             value: details.host_name.clone(),
         },
     ];
@@ -1769,6 +1778,7 @@ pub async fn send_guest_reschedule_notification(
         location: details.location.clone(),
         reminder_minutes: None,
         additional_attendees: vec![],
+        ..Default::default()
     };
     let ics = generate_ics(&booking_details, "REQUEST");
 
@@ -1809,26 +1819,26 @@ pub async fn send_guest_reschedule_notification(
 
     let rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Previous",
+            label: "Previous".to_string(),
             value: format!(
                 "{} at {} \u{2013} {}",
                 details.old_date, details.old_start_time, details.old_end_time
             ),
         },
         EmailRow {
-            label: "New date",
+            label: "New date".to_string(),
             value: details.new_date.clone(),
         },
         EmailRow {
-            label: "New time",
+            label: "New time".to_string(),
             value: new_time_display,
         },
         EmailRow {
-            label: "With",
+            label: "With".to_string(),
             value: details.host_name.clone(),
         },
     ];
@@ -1949,22 +1959,22 @@ pub async fn send_host_reschedule_request(
 
     let rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Previous",
+            label: "Previous".to_string(),
             value: format!(
                 "{} at {} \u{2013} {}",
                 details.old_date, details.old_start_time, details.old_end_time
             ),
         },
         EmailRow {
-            label: "Requested",
+            label: "Requested".to_string(),
             value: format!("{} at {}", details.new_date, new_time_display),
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
@@ -2053,29 +2063,29 @@ pub async fn send_watcher_claim_notification(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
         EmailRow {
-            label: "Assigned to",
+            label: "Assigned to".to_string(),
             value: assigned_to_name.to_string(),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
@@ -2144,25 +2154,25 @@ pub async fn send_claim_confirmation(
 
     let mut rows = vec![
         EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         },
         EmailRow {
-            label: "Date",
+            label: "Date".to_string(),
             value: details.date.clone(),
         },
         EmailRow {
-            label: "Time",
+            label: "Time".to_string(),
             value: time_display,
         },
         EmailRow {
-            label: "Guest",
+            label: "Guest".to_string(),
             value: format!("{} <{}>", details.guest_name, details.guest_email),
         },
     ];
     if let Some(loc) = &details.location {
         rows.push(EmailRow {
-            label: "Location",
+            label: "Location".to_string(),
             value: loc.clone(),
         });
     }
@@ -2251,6 +2261,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -2291,6 +2302,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "REQUEST");
@@ -2335,6 +2347,7 @@ mod tests {
             location: Some("https://meet.example.com/room".to_string()),
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "REQUEST");
@@ -2365,6 +2378,7 @@ mod tests {
             location: Some("https://example.com".to_string()),
             reminder_minutes: Some(15),
             additional_attendees: vec!["a@test.com".to_string(), "b@test.com".to_string()],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "REQUEST");
         for line in ics.split("\r\n") {
@@ -2393,6 +2407,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -2416,6 +2431,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -2439,6 +2455,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -2472,11 +2489,11 @@ mod tests {
             "#16a34a",
             &[
                 EmailRow {
-                    label: "Event",
+                    label: "Event".to_string(),
                     value: "Intro Call".to_string(),
                 },
                 EmailRow {
-                    label: "Date",
+                    label: "Date".to_string(),
                     value: "2026-03-10".to_string(),
                 },
             ],
@@ -2536,6 +2553,7 @@ mod tests {
             uid: "cancel-uid-123".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         let ics = generate_cancel_ics(&details);
@@ -2565,6 +2583,7 @@ mod tests {
             uid: "cancel-dtstamp-uid".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         let ics = generate_cancel_ics(&details);
@@ -2592,6 +2611,7 @@ mod tests {
             uid: "uid-1".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         // Host email should say "You cancelled this booking."
@@ -2636,6 +2656,7 @@ mod tests {
             uid: "uid-2".to_string(),
             reason: Some("Schedule conflict".to_string()),
             cancelled_by_host: false,
+            ..Default::default()
         };
 
         // Host email should say who cancelled
@@ -2665,7 +2686,7 @@ mod tests {
             "Your booking has been confirmed!",
             "#16a34a",
             &[EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: "Intro Call".to_string(),
             }],
             Some("A calendar invite is attached."),
@@ -2688,7 +2709,7 @@ mod tests {
             "Test",
             "#000",
             &[EmailRow {
-                label: "Notes",
+                label: "Notes".to_string(),
                 value: "<script>alert(1)</script>".to_string(),
             }],
             None,
@@ -2717,6 +2738,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "REQUEST");
         // The injected ATTENDEE line must not appear as a separate field
@@ -2741,6 +2763,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(!ics.contains("LOCATION:"));
@@ -2763,6 +2786,7 @@ mod tests {
             location: None,
             reminder_minutes: Some(15),
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(ics.contains("BEGIN:VALARM"));
@@ -2788,6 +2812,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(!ics.contains("VALARM"));
@@ -2810,6 +2835,7 @@ mod tests {
             location: None,
             reminder_minutes: Some(0),
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(!ics.contains("VALARM"));
@@ -2830,6 +2856,7 @@ mod tests {
             uid: "cancel-special".to_string(),
             reason: Some("No longer needed".to_string()),
             cancelled_by_host: true,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         assert!(ics.contains("SUMMARY:Team sync\\; weekly\\, recurring \u{2014} Bob & Alice"));
@@ -2859,15 +2886,15 @@ mod tests {
             "#000",
             &[
                 EmailRow {
-                    label: "Row1",
+                    label: "Row1".to_string(),
                     value: "val1".to_string(),
                 },
                 EmailRow {
-                    label: "Row2",
+                    label: "Row2".to_string(),
                     value: "val2".to_string(),
                 },
                 EmailRow {
-                    label: "Row3",
+                    label: "Row3".to_string(),
                     value: "val3".to_string(),
                 },
             ],
@@ -2986,6 +3013,7 @@ mod tests {
             location: Some("https://meet.example.com/room".to_string()),
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -3033,6 +3061,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -3069,6 +3098,7 @@ mod tests {
             uid: "uid-cancel-z".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         let ics = generate_cancel_ics(&details);
@@ -3111,6 +3141,7 @@ mod tests {
                 "bob@example.com".to_string(),
                 "carol@example.com".to_string(),
             ],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "REQUEST");
@@ -3137,6 +3168,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         let ics = generate_ics(&details, "PUBLISH");
@@ -3188,6 +3220,7 @@ mod tests {
             location: details.location.clone(),
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&booking_details, "PUBLISH");
         assert!(
@@ -3221,6 +3254,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&booking_details, "REQUEST");
         assert!(
@@ -3292,29 +3326,29 @@ mod tests {
         let details = sample_reschedule_details();
         let rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Previous",
+                label: "Previous".to_string(),
                 value: format!(
                     "{} at {} \u{2013} {}",
                     details.old_date, details.old_start_time, details.old_end_time
                 ),
             },
             EmailRow {
-                label: "New date",
+                label: "New date".to_string(),
                 value: details.new_date.clone(),
             },
             EmailRow {
-                label: "New time",
+                label: "New time".to_string(),
                 value: format!(
                     "{} \u{2013} {} ({})",
                     details.new_start_time, details.new_end_time, details.guest_timezone
                 ),
             },
             EmailRow {
-                label: "With",
+                label: "With".to_string(),
                 value: details.host_name.clone(),
             },
         ];
@@ -3361,7 +3395,7 @@ mod tests {
             "A guest wants to reschedule.",
             "#d97706",
             &[EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: "Test".to_string(),
             }],
             None,
@@ -3485,6 +3519,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         // Empty/whitespace-only notes should not produce a DESCRIPTION line
@@ -3508,6 +3543,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(ics.contains("DESCRIPTION:Topic: budget\\; Q1\\, Q2"));
@@ -3530,6 +3566,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "REQUEST");
         assert!(ics.contains("METHOD:REQUEST"));
@@ -3553,6 +3590,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(ics.contains("PRODID:-//calrs//calrs//EN"));
@@ -3576,6 +3614,7 @@ mod tests {
             location: None,
             reminder_minutes: Some(-5),
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(!ics.contains("VALARM"));
@@ -3598,6 +3637,7 @@ mod tests {
             location: None,
             reminder_minutes: Some(1440),
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(ics.contains("TRIGGER:-PT1440M"));
@@ -3620,6 +3660,7 @@ mod tests {
             location: Some("Room A; Building 3, Floor 2".to_string()),
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(ics.contains("LOCATION:Room A\\; Building 3\\, Floor 2"));
@@ -3645,6 +3686,7 @@ mod tests {
                 "user+tag@example.com".to_string(),
                 "another.user@sub.domain.com".to_string(),
             ],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         assert!(ics.contains("ATTENDEE;RSVP=TRUE:mailto:user+tag@example.com"));
@@ -3668,6 +3710,7 @@ mod tests {
             uid: "uid-cancel-noloc".to_string(),
             reason: None,
             cancelled_by_host: false,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         assert!(!ics.contains("LOCATION:"));
@@ -3690,6 +3733,7 @@ mod tests {
             uid: "uid-cancel-novalarm".to_string(),
             reason: Some("Conflict".to_string()),
             cancelled_by_host: true,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         assert!(!ics.contains("VALARM"));
@@ -3711,6 +3755,7 @@ mod tests {
             uid: "uid-cancel-att".to_string(),
             reason: None,
             cancelled_by_host: false,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         let attendee_count = ics.matches("ATTENDEE;").count();
@@ -3733,6 +3778,7 @@ mod tests {
             uid: "uid-cancel-tz".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         // July: PDT = UTC-7, so 15:00 PDT = 22:00 UTC
@@ -3755,6 +3801,7 @@ mod tests {
             uid: "uid-cancel-prodid".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         assert!(ics.contains("PRODID:-//calrs//calrs//EN"));
@@ -3841,11 +3888,11 @@ mod tests {
             "#000",
             &[
                 EmailRow {
-                    label: "Name",
+                    label: "Name".to_string(),
                     value: "Alice & Bob <team>".to_string(),
                 },
                 EmailRow {
-                    label: "Notes",
+                    label: "Notes".to_string(),
                     value: "use \"quotes\"".to_string(),
                 },
             ],
@@ -3871,23 +3918,23 @@ mod tests {
             "#16a34a",
             &[
                 EmailRow {
-                    label: "Event",
+                    label: "Event".to_string(),
                     value: "Intro Call".to_string(),
                 },
                 EmailRow {
-                    label: "Date",
+                    label: "Date".to_string(),
                     value: "2026-03-15".to_string(),
                 },
                 EmailRow {
-                    label: "Time",
+                    label: "Time".to_string(),
                     value: "10:00 - 10:30 (UTC)".to_string(),
                 },
                 EmailRow {
-                    label: "With",
+                    label: "With".to_string(),
                     value: "Bob".to_string(),
                 },
                 EmailRow {
-                    label: "Location",
+                    label: "Location".to_string(),
                     value: "https://meet.example.com/room".to_string(),
                 },
             ],
@@ -3968,6 +4015,7 @@ mod tests {
             location: Some("https://meet.example.com/room".to_string()),
             reminder_minutes: Some(15),
             additional_attendees: vec!["cc@example.com".to_string()],
+            ..Default::default()
         }
     }
 
@@ -3985,31 +4033,31 @@ mod tests {
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Date",
+                label: "Date".to_string(),
                 value: details.date.clone(),
             },
             EmailRow {
-                label: "Time",
+                label: "Time".to_string(),
                 value: time_display,
             },
             EmailRow {
-                label: "With",
+                label: "With".to_string(),
                 value: details.host_name.clone(),
             },
         ];
         if let Some(loc) = &details.location {
             rows.push(EmailRow {
-                label: "Location",
+                label: "Location".to_string(),
                 value: loc.clone(),
             });
         }
         if let Some(notes) = &details.notes {
             rows.push(EmailRow {
-                label: "Notes",
+                label: "Notes".to_string(),
                 value: notes.clone(),
             });
         }
@@ -4064,26 +4112,26 @@ mod tests {
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Date",
+                label: "Date".to_string(),
                 value: details.date.clone(),
             },
             EmailRow {
-                label: "Time",
+                label: "Time".to_string(),
                 value: time_display,
             },
             EmailRow {
-                label: "Host",
+                label: "Host".to_string(),
                 value: details.host_name.clone(),
             },
         ];
         // Note: no location row for pending emails
         if let Some(notes) = &details.notes {
             rows.push(EmailRow {
-                label: "Notes",
+                label: "Notes".to_string(),
                 value: notes.clone(),
             });
         }
@@ -4115,31 +4163,31 @@ mod tests {
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Date",
+                label: "Date".to_string(),
                 value: details.date.clone(),
             },
             EmailRow {
-                label: "Time",
+                label: "Time".to_string(),
                 value: time_display,
             },
             EmailRow {
-                label: "Guest",
+                label: "Guest".to_string(),
                 value: format!("{} <{}>", details.guest_name, details.guest_email),
             },
         ];
         if let Some(loc) = &details.location {
             rows.push(EmailRow {
-                label: "Location",
+                label: "Location".to_string(),
                 value: loc.clone(),
             });
         }
         if let Some(notes) = &details.notes {
             rows.push(EmailRow {
-                label: "Notes",
+                label: "Notes".to_string(),
                 value: notes.clone(),
             });
         }
@@ -4211,7 +4259,7 @@ mod tests {
             &format!("{} wants to book a slot with you.", h(&details.guest_name)),
             "#f59e0b",
             &[EmailRow {
-                label: "Guest",
+                label: "Guest".to_string(),
                 value: format!("{} <{}>", details.guest_name, details.guest_email),
             }],
             Some("You can also manage this from your dashboard."),
@@ -4281,25 +4329,26 @@ mod tests {
             uid: "uid-decline".to_string(),
             reason: Some("Schedule conflict".to_string()),
             cancelled_by_host: true, // decline is host-initiated
+            ..Default::default()
         };
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Date",
+                label: "Date".to_string(),
                 value: details.date.clone(),
             },
             EmailRow {
-                label: "With",
+                label: "With".to_string(),
                 value: details.host_name.clone(),
             },
         ];
         if let Some(reason) = &details.reason {
             rows.push(EmailRow {
-                label: "Reason",
+                label: "Reason".to_string(),
                 value: reason.clone(),
             });
         }
@@ -4333,15 +4382,16 @@ mod tests {
             uid: "uid-decline-noreason".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         let mut rows = vec![EmailRow {
-            label: "Event",
+            label: "Event".to_string(),
             value: details.event_title.clone(),
         }];
         if let Some(reason) = &details.reason {
             rows.push(EmailRow {
-                label: "Reason",
+                label: "Reason".to_string(),
                 value: reason.clone(),
             });
         }
@@ -4362,23 +4412,23 @@ mod tests {
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: event_title.to_string(),
             },
             EmailRow {
-                label: "Invited by",
+                label: "Invited by".to_string(),
                 value: host_name.to_string(),
             },
         ];
         if let Some(msg) = message.filter(|m| !m.trim().is_empty()) {
             rows.push(EmailRow {
-                label: "Message",
+                label: "Message".to_string(),
                 value: msg.to_string(),
             });
         }
         if let Some(exp) = expires_at {
             rows.push(EmailRow {
-                label: "Expires",
+                label: "Expires".to_string(),
                 value: exp.to_string(),
             });
         }
@@ -4418,23 +4468,23 @@ mod tests {
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: "Meeting".to_string(),
             },
             EmailRow {
-                label: "Invited by",
+                label: "Invited by".to_string(),
                 value: "Host".to_string(),
             },
         ];
         if let Some(msg) = message.filter(|m| !m.trim().is_empty()) {
             rows.push(EmailRow {
-                label: "Message",
+                label: "Message".to_string(),
                 value: msg.to_string(),
             });
         }
         if let Some(exp) = expires_at {
             rows.push(EmailRow {
-                label: "Expires",
+                label: "Expires".to_string(),
                 value: exp.to_string(),
             });
         }
@@ -4449,7 +4499,7 @@ mod tests {
         let mut rows = Vec::new();
         if let Some(msg) = message.filter(|m| !m.trim().is_empty()) {
             rows.push(EmailRow {
-                label: "Message",
+                label: "Message".to_string(),
                 value: msg.to_string(),
             });
         }
@@ -4482,11 +4532,11 @@ mod tests {
             "#3b82f6",
             &[
                 EmailRow {
-                    label: "Event",
+                    label: "Event".to_string(),
                     value: details.event_title.clone(),
                 },
                 EmailRow {
-                    label: "Date",
+                    label: "Date".to_string(),
                     value: details.date.clone(),
                 },
             ],
@@ -4568,15 +4618,15 @@ mod tests {
 
         let rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Originally",
+                label: "Originally".to_string(),
                 value: format!("{} at {}", details.date, time_display),
             },
             EmailRow {
-                label: "Host",
+                label: "Host".to_string(),
                 value: details.host_name.clone(),
             },
         ];
@@ -4622,25 +4672,25 @@ mod tests {
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Date",
+                label: "Date".to_string(),
                 value: details.date.clone(),
             },
             EmailRow {
-                label: "Time",
+                label: "Time".to_string(),
                 value: time_display,
             },
             EmailRow {
-                label: "Guest",
+                label: "Guest".to_string(),
                 value: format!("{} <{}>", details.guest_name, details.guest_email),
             },
         ];
         if let Some(loc) = &details.location {
             rows.push(EmailRow {
-                label: "Location",
+                label: "Location".to_string(),
                 value: loc.clone(),
             });
         }
@@ -4679,6 +4729,7 @@ mod tests {
             location: details.location.clone(),
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&booking_details, "PUBLISH");
         // March 17, 2026 in Paris (CET, UTC+1): 14:00 Paris = 13:00 UTC
@@ -4707,6 +4758,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&booking_details, "PUBLISH");
         assert!(!ics.contains("LOCATION:"));
@@ -4731,6 +4783,7 @@ mod tests {
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         let ics = generate_ics(&details, "PUBLISH");
         // Every line should end with \r\n (RFC 5545 requirement)
@@ -4755,6 +4808,7 @@ mod tests {
             uid: "uid-cancel-crlf".to_string(),
             reason: None,
             cancelled_by_host: false,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         assert!(ics.starts_with("BEGIN:VCALENDAR\r\n"));
@@ -4811,25 +4865,26 @@ mod tests {
             uid: "uid-gcancel".to_string(),
             reason: Some("Emergency".to_string()),
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         let mut rows = vec![
             EmailRow {
-                label: "Event",
+                label: "Event".to_string(),
                 value: details.event_title.clone(),
             },
             EmailRow {
-                label: "Date",
+                label: "Date".to_string(),
                 value: details.date.clone(),
             },
             EmailRow {
-                label: "With",
+                label: "With".to_string(),
                 value: details.host_name.clone(),
             },
         ];
         if let Some(reason) = &details.reason {
             rows.push(EmailRow {
-                label: "Reason",
+                label: "Reason".to_string(),
                 value: reason.clone(),
             });
         }
@@ -4870,6 +4925,7 @@ mod tests {
             uid: "uid-hcancel".to_string(),
             reason: Some("Double booked".to_string()),
             cancelled_by_host: false,
+            ..Default::default()
         };
 
         let msg = if details.cancelled_by_host {
@@ -4914,6 +4970,7 @@ mod tests {
             uid: "uid-cancel-method".to_string(),
             reason: None,
             cancelled_by_host: true,
+            ..Default::default()
         };
         let ics = generate_cancel_ics(&details);
         assert!(ics.contains("METHOD:CANCEL"));

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -161,8 +161,8 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
         // - event type has reminder_minutes set (> 0)
         // - start_at minus reminder_minutes <= now
         // - start_at > now (don't remind for past bookings)
-        let due: Vec<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String)> = sqlx::query_as(
-            "SELECT b.id, b.guest_name, b.guest_email, b.guest_timezone, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), et.location_value, b.cancel_token, b.uid
+        let due: Vec<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>, Option<String>)> = sqlx::query_as(
+            "SELECT b.id, b.guest_name, b.guest_email, b.guest_timezone, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), et.location_value, b.cancel_token, b.uid, b.language, u.language
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -202,6 +202,8 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
             location_value,
             cancel_token,
             uid,
+            guest_language,
+            host_language,
         ) in &due
         {
             let date = start_at.get(..10).unwrap_or(start_at).to_string();
@@ -225,7 +227,8 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
                 location,
                 reminder_minutes: None,
                 additional_attendees: vec![],
-                ..Default::default()
+                guest_language: guest_language.clone(),
+                host_language: host_language.clone(),
             };
 
             let guest_cancel_url = cancel_token.as_ref().and_then(|t| {
@@ -7271,8 +7274,8 @@ async fn handle_group_booking(
     }
 
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, assigned_user_id, confirm_token)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, assigned_user_id, confirm_token, language)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -7288,6 +7291,7 @@ async fn handle_group_booking(
     .bind(&reschedule_token)
     .bind(&assigned_user_id)
     .bind(&confirm_token)
+    .bind(lang)
     .execute(&mut *tx)
     .await;
 
@@ -7358,6 +7362,7 @@ async fn handle_group_booking(
             location: location_display,
             reminder_minutes: reminder_min,
             additional_attendees: additional_attendees.clone(),
+            guest_language: Some(lang.to_string()),
             ..Default::default()
         };
 
@@ -8013,8 +8018,8 @@ async fn handle_dynamic_group_booking(
     };
 
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -8029,6 +8034,7 @@ async fn handle_dynamic_group_booking(
     .bind(&cancel_token)
     .bind(&reschedule_token)
     .bind(&confirm_token)
+    .bind(lang)
     .execute(&mut *tx)
     .await;
 
@@ -8107,6 +8113,7 @@ async fn handle_dynamic_group_booking(
             location: location_display,
             reminder_minutes: reminder_min,
             additional_attendees: all_additional.clone(),
+            guest_language: Some(lang.to_string()),
             ..Default::default()
         };
 
@@ -8712,8 +8719,8 @@ async fn handle_booking_for_user(
     }
 
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -8728,6 +8735,7 @@ async fn handle_booking_for_user(
     .bind(&cancel_token)
     .bind(&reschedule_token)
     .bind(&confirm_token)
+    .bind(lang)
     .execute(&mut *tx)
     .await;
 
@@ -8807,6 +8815,7 @@ async fn handle_booking_for_user(
                 location: location_display,
                 reminder_minutes: reminder_min,
                 additional_attendees: additional_attendees.clone(),
+                guest_language: Some(lang.to_string()),
                 ..Default::default()
             };
 
@@ -10481,8 +10490,8 @@ async fn handle_booking(
     }
 
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -10497,6 +10506,7 @@ async fn handle_booking(
     .bind(&cancel_token)
     .bind(&reschedule_token)
     .bind(&confirm_token)
+    .bind(lang)
     .execute(&mut *tx)
     .await;
 
@@ -10560,6 +10570,7 @@ async fn handle_booking(
                 location: None,
                 reminder_minutes: reminder_min,
                 additional_attendees: additional_attendees.clone(),
+                guest_language: Some(lang.to_string()),
                 ..Default::default()
             };
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -12481,6 +12481,9 @@ async fn guest_cancel_booking(
             uid,
             reason: reason.clone(),
             cancelled_by_host: false,
+            // Guest is the one cancelling; their browser language now is the
+            // best signal we have (they chose this language to view the form).
+            guest_language: Some(lang.to_string()),
             ..Default::default()
         };
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -225,6 +225,7 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
                 location,
                 reminder_minutes: None,
                 additional_attendees: vec![],
+                ..Default::default()
             };
 
             let guest_cancel_url = cancel_token.as_ref().and_then(|t| {
@@ -3167,6 +3168,7 @@ async fn cancel_booking(
             uid,
             reason,
             cancelled_by_host: true,
+            ..Default::default()
         };
 
         if was_pending {
@@ -3256,6 +3258,7 @@ async fn confirm_booking(
         location: location_value,
         reminder_minutes: None,
         additional_attendees: vec![],
+        ..Default::default()
     };
 
     // Push to CalDAV calendar
@@ -7355,6 +7358,7 @@ async fn handle_group_booking(
             location: location_display,
             reminder_minutes: reminder_min,
             additional_attendees: additional_attendees.clone(),
+            ..Default::default()
         };
 
         let base_url = std::env::var("CALRS_BASE_URL").ok();
@@ -8103,6 +8107,7 @@ async fn handle_dynamic_group_booking(
             location: location_display,
             reminder_minutes: reminder_min,
             additional_attendees: all_additional.clone(),
+            ..Default::default()
         };
 
         let base_url = std::env::var("CALRS_BASE_URL").ok();
@@ -8802,6 +8807,7 @@ async fn handle_booking_for_user(
                 location: location_display,
                 reminder_minutes: reminder_min,
                 additional_attendees: additional_attendees.clone(),
+                ..Default::default()
             };
 
             let base_url = std::env::var("CALRS_BASE_URL").ok();
@@ -10554,6 +10560,7 @@ async fn handle_booking(
                 location: None,
                 reminder_minutes: reminder_min,
                 additional_attendees: additional_attendees.clone(),
+                ..Default::default()
             };
 
             let base_url = std::env::var("CALRS_BASE_URL").ok();
@@ -12036,6 +12043,7 @@ async fn approve_booking_by_token(
         location: location_value,
         reminder_minutes: None,
         additional_attendees: vec![],
+        ..Default::default()
     };
 
     // Push to CalDAV calendar
@@ -12250,6 +12258,7 @@ async fn decline_booking_by_token(
             uid: String::new(),
             reason: reason.clone(),
             cancelled_by_host: true,
+            ..Default::default()
         };
         let _ = crate::email::send_guest_decline_notice(&smtp_config, &details).await;
     }
@@ -12461,6 +12470,7 @@ async fn guest_cancel_booking(
             uid,
             reason: reason.clone(),
             cancelled_by_host: false,
+            ..Default::default()
         };
 
         let _ = crate::email::send_guest_cancellation(&smtp_config, &details).await;
@@ -13036,6 +13046,7 @@ async fn guest_reschedule_booking(
                 location: loc_value,
                 reminder_minutes: None,
                 additional_attendees: vec![],
+                ..Default::default()
             };
             let _ = crate::email::send_guest_pending_notice_ex(
                 &smtp_config,
@@ -13063,6 +13074,7 @@ async fn guest_reschedule_booking(
             location: loc_value.clone(),
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
         caldav_push_booking(
             &state.pool,
@@ -13300,6 +13312,7 @@ async fn host_reschedule_booking(
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            ..Default::default()
         };
 
         if let Some(url) = &reschedule_url {
@@ -13921,6 +13934,7 @@ async fn claim_booking(
         location,
         reminder_minutes: None,
         additional_attendees: vec![claimant_email.clone()],
+        ..Default::default()
     };
 
     // Also include any pre-existing additional attendees

--- a/templates/slots.html
+++ b/templates/slots.html
@@ -176,6 +176,11 @@
   .cal-header-title {
     font-size: 1rem;
     font-weight: 700;
+    /* Title-case the standalone month/week label. Lets locales like French
+       store grammatically-correct lowercase ("avril") while still rendering
+       a typographic header ("Avril 2026"). Mid-sentence date labels are
+       unaffected, they live in different elements. */
+    text-transform: capitalize;
   }
   .cal-header-title span {
     font-weight: 400;


### PR DESCRIPTION
Continues the i18n work. Previous PRs covered the public-facing booking flow templates; this PR extends translation to the highest-volume guest emails.

## What ships in this PR

### Foundation
- **Migration 048**: \`ALTER TABLE bookings ADD language TEXT\`. Captured at booking-create time from the guest's Accept-Language so emails sent days later still know which language to use.
- **BookingDetails** and **CancellationDetails** gain \`guest_language\` and \`host_language\` fields (both \`Option<String>\`, None means English fallback). Both structs now derive \`Default\` so existing call sites use \`..Default::default()\` instead of being forced to fill the new fields.
- **EmailRow.label** is now \`String\` instead of \`&'static str\` so labels can be translated. All 152 \`EmailRow\` constructions updated to call \`.to_string()\` on their literals.

### Language capture
- All four production \`INSERT INTO bookings\` sites now bind \`lang\` to the new column (group, dynamic-group, user-scoped, legacy single-tenant booking handlers).
- The four corresponding \`BookingDetails\` constructions populate \`guest_language: Some(lang.to_string())\`.
- The reminder background task SELECT pulls both \`b.language\` and \`u.language\` from the existing JOIN, populating both fields on the booking details so a reminder fired days after the booking still picks the right language for guest and host.
- \`guest_cancel_booking\` now sets \`guest_language\` on its \`CancellationDetails\`.

### Email translation (option B: direct \`crate::i18n::translate()\`)
Three guest-facing emails translated:
- \`send_guest_confirmation_ex\`: subject, greeting, headline, all row labels (reuses existing \`confirmed-detail-*\` keys), "calendar invite attached" notice, "Need to cancel?" hint, Reschedule/Cancel action button labels, signature.
- \`send_guest_reminder\`: subject, greeting, headline, row labels, cancel hint, cancel action, signature.
- \`send_guest_cancellation\`: subject, greeting, two-variant headline (cancelled by host vs by guest), row labels, reason line, "calendar cancellation attached" notice, signature.

Two helpers in \`email.rs\` keep call sites tight:
\`\`\`rust
fn t(lang: &str, key: &str) -> String;
fn ta::<const N: usize>(lang: &str, key: &str, args: [(&str, &str); N]) -> String;
\`\`\`

### .ftl additions
- \`en/main.ftl\`: 19 new keys (subjects, greetings, headlines, action labels, ICS-attached notices, signature, attendee variants, cancel-by-host/by-guest variants).
- \`fr/main.ftl\`: same 19 keys translated.
- ES and PL fall through to English at runtime, awaiting community translation on Weblate.

## Out of scope (deliberate, deferred)

These are the next follow-ups; flagging them in the PR body so it's clear what's still untranslated:

1. **Host-side emails**: \`send_host_notification\`, \`send_host_reminder\`, \`send_host_cancellation\`, \`send_host_approval_request\`. \`host_language\` is captured for the reminder path but no host email body is translated yet.
2. **Pending / decline / reschedule emails**: \`send_guest_pending_notice_ex\`, \`send_guest_decline_notice\`, \`send_guest_reschedule_notification\`, \`send_guest_pick_new_time\`.
3. **Additional-attendee block** inside \`send_guest_confirmation_ex\`.
4. **decline_booking_by_token** and **dashboard-host-cancel** paths don't yet load \`bookings.language\`, so the resulting guest-facing emails go out in English. Easy follow-up: extend their SELECTs.
5. **Watcher claim emails** and other lower-volume types.

## Numbers

- 4 commits, ~330 net lines added
- All 563 tests passing, \`cargo fmt\` and \`cargo clippy -D warnings\` clean
- Migration count assertions bumped from 47 to 48

## Branch handling

Continues to ship from the long-lived \`i18n\` branch. **Do not delete the branch on merge.** (Per CLAUDE.md.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)