### PR TITLE
fix(event-types): respect user's profile default availability

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -18595,6 +18595,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_event_type_with_empty_schedule_uses_user_default() {
+        // Regression test for #68: when the event-type edit form is submitted
+        // with an empty avail_schedule, the resulting availability_rules must
+        // come from the user's profile-default schedule, not a hardcoded
+        // Mon-Fri 09:00-17:00 fallback. Locks in the behaviour wired through
+        // update_event_type so a future refactor can't silently regress it.
+        let (app, pool, session, _) = setup_test_app().await;
+
+        // Seed the test user's profile default with something distinctive
+        // (Tue+Thu 14:00-18:00) so we can tell it apart from the legacy
+        // hardcoded Mon-Fri 09:00-17:00 fallback.
+        let user_id: String =
+            sqlx::query_scalar("SELECT id FROM users WHERE username = 'testuser'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        sqlx::query("DELETE FROM user_availability_rules WHERE user_id = ?")
+            .bind(&user_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        for day in [2_i32, 4] {
+            sqlx::query(
+                "INSERT INTO user_availability_rules (id, user_id, day_of_week, start_time, end_time) VALUES (?, ?, ?, '14:00', '18:00')",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&user_id)
+            .bind(day)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let csrf = "test-csrf-empty-schedule";
+        // Submit with avail_schedule explicitly empty (matches what the form
+        // sends when all days are unchecked) and no legacy fields.
+        let body = format!(
+            "_csrf={}&title=Test+Meeting&slug=test-meeting&duration_min=30&location_value=https%3A%2F%2Fmeet.example.com&avail_schedule=",
+            csrf
+        );
+        let response = app
+            .oneshot(post_form(
+                "/dashboard/event-types/test-meeting/edit",
+                &session,
+                csrf,
+                &body,
+            ))
+            .await
+            .unwrap();
+        assert!(response.status().is_redirection() || response.status() == 200);
+
+        // Inspect the persisted availability_rules. Expect Tue+Thu 14:00-18:00
+        // (the user's profile default), not Mon-Fri 09:00-17:00.
+        let rules: Vec<(i32, String, String)> = sqlx::query_as(
+            "SELECT day_of_week, start_time, end_time FROM availability_rules \
+             WHERE event_type_id = (SELECT id FROM event_types WHERE slug = 'test-meeting') \
+             ORDER BY day_of_week, start_time",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            rules,
+            vec![
+                (2, "14:00".to_string(), "18:00".to_string()),
+                (4, "14:00".to_string(), "18:00".to_string()),
+            ],
+            "empty avail_schedule submission must fall back to the user's profile default, not the hardcoded Mon-Fri 09:00-17:00",
+        );
+    }
+
+    #[tokio::test]
     async fn update_group_event_type_persists_location() {
         let (app, pool, session, _) = setup_test_app().await;
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -396,63 +396,80 @@ fn parse_avail_windows(
     )]
 }
 
+/// Parse a single schedule string in the new format.
+/// Format: "1:09:00-17:00;2:09:00-12:00,13:00-17:00" (day:windows;day:windows)
+fn parse_schedule_string(s: &str) -> std::collections::BTreeMap<i32, Vec<(String, String)>> {
+    let mut result = std::collections::BTreeMap::new();
+    let s = s.trim();
+    if s.is_empty() {
+        return result;
+    }
+    for segment in s.split(';') {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = segment.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            continue;
+        }
+        let day: i32 = match parts[0].trim().parse() {
+            Ok(d) if (0..=6).contains(&d) => d,
+            _ => continue,
+        };
+        let windows: Vec<(String, String)> = parts[1]
+            .split(',')
+            .filter_map(|w| {
+                let times: Vec<&str> = w.trim().split('-').collect();
+                if times.len() == 2 {
+                    let s = times[0].trim().to_string();
+                    let e = times[1].trim().to_string();
+                    if !s.is_empty() && !e.is_empty() {
+                        Some((s, e))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !windows.is_empty() {
+            result.insert(day, windows);
+        }
+    }
+    result
+}
+
 /// Parse per-day availability schedule.
-/// New format: "1:09:00-17:00;2:09:00-12:00,13:00-17:00" (day:windows;day:windows)
-/// Falls back to legacy format (avail_days + avail_windows/avail_start/avail_end).
+/// Resolution order: submitted `schedule` (new format) → `user_default` (new format,
+/// e.g. the user's profile default availability) → legacy form fields → hardcoded
+/// Mon–Fri 09:00–17:00. The `user_default` step is what stops an empty submission
+/// from silently snapping back to the hardcoded default.
 fn parse_avail_schedule(
     schedule: Option<&str>,
     legacy_days: Option<&str>,
     legacy_windows: Option<&str>,
     legacy_start: Option<&str>,
     legacy_end: Option<&str>,
+    user_default: Option<&str>,
 ) -> std::collections::BTreeMap<i32, Vec<(String, String)>> {
-    let mut result = std::collections::BTreeMap::new();
-
-    // Try new format first
     if let Some(s) = schedule {
-        let s = s.trim();
-        if !s.is_empty() {
-            for segment in s.split(';') {
-                let segment = segment.trim();
-                if segment.is_empty() {
-                    continue;
-                }
-                let parts: Vec<&str> = segment.splitn(2, ':').collect();
-                if parts.len() != 2 {
-                    continue;
-                }
-                let day: i32 = match parts[0].trim().parse() {
-                    Ok(d) if (0..=6).contains(&d) => d,
-                    _ => continue,
-                };
-                let windows: Vec<(String, String)> = parts[1]
-                    .split(',')
-                    .filter_map(|w| {
-                        let times: Vec<&str> = w.trim().split('-').collect();
-                        if times.len() == 2 {
-                            let s = times[0].trim().to_string();
-                            let e = times[1].trim().to_string();
-                            if !s.is_empty() && !e.is_empty() {
-                                Some((s, e))
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                if !windows.is_empty() {
-                    result.insert(day, windows);
-                }
-            }
-            if !result.is_empty() {
-                return result;
-            }
+        let parsed = parse_schedule_string(s);
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+
+    if let Some(s) = user_default {
+        let parsed = parse_schedule_string(s);
+        if !parsed.is_empty() {
+            return parsed;
         }
     }
 
     // Fall back to legacy format
+    let mut result = std::collections::BTreeMap::new();
     let days_str = legacy_days.unwrap_or("1,2,3,4,5");
     let windows = parse_avail_windows(legacy_windows, legacy_start, legacy_end);
     for day_str in days_str.split(',') {
@@ -530,6 +547,10 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/", get(root_redirect))
         .route("/dashboard", get(dashboard))
         .route("/dashboard/event-types", get(dashboard_event_types))
+        .route(
+            "/dashboard/availability/default",
+            get(dashboard_availability_default),
+        )
         .route("/dashboard/bookings", get(dashboard_bookings))
         .route("/dashboard/teams", get(dashboard_teams))
         .route(
@@ -2084,6 +2105,17 @@ async fn ensure_user_avail_seeded(pool: &SqlitePool, user_id: &str) {
         .execute(pool)
         .await;
     }
+}
+
+/// Returns the authenticated user's profile-default availability schedule
+/// as JSON. Used by the event-type form's "Reset to my default" button.
+async fn dashboard_availability_default(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::auth::AuthUser,
+) -> impl IntoResponse {
+    ensure_user_avail_seeded(&state.pool, &auth_user.user.id).await;
+    let schedule = load_user_avail_schedule(&state.pool, &auth_user.user.id).await;
+    axum::Json(serde_json::json!({ "schedule": schedule }))
 }
 
 fn settings_render(
@@ -3656,13 +3688,18 @@ async fn create_event_type(
 
     tracing::info!(slug = %slug, user = %auth_user.user.email, "event type created");
 
-    // Create availability rules
+    // Create availability rules. Pass the user's profile-default schedule as a
+    // fallback so an empty submission falls back to it instead of hardcoded
+    // Mon-Fri 09:00-17:00.
+    ensure_user_avail_seeded(&state.pool, &auth_user.user.id).await;
+    let user_default = load_user_avail_schedule(&state.pool, &auth_user.user.id).await;
     let schedule = parse_avail_schedule(
         form.avail_schedule.as_deref(),
         form.avail_days.as_deref(),
         form.avail_windows.as_deref(),
         form.avail_start.as_deref(),
         form.avail_end.as_deref(),
+        Some(&user_default),
     );
 
     for (day, windows) in &schedule {
@@ -4139,18 +4176,23 @@ async fn update_event_type(
     .execute(&state.pool)
     .await;
 
-    // Update availability rules: delete old, insert new
+    // Update availability rules: delete old, insert new. Pass the user's
+    // profile-default schedule as a fallback so an empty submission falls back
+    // to it instead of hardcoded Mon-Fri 09:00-17:00.
     let _ = sqlx::query("DELETE FROM availability_rules WHERE event_type_id = ?")
         .bind(&et_id)
         .execute(&state.pool)
         .await;
 
+    ensure_user_avail_seeded(&state.pool, &auth_user.user.id).await;
+    let user_default = load_user_avail_schedule(&state.pool, &auth_user.user.id).await;
     let schedule = parse_avail_schedule(
         form.avail_schedule.as_deref(),
         form.avail_days.as_deref(),
         form.avail_windows.as_deref(),
         form.avail_start.as_deref(),
         form.avail_end.as_deref(),
+        Some(&user_default),
     );
 
     for (day, windows) in &schedule {
@@ -5999,13 +6041,18 @@ async fn create_group_event_type(
     .execute(&state.pool)
     .await;
 
-    // Create availability rules
+    // Create availability rules. Pass the creating user's profile-default
+    // schedule as a fallback so an empty submission falls back to it instead
+    // of hardcoded Mon-Fri 09:00-17:00.
+    ensure_user_avail_seeded(&state.pool, &user.id).await;
+    let user_default = load_user_avail_schedule(&state.pool, &user.id).await;
     let schedule = parse_avail_schedule(
         form.avail_schedule.as_deref(),
         form.avail_days.as_deref(),
         form.avail_windows.as_deref(),
         form.avail_start.as_deref(),
         form.avail_end.as_deref(),
+        Some(&user_default),
     );
 
     for (day, windows) in &schedule {
@@ -6441,18 +6488,23 @@ async fn update_group_event_type(
     .execute(&state.pool)
     .await;
 
-    // Update availability rules
+    // Update availability rules. Pass the editing user's profile-default
+    // schedule as a fallback so an empty submission falls back to it instead
+    // of hardcoded Mon-Fri 09:00-17:00.
     let _ = sqlx::query("DELETE FROM availability_rules WHERE event_type_id = ?")
         .bind(&et_id)
         .execute(&state.pool)
         .await;
 
+    ensure_user_avail_seeded(&state.pool, &user.id).await;
+    let user_default = load_user_avail_schedule(&state.pool, &user.id).await;
     let schedule = parse_avail_schedule(
         form.avail_schedule.as_deref(),
         form.avail_days.as_deref(),
         form.avail_windows.as_deref(),
         form.avail_start.as_deref(),
         form.avail_end.as_deref(),
+        Some(&user_default),
     );
 
     for (day, windows) in &schedule {
@@ -14235,6 +14287,43 @@ mod tests {
     }
 
     // --- parse_datetime tests ---
+
+    #[test]
+    fn parse_avail_schedule_uses_user_default_when_submitted_is_empty() {
+        // Empty submission + user default "Tue 14:00-18:00" → returns the user default
+        // instead of falling back to the hardcoded Mon-Fri 09:00-17:00.
+        let result = parse_avail_schedule(Some(""), None, None, None, None, Some("2:14:00-18:00"));
+        assert_eq!(result.len(), 1);
+        let windows = result.get(&2).expect("Tuesday should be set");
+        assert_eq!(windows, &vec![("14:00".to_string(), "18:00".to_string())]);
+    }
+
+    #[test]
+    fn parse_avail_schedule_prefers_submitted_over_user_default() {
+        // A populated submission overrides the user default.
+        let result = parse_avail_schedule(
+            Some("3:10:00-12:00"),
+            None,
+            None,
+            None,
+            None,
+            Some("2:14:00-18:00"),
+        );
+        assert_eq!(result.len(), 1);
+        let windows = result.get(&3).expect("Wednesday should be set");
+        assert_eq!(windows, &vec![("10:00".to_string(), "12:00".to_string())]);
+    }
+
+    #[test]
+    fn parse_avail_schedule_falls_back_to_legacy_when_both_empty() {
+        // Empty submission and empty user default → hardcoded Mon-Fri 09:00-17:00.
+        let result = parse_avail_schedule(Some(""), None, None, None, None, Some(""));
+        assert_eq!(result.len(), 5);
+        for day in 1..=5 {
+            let windows = result.get(&day).expect("weekday should be set");
+            assert_eq!(windows, &vec![("09:00".to_string(), "17:00".to_string())]);
+        }
+    }
 
     #[test]
     fn parse_datetime_compact_format() {

--- a/templates/event_type_form.html
+++ b/templates/event_type_form.html
@@ -250,7 +250,8 @@
       <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">The hours below are interpreted in this timezone. For team event types, pick the team's working timezone (not necessarily the creator's).</span>
     </div>
     <div id="schedule-container" style="display: flex; flex-direction: column; gap: 0.25rem;"></div>
-    <div style="display: flex; justify-content: flex-end; margin-top: 0.5rem;">
+    <div style="display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 0.5rem;">
+      <button type="button" id="reset-to-default-btn" style="padding: 0.25rem 0.625rem; border: 1px solid var(--border); border-radius: var(--radius); background: transparent; color: var(--text-muted); cursor: pointer; font-size: 0.75rem; transition: all 0.15s ease;" title="Replace these hours with your profile-default availability">Reset to my default</button>
       <button type="button" id="copy-to-all-btn" style="padding: 0.25rem 0.625rem; border: 1px solid var(--border); border-radius: var(--radius); background: transparent; color: var(--text-muted); cursor: pointer; font-size: 0.75rem; transition: all 0.15s ease;" title="Copy the first enabled day's windows to all other enabled days">Copy to all days</button>
     </div>
     <input type="hidden" name="avail_schedule" id="avail_schedule" value="{{ form_avail_schedule | default(value='') }}">
@@ -1098,6 +1099,43 @@
       btn.style.color = 'var(--success)';
       btn.style.borderColor = 'var(--success)';
       setTimeout(function() { btn.textContent = 'Copy to all days'; btn.style.color = ''; btn.style.borderColor = ''; }, 1500);
+    });
+
+    // "Reset to my default" button: fetch the user's profile-default
+    // availability and rehydrate the editor from it.
+    document.getElementById('reset-to-default-btn').addEventListener('click', function() {
+      var btn = this;
+      var original = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Loading...';
+      fetch('/dashboard/availability/default', { headers: { 'Accept': 'application/json' } })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          var parsed = parseSchedule(data.schedule || '');
+          // Empty profile schedule means the user has no defaults; treat
+          // that as a no-op to avoid wiping the form silently.
+          if (!Object.keys(parsed).length) {
+            btn.textContent = 'No default set';
+            setTimeout(function() { btn.textContent = original; btn.disabled = false; }, 1500);
+            return;
+          }
+          schedule = parsed;
+          renderSchedule();
+          serializeSchedule();
+          btn.textContent = 'Reset!';
+          btn.style.color = 'var(--success)';
+          btn.style.borderColor = 'var(--success)';
+          setTimeout(function() {
+            btn.textContent = original;
+            btn.style.color = '';
+            btn.style.borderColor = '';
+            btn.disabled = false;
+          }, 1500);
+        })
+        .catch(function() {
+          btn.textContent = 'Error';
+          setTimeout(function() { btn.textContent = original; btn.disabled = false; }, 1500);
+        });
     });
 
     // Initialize from saved schedule or legacy format


### PR DESCRIPTION
## Summary

Closes #68. Two related gaps in the event-type availability editor:

1. **Empty save silently snapped back to a hardcoded Mon-Fri 09:00-17:00 default**, ignoring the user's profile-level \`user_availability_rules\`. Users who customized their profile default would still see the hardcoded fallback after unchecking all days on an event type.
2. **No way to re-sync a divergent event-type schedule to the user's current profile default** without manually re-entering every weekly window.

(Note: part 3 from the original issue — pre-fill the *creation* form from \`user_availability_rules\` — was already implemented at \`new_event_type_form\` and \`new_group_event_type_form\`. Verified in passing while implementing this PR; left as-is.)

## Changes

**Backend:**
- \`parse_avail_schedule\` refactored: extracted \`parse_schedule_string\` helper, added a \`user_default: Option<&str>\` parameter consulted before the legacy hardcoded fallback. New resolution order: submitted → user default → legacy hardcoded.
- All four save paths (\`create_event_type\`, \`update_event_type\`, \`create_group_event_type\`, \`update_group_event_type\`) load the user's profile default via the existing \`load_user_avail_schedule\` (calling \`ensure_user_avail_seeded\` first so first-time users get the seeded Mon-Fri 9-17 in their profile rather than as a silent magic value).
- New endpoint \`GET /dashboard/availability/default\` returns the user's profile-default schedule as JSON \`{"schedule": "..."}\`. Used by the new button.

**Frontend:**
- New **"Reset to my default"** button next to "Copy to all days" in the availability section of \`event_type_form.html\`.
- JS fetches \`/dashboard/availability/default\`, calls the existing \`parseSchedule\` to convert the response to the editor's internal shape, then re-renders. If the user has no profile default (empty schedule), the button shows "No default set" instead of silently wiping the form.

**Tests:**
- 3 new unit tests on \`parse_avail_schedule\` covering the three resolution branches: submitted-overrides-default, default-fills-empty-submission, both-empty-falls-through-to-legacy.
- Total tests: 578 (up from 575). All green on pre-commit.

## Test plan

- [ ] Set profile default availability to something distinctive (e.g. Tue+Thu 14:00-18:00). Edit an existing event type, uncheck all days, save → event type now has Tue+Thu 14:00-18:00 (not Mon-Fri 9-17).
- [ ] Same setup. Edit a different event type that has a snapshot, click **Reset to my default** → editor shows Tue+Thu 14:00-18:00 without saving. Save to persist.
- [ ] Brand-new account, no profile default seeded, click **Reset to my default** → button shows "No default set" briefly, form is unchanged.
- [ ] Existing test suite passes (verified locally).

## Verification gap I'm flagging

I have not driven the new button in a real browser. The JS pattern (fetch + parseSchedule + renderSchedule) reuses functions that already work in this template, but the integration is not browser-tested. The Test plan above is the manual checklist for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)