### PR TITLE
Fix(auth): prevent user enumeration via login timing oracle

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -41,6 +41,10 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
         .is_ok()
 }
 
+// Pre-computed Argon2id hash used as a timing dummy when no user is found,
+// preventing user enumeration via response-time differences.
+const DUMMY_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
 // --- Session management ---
 
 fn generate_session_token() -> String {
@@ -538,7 +542,7 @@ async fn login_handler(
         return render_login_error(&state, "Too many login attempts. Please try again later.");
     }
 
-    let user = sqlx::query_as::<_, User>(
+    let user_row = sqlx::query_as::<_, User>(
         "SELECT * FROM users WHERE email = ? AND auth_provider = 'local' AND enabled = 1",
     )
     .bind(&form.email)
@@ -546,26 +550,21 @@ async fn login_handler(
     .await
     .unwrap_or(None);
 
-    let user = match user {
-        Some(u) => u,
-        None => {
+    // Always run Argon2 regardless of whether the user exists to prevent
+    // user enumeration via response-time differences (timing oracle).
+    let hash_to_check = user_row
+        .as_ref()
+        .and_then(|u| u.password_hash.as_deref())
+        .unwrap_or(DUMMY_HASH);
+    let password_ok = verify_password(&form.password, hash_to_check);
+
+    let user = match user_row {
+        Some(u) if password_ok => u,
+        _ => {
             tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
             return render_login_error(&state, "Invalid email or password");
         }
     };
-
-    let password_hash = match &user.password_hash {
-        Some(h) => h,
-        None => {
-            tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
-            return render_login_error(&state, "Invalid email or password");
-        }
-    };
-
-    if !verify_password(&form.password, password_hash) {
-        tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
-        return render_login_error(&state, "Invalid email or password");
-    }
 
     let session = match create_session(&state.pool, &user.id).await {
         Ok(s) => s,


### PR DESCRIPTION
Hi again, `calrs` team!

Thanks for looking into my previous PR!
I have finally gotten around to making another round of security auditing with Claude.
This round seems to have found fewer "high" security risks.

This PR in particular mitigates the highest security risk Claude identified (and fixed).

When at login, we want a bad actor "making up" credentials not to know whether the username was wrong OR the password was wrong.
However, currently, if the username is wrong, the result is returned immediately, vs if the password is wrong, the result is returned after a moment, the time necessary to run Argon2. This difference allows the attacker to tell the two scenarios apart.

This fix basically always runs Argon2 regardless, using a dummy hash if the user was not found in the DB.

---

The *medium* issues Claude found are these:
* Use of `thread_rng` instead of `OsRng`; Claude claims that OsRng is the appropriate standard, as the other lives in userspace.
* The time between the check for any registered user and the time of storing the new first-admin account, allows multiple admin accounts to be created.
* > The CSRF token verification uses standard string equality, which is not guaranteed to be constant-time. This creates a theoretical timing oracle for CSRF token forgery.
* The rate-limiter uses the first IP in `X-Forwarded-For`, but it should use the "rightmost non-trusted IP" instead, as that's not spoofable.
* > Raw database errors, template rendering errors, and OIDC token exchange errors are returned directly to HTTP clients
* The admin-configurable `company_link` can be maliciously set to `javascript:` - the schema should be checked to be `http`/`https`.
* The OICD `client_secret` is stored in plaintext.

For the full list plus more details and suggested remediations, I am attaching the full report: 
[SECURITY-REPORT.md](https://github.com/user-attachments/files/27326622/SECURITY-REPORT.md)
