### PR TITLE
fix(caldav): fall back to PROPFIND when OPTIONS doesn't advertise calendar-access

### DIFF
--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -142,7 +142,15 @@ impl CaldavClient {
         Ok(resp.text().await?)
     }
 
-    /// Check if the server supports CalDAV (OPTIONS request)
+    /// Check if the server supports CalDAV.
+    ///
+    /// Two-step probe: a fast `OPTIONS` request looking for `calendar-access`
+    /// in the `DAV` response header, then if that doesn't match, a PROPFIND
+    /// for the current-user principal. Some servers (notably SOGo on its
+    /// `/SOGo/dav/` root) don't advertise `calendar-access` in OPTIONS even
+    /// though they are CalDAV-capable, so the OPTIONS-only check produced
+    /// false negatives. A successful principal PROPFIND is unambiguous proof
+    /// that the server speaks CalDAV.
     pub async fn check_connection(&self) -> Result<bool> {
         let resp = self
             .client
@@ -165,9 +173,17 @@ impl CaldavClient {
             .map(|v| v.to_str().unwrap_or(""))
             .unwrap_or("");
 
-        Ok(dav_header.contains("calendar-access")
+        if dav_header.contains("calendar-access")
             || dav_header.contains("nc-calendar-search")
-            || dav_header.contains("nc-enable-birthday-calendar"))
+            || dav_header.contains("nc-enable-birthday-calendar")
+        {
+            return Ok(true);
+        }
+
+        // OPTIONS came back clean but didn't advertise CalDAV. Try the
+        // PROPFIND probe; if it returns a principal href, the server speaks
+        // CalDAV regardless of what the OPTIONS header said.
+        Ok(self.discover_principal().await.is_ok())
     }
 
     /// Discover the current-user-principal URL via PROPFIND


### PR DESCRIPTION
## Summary

The "Test connection" action on a CalDAV source was reporting `'X' — connected but CalDAV not explicitly detected. Sync may still work.` against fully working SOGo instances, even though sync (which uses a separate code path) worked fine. The probe was OPTIONS-only and looked for `calendar-access` in the `DAV` response header. SOGo at its `/SOGo/dav/` root returns `dav: 1,2` without the `calendar-access` token, so the probe produced false negatives.

This change adds a PROPFIND fallback after a clean-but-not-CalDAV-tagged OPTIONS response: if the server responds to a PROPFIND for `current-user-principal` with a valid principal href, the answer is unambiguous — it speaks CalDAV, regardless of what the OPTIONS DAV header advertised. This is the same code path the actual sync flow uses, so a positive answer also predicts the rest of the sync pipeline.

Strict improvement: anything that resolved as "supported" before still does; only the previously-misleading "not detected" branch gets the second chance.

## Verification against a real SOGo instance

Confirmed empirically against a live SOGo install:

| Step | Response |
|---|---|
| `OPTIONS https://sogo.example/SOGo/` | `200`, `dav: 1,2` (no `calendar-access`) — old code returns `Ok(false)` |
| `PROPFIND https://sogo.example/SOGo/` for `current-user-principal` | `207`, `<D:current-user-principal><D:href>/SOGo/dav/<user>/</D:href></D:current-user-principal>` — `discover_principal()` returns `Ok(href)` |
| In-app message after the patch | `'SOGo' — connection OK, CalDAV supported.` (confirmed by the reporter) |

## What it doesn't change

- The OPTIONS path still wins fast for servers that advertise `calendar-access` correctly (Nextcloud, BlueMind, Fastmail, iCloud, etc.).
- No changes to the discovery flow itself — only the test-connection probe consults it.
- Returns `Ok(false)` (the "not detected" warning) only if **both** OPTIONS lacks the marker **and** PROPFIND fails to return a principal href. That's a much stronger signal than the old behaviour.

## Test plan

- [x] OPTIONS+PROPFIND empirical check against real SOGo (via curl)
- [x] In-app message flips from "not explicitly detected" to "CalDAV supported" after the patch (confirmed by reporter)
- [x] Existing 579 tests still pass
- [x] Clippy clean

## Verification gap I'm flagging

No HTTP-mock unit test added. The codebase doesn't currently have HTTP mocking infrastructure (no \`mockito\`/\`wiremock\`/\`httpmock\` dep), and adding one for a 5-line behavioural fall-through felt heavier than the change itself. The live SOGo verification above is the real test. Happy to add a proper mocked test in a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)