### PR TITLE
fix(auth): use OsRng for session token generation

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use argon2::password_hash::rand_core::OsRng;
 use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
 use axum::extract::{Form, FromRequestParts, State};
@@ -9,6 +8,7 @@ use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum_extra::extract::CookieJar;
 use base64::Engine;
 use chrono::{Duration, Utc};
+use rand::rngs::OsRng;
 use rand::RngCore;
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -1653,6 +1653,17 @@ mod tests {
         let password = "a".repeat(1000);
         let hash = hash_password(&password).unwrap();
         assert!(verify_password(&password, &hash));
+    }
+
+    // --- generate_session_token ---
+
+    #[test]
+    fn session_tokens_are_64_hex_chars_and_unique() {
+        let a = generate_session_token();
+        let b = generate_session_token();
+        assert_eq!(a.len(), 64, "32 bytes hex-encoded should be 64 chars");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "two consecutive tokens must not collide");
     }
 
     // --- extract_claims_from_id_token (title) ---

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -9,7 +9,7 @@ use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum_extra::extract::CookieJar;
 use base64::Engine;
 use chrono::{Duration, Utc};
-use rand::Rng;
+use rand::RngCore;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
@@ -48,8 +48,10 @@ const DUMMY_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAAAAA$
 // --- Session management ---
 
 fn generate_session_token() -> String {
-    let mut rng = rand::thread_rng();
-    let bytes: [u8; 32] = rng.gen();
+    // Use OsRng (kernel CSPRNG) directly rather than thread_rng (userspace
+    // ChaCha12). 30-day session tokens warrant the strongest entropy source.
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
     hex::encode(bytes)
 }
 


### PR DESCRIPTION
## Summary
- Switch `generate_session_token()` from `rand::thread_rng()` (userspace ChaCha12) to `rand::rngs::OsRng` (kernel CSPRNG via `getrandom`).
- Matches what `src/crypto.rs` already uses for AES-GCM key and nonce generation.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (589 passing, including all 68 auth tests)
- [x] Reviewer: confirm session login still issues a fresh, hex-encoded 32-byte token

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)