### PR TITLE
fix(admin): reject non-http(s) schemes for company_link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +413,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "iana-time-zone",
+ "ldap3",
  "lettre",
  "minijinja",
  "openidconnect",
@@ -696,6 +736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +750,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -968,7 +1028,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -990,6 +1050,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1037,6 +1112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,8 +1140,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1662,7 +1750,44 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "lber"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df7f9fd9f64cf8f59e1a4a0753fe7d575a5b38d3d7ac5758dcee9357d83ef0a"
+dependencies = [
+ "bytes",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "ldap3"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166199a8207874a275144c8a94ff6eed5fcbf5c52303e4d9b4d53a0c7ac76554"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "lazy_static",
+ "lber",
+ "log",
+ "nom 7.1.3",
+ "percent-encoding",
+ "ring 0.16.20",
+ "rustls 0.21.12",
+ "rustls-native-certs",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1853,7 +1978,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -1883,6 +2008,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1967,6 +2102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2158,12 @@ dependencies = [
  "thiserror 1.0.69",
  "url",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "option-ext"
@@ -2358,7 +2508,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
- "ring",
+ "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
  "rustls-pki-types",
@@ -2638,6 +2788,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -2646,7 +2811,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2713,6 +2878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,7 +2906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.14",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -2745,11 +2919,23 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2777,8 +2963,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.14",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2787,9 +2973,9 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2803,6 +2989,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -2840,8 +3035,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.14",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2856,6 +3051,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3102,6 +3320,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -3414,6 +3638,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3880,6 +4116,12 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -4119,6 +4361,28 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4441,6 +4705,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4460,7 +4741,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -4501,7 +4782,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "iana-time-zone",
+ "include_dir",
  "ldap3",
  "lettre",
  "minijinja",
@@ -1644,6 +1645,25 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ argon2 = { version = "0.5", features = ["rand"] }
 rand = "0.8"
 base64 = "0.22"
 openidconnect = { version = "4.0.1", default-features = false, features = ["reqwest", "rustls-tls"] }
+ldap3 = { version = "0.11", default-features = false, features = ["tls-rustls"] }
 iana-time-zone = "0.1.65"
 urlencoding = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ lettre = { version = "0.11", default-features = false, features = ["tokio1-rustl
 axum = { version = "0.8", features = ["macros", "multipart"] }
 axum-extra = { version = "0.10", features = ["cookie", "form"] }
 minijinja = { version = "2", features = ["loader", "json"] }
+include_dir = "0.7"
 tower-http = { version = "0.6", features = ["trace"] }
 
 # Logging

--- a/migrations/050_ldap.sql
+++ b/migrations/050_ldap.sql
@@ -1,0 +1,96 @@
+-- LDAP authentication support
+--
+-- Widens users.auth_provider and groups.source CHECK constraints to include
+-- 'ldap', adds users.ldap_dn for identity linking, and adds LDAP config columns
+-- to auth_config. SQLite cannot alter CHECK constraints in place, so the
+-- users and groups tables are rebuilt with the 12-step pattern from
+-- https://sqlite.org/lang_altertable.html §7.
+--
+-- Foreign keys pointing at these tables (sessions.user_id, accounts.user_id,
+-- user_groups, team_members, event_types.group_id, team_groups, etc.) refer
+-- by table name, so they re-resolve after the RENAME. PRAGMA foreign_keys=OFF
+-- is required during the rebuild.
+
+PRAGMA foreign_keys = OFF;
+
+-- --- Rebuild users ---
+
+CREATE TABLE users_new (
+    id                  TEXT PRIMARY KEY,
+    email               TEXT NOT NULL UNIQUE,
+    name                TEXT NOT NULL,
+    timezone            TEXT NOT NULL DEFAULT 'UTC',
+    password_hash       TEXT,
+    role                TEXT NOT NULL DEFAULT 'user' CHECK(role IN ('admin', 'user')),
+    auth_provider       TEXT NOT NULL DEFAULT 'local' CHECK(auth_provider IN ('local', 'oidc', 'ldap')),
+    oidc_subject        TEXT,
+    ldap_dn             TEXT,
+    enabled             INTEGER NOT NULL DEFAULT 1,
+    username            TEXT,
+    booking_email       TEXT,
+    title               TEXT,
+    bio                 TEXT,
+    avatar_path         TEXT,
+    allow_dynamic_group INTEGER NOT NULL DEFAULT 1,
+    language            TEXT,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO users_new (
+    id, email, name, timezone, password_hash, role, auth_provider, oidc_subject,
+    enabled, username, booking_email, title, bio, avatar_path,
+    allow_dynamic_group, language, created_at, updated_at
+)
+SELECT
+    id, email, name, timezone, password_hash, role, auth_provider, oidc_subject,
+    enabled, username, booking_email, title, bio, avatar_path,
+    allow_dynamic_group, language, created_at, updated_at
+FROM users;
+
+DROP TABLE users;
+ALTER TABLE users_new RENAME TO users;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users(username);
+
+-- --- Rebuild groups ---
+
+CREATE TABLE groups_new (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    source      TEXT NOT NULL DEFAULT 'local' CHECK(source IN ('local', 'oidc', 'ldap')),
+    oidc_id     TEXT,
+    slug        TEXT,
+    description TEXT,
+    avatar_path TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO groups_new (id, name, source, oidc_id, slug, description, avatar_path, created_at)
+SELECT id, name, source, oidc_id, slug, description, avatar_path, created_at FROM groups;
+
+DROP TABLE groups;
+ALTER TABLE groups_new RENAME TO groups;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_groups_slug ON groups(slug);
+
+-- --- LDAP config on auth_config ---
+-- ldap_bind_password is AES-256-GCM encrypted via src/crypto.rs.
+-- ldap_tls_mode: 'ldaps' (implicit TLS on port 636), 'starttls' (StartTLS on
+-- 389), or 'plain' (no encryption, opt-in only — will warn at runtime).
+-- ldap_user_filter: must contain '{username}' as a placeholder that is
+-- RFC 4515-escaped at query time (see auth::ldap::escape_filter).
+
+ALTER TABLE auth_config ADD COLUMN ldap_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE auth_config ADD COLUMN ldap_server_url TEXT;
+ALTER TABLE auth_config ADD COLUMN ldap_tls_mode TEXT NOT NULL DEFAULT 'starttls' CHECK(ldap_tls_mode IN ('ldaps', 'starttls', 'plain'));
+ALTER TABLE auth_config ADD COLUMN ldap_bind_dn TEXT;
+ALTER TABLE auth_config ADD COLUMN ldap_bind_password TEXT;
+ALTER TABLE auth_config ADD COLUMN ldap_user_search_base TEXT;
+ALTER TABLE auth_config ADD COLUMN ldap_user_filter TEXT NOT NULL DEFAULT '(uid={username})';
+ALTER TABLE auth_config ADD COLUMN ldap_email_attr TEXT NOT NULL DEFAULT 'mail';
+ALTER TABLE auth_config ADD COLUMN ldap_name_attr TEXT NOT NULL DEFAULT 'cn';
+ALTER TABLE auth_config ADD COLUMN ldap_groups_attr TEXT;
+ALTER TABLE auth_config ADD COLUMN ldap_auto_register INTEGER NOT NULL DEFAULT 1;
+
+PRAGMA foreign_keys = ON;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -497,6 +497,10 @@ async fn login_page(State(state): State<Arc<AppState>>, jar: CookieJar) -> Respo
         .as_ref()
         .map(|c| c.oidc_enabled)
         .unwrap_or(false);
+    let ldap_enabled = auth_config
+        .as_ref()
+        .map(|c| c.ldap_enabled)
+        .unwrap_or(false);
     let registration_enabled = auth_config
         .as_ref()
         .map(|c| c.registration_enabled)
@@ -509,7 +513,7 @@ async fn login_page(State(state): State<Arc<AppState>>, jar: CookieJar) -> Respo
         Err(e) => return Html(format!("Template error: {}", e)).into_response(),
     };
     let body = Html(
-        tmpl.render(minijinja::context! { error => "", oidc_enabled => oidc_enabled, registration_enabled => registration_enabled, csrf_token => csrf_token })
+        tmpl.render(minijinja::context! { error => "", oidc_enabled => oidc_enabled, ldap_enabled => ldap_enabled, registration_enabled => registration_enabled, csrf_token => csrf_token })
             .unwrap_or_default(),
     );
     ([("Set-Cookie", csrf_cookie_value(&csrf_token))], body).into_response()
@@ -538,36 +542,26 @@ async fn login_handler(
         return render_login_error(&state, "Too many login attempts. Please try again later.");
     }
 
-    let user = sqlx::query_as::<_, User>(
-        "SELECT * FROM users WHERE email = ? AND auth_provider = 'local' AND enabled = 1",
-    )
-    .bind(&form.email)
-    .fetch_optional(&state.pool)
-    .await
-    .unwrap_or(None);
+    let user_id = match try_local_login(&state, &form).await {
+        LoginOutcome::Ok(id) => Some(id),
+        LoginOutcome::Fail => None,
+    };
 
-    let user = match user {
-        Some(u) => u,
+    let user_id = match user_id {
+        Some(id) => id,
         None => {
-            tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
-            return render_login_error(&state, "Invalid email or password");
+            // Fall through to LDAP if enabled.
+            match try_ldap_login(&state, &form).await {
+                LoginOutcome::Ok(id) => id,
+                LoginOutcome::Fail => {
+                    tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
+                    return render_login_error(&state, "Invalid email or password");
+                }
+            }
         }
     };
 
-    let password_hash = match &user.password_hash {
-        Some(h) => h,
-        None => {
-            tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
-            return render_login_error(&state, "Invalid email or password");
-        }
-    };
-
-    if !verify_password(&form.password, password_hash) {
-        tracing::warn!(email = %form.email, ip = %client_ip, "login failed");
-        return render_login_error(&state, "Invalid email or password");
-    }
-
-    let session = match create_session(&state.pool, &user.id).await {
+    let session = match create_session(&state.pool, &user_id).await {
         Ok(s) => s,
         Err(_) => return render_login_error(&state, "Internal error"),
     };
@@ -582,6 +576,76 @@ async fn login_handler(
     tracing::info!(email = %form.email, ip = %client_ip, "user login");
 
     (jar, [("Set-Cookie", cookie)], Redirect::to("/dashboard")).into_response()
+}
+
+enum LoginOutcome {
+    Ok(String),
+    Fail,
+}
+
+async fn try_local_login(state: &AppState, form: &LoginForm) -> LoginOutcome {
+    let user = sqlx::query_as::<_, User>(
+        "SELECT * FROM users WHERE email = ? AND auth_provider = 'local' AND enabled = 1",
+    )
+    .bind(&form.email)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
+
+    let Some(user) = user else {
+        return LoginOutcome::Fail;
+    };
+    let Some(hash) = &user.password_hash else {
+        return LoginOutcome::Fail;
+    };
+    if !verify_password(&form.password, hash) {
+        return LoginOutcome::Fail;
+    }
+    LoginOutcome::Ok(user.id)
+}
+
+async fn try_ldap_login(state: &AppState, form: &LoginForm) -> LoginOutcome {
+    let config = match get_auth_config(&state.pool).await {
+        Ok(c) if c.ldap_enabled => c,
+        _ => return LoginOutcome::Fail,
+    };
+
+    let info =
+        match ldap_authenticate(&state.secret_key, &config, &form.email, &form.password).await {
+            Ok(i) => i,
+            Err(e) => {
+                // Log at debug (not warn) to avoid flooding on typos; the outer
+                // handler logs a single "login failed" line with the identifier.
+                tracing::debug!(error = %e, "LDAP authentication attempt failed");
+                return LoginOutcome::Fail;
+            }
+        };
+
+    // Honor the same email-domain allowlist used for local registration / OIDC.
+    if !is_email_allowed(&info.email, &config.allowed_email_domains) {
+        tracing::warn!(email = %info.email, "LDAP login rejected: email domain not allowed");
+        return LoginOutcome::Fail;
+    }
+
+    let user_id =
+        match find_or_create_ldap_user(&state.pool, &info.dn, &info.email, &info.name, &config)
+            .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(email = %info.email, error = %e, "LDAP find_or_create failed");
+                return LoginOutcome::Fail;
+            }
+        };
+
+    if config.ldap_groups_attr.is_some() && !info.groups.is_empty() {
+        if let Err(e) = sync_ldap_user_groups(&state.pool, &user_id, &info.groups).await {
+            tracing::warn!(error = %e, "failed to sync LDAP groups");
+        }
+    }
+
+    tracing::info!(email = %info.email, "user login via LDAP");
+    LoginOutcome::Ok(user_id)
 }
 
 async fn register_page(State(state): State<Arc<AppState>>, jar: CookieJar) -> Response {
@@ -603,6 +667,17 @@ async fn register_page(State(state): State<Arc<AppState>>, jar: CookieJar) -> Re
         oidc_client_id: None,
         oidc_client_secret: None,
         oidc_auto_register: true,
+        ldap_enabled: false,
+        ldap_server_url: None,
+        ldap_tls_mode: "starttls".to_string(),
+        ldap_bind_dn: None,
+        ldap_bind_password: None,
+        ldap_user_search_base: None,
+        ldap_user_filter: "(uid={username})".to_string(),
+        ldap_email_attr: "mail".to_string(),
+        ldap_name_attr: "cn".to_string(),
+        ldap_groups_attr: None,
+        ldap_auto_register: true,
     });
 
     if !auth_config.registration_enabled {
@@ -1463,6 +1538,482 @@ pub fn generate_group_slug(name: &str) -> String {
     }
 }
 
+// --- LDAP authentication ---
+
+/// RFC 4515 (LDAP search filter) escape. Any user-supplied string interpolated
+/// into an LDAP filter must be passed through this function. Without it, a
+/// username like `*)(uid=admin)(|(uid=*` would turn the filter into an OR that
+/// matches arbitrary accounts.
+fn escape_ldap_filter(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for b in input.bytes() {
+        match b {
+            b'\\' => out.push_str("\\5c"),
+            b'*' => out.push_str("\\2a"),
+            b'(' => out.push_str("\\28"),
+            b')' => out.push_str("\\29"),
+            0 => out.push_str("\\00"),
+            _ => out.push(b as char),
+        }
+    }
+    out
+}
+
+/// RFC 4514 (LDAP DN) escape for DN component values (used when embedding a
+/// service-account DN sourced from config into a bind call). ldap3 accepts the
+/// DN verbatim on bind, so this is a defense-in-depth helper — not currently
+/// called but kept so future DN-construction code has one canonical escape.
+#[allow(dead_code)]
+fn escape_ldap_dn(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for (i, c) in input.chars().enumerate() {
+        let last = i + c.len_utf8() == input.len();
+        match c {
+            '"' | '+' | ',' | ';' | '<' | '>' | '\\' => {
+                out.push('\\');
+                out.push(c);
+            }
+            ' ' | '#' if i == 0 => {
+                out.push('\\');
+                out.push(c);
+            }
+            ' ' if last => {
+                out.push('\\');
+                out.push(c);
+            }
+            '\0' => out.push_str("\\00"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Information returned by a successful LDAP authentication.
+#[derive(Debug, Clone)]
+pub struct LdapUserInfo {
+    pub dn: String,
+    pub email: String,
+    pub name: String,
+    pub groups: Vec<String>,
+}
+
+const LDAP_TIMEOUT_SECS: u64 = 10;
+
+/// Authenticate a user against the configured LDAP server.
+///
+/// Flow (search-then-bind):
+/// 1. Open connection using `ldap_tls_mode` (ldaps implicit, starttls, or
+///    plain — plain requires explicit opt-in in config).
+/// 2. Bind as the service account (`ldap_bind_dn`/`ldap_bind_password`). The
+///    password is decrypted via `crypto::decrypt_password`. Anonymous bind is
+///    supported when no bind_dn is set.
+/// 3. Search by `ldap_user_filter` (with `{username}` replaced by the
+///    RFC-4515-escaped identifier) under `ldap_user_search_base`.
+/// 4. Re-bind as the found user DN with the user's password. This is the
+///    actual credential check — the service bind only proves we can find
+///    users, not that the password is right.
+/// 5. Extract email / name / groups from the user's entry attributes.
+pub async fn ldap_authenticate(
+    secret_key: &[u8; 32],
+    config: &AuthConfig,
+    username: &str,
+    password: &str,
+) -> Result<LdapUserInfo> {
+    use ldap3::{LdapConnAsync, LdapConnSettings, Scope, SearchEntry};
+
+    if !config.ldap_enabled {
+        anyhow::bail!("LDAP is not enabled");
+    }
+    if password.is_empty() {
+        // Anonymous bind with an empty password would mask credential failures
+        // as "unauthenticated bind success" on some LDAP servers (RFC 4513 §5.1.2).
+        anyhow::bail!("empty password");
+    }
+    let server_url = config
+        .ldap_server_url
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("LDAP server URL not configured"))?;
+    let user_search_base = config
+        .ldap_user_search_base
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("LDAP user search base not configured"))?;
+
+    // TLS posture: respect explicit mode, reject scheme/mode mismatch.
+    let mode = config.ldap_tls_mode.as_str();
+    let use_starttls = match mode {
+        "ldaps" => {
+            if !server_url.starts_with("ldaps://") {
+                anyhow::bail!("ldap_tls_mode=ldaps requires an ldaps:// URL");
+            }
+            false
+        }
+        "starttls" => {
+            if !server_url.starts_with("ldap://") {
+                anyhow::bail!("ldap_tls_mode=starttls requires an ldap:// URL");
+            }
+            true
+        }
+        "plain" => {
+            if !server_url.starts_with("ldap://") {
+                anyhow::bail!("ldap_tls_mode=plain requires an ldap:// URL");
+            }
+            tracing::warn!(
+                "LDAP connection is unencrypted (ldap_tls_mode=plain). \
+                 Credentials will traverse the network in cleartext."
+            );
+            false
+        }
+        other => anyhow::bail!("invalid ldap_tls_mode: {}", other),
+    };
+
+    let settings = LdapConnSettings::new()
+        .set_conn_timeout(std::time::Duration::from_secs(LDAP_TIMEOUT_SECS))
+        .set_starttls(use_starttls);
+
+    let (conn, mut ldap) = LdapConnAsync::with_settings(settings, server_url)
+        .await
+        .with_context(|| format!("LDAP connect to {} failed", server_url))?;
+
+    // Drive the connection on a background task; it will end when `ldap` is dropped.
+    tokio::spawn(async move {
+        if let Err(e) = conn.drive().await {
+            tracing::warn!(error = %e, "LDAP connection driver error");
+        }
+    });
+
+    // Service bind — only if configured. Decrypt the bind password at use.
+    if let Some(bind_dn) = config.ldap_bind_dn.as_deref() {
+        if !bind_dn.is_empty() {
+            let bind_pw = match config.ldap_bind_password.as_deref() {
+                Some(enc) if !enc.is_empty() => crate::crypto::decrypt_password(secret_key, enc)
+                    .context("failed to decrypt LDAP bind password")?,
+                _ => anyhow::bail!("LDAP bind DN is set but bind password is missing"),
+            };
+            ldap.simple_bind(bind_dn, &bind_pw)
+                .await
+                .context("LDAP service bind failed")?
+                .success()
+                .context("LDAP service bind rejected")?;
+        }
+    }
+
+    // Search for the user.
+    let escaped = escape_ldap_filter(username);
+    let filter = config.ldap_user_filter.replace("{username}", &escaped);
+    let mut attrs: Vec<&str> = vec![
+        config.ldap_email_attr.as_str(),
+        config.ldap_name_attr.as_str(),
+    ];
+    if let Some(a) = config.ldap_groups_attr.as_deref() {
+        if !a.is_empty() {
+            attrs.push(a);
+        }
+    }
+
+    let (rs, _res) = ldap
+        .search(user_search_base, Scope::Subtree, &filter, attrs)
+        .await
+        .context("LDAP search failed")?
+        .success()
+        .context("LDAP search returned an error")?;
+
+    let entry = rs
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("user not found"))?;
+    let entry = SearchEntry::construct(entry);
+    let dn = entry.dn.clone();
+
+    // Re-bind as the user with the supplied password. This is the credential check.
+    ldap.simple_bind(&dn, password)
+        .await
+        .context("LDAP user bind failed")?
+        .success()
+        .context("LDAP user bind rejected (wrong password?)")?;
+
+    let email = entry
+        .attrs
+        .get(&config.ldap_email_attr)
+        .and_then(|v| v.first())
+        .cloned()
+        .unwrap_or_default();
+    let name = entry
+        .attrs
+        .get(&config.ldap_name_attr)
+        .and_then(|v| v.first())
+        .cloned()
+        .unwrap_or_else(|| username.to_string());
+    let groups = config
+        .ldap_groups_attr
+        .as_deref()
+        .and_then(|a| entry.attrs.get(a).cloned())
+        .unwrap_or_default();
+
+    let _ = ldap.unbind().await;
+
+    if email.is_empty() {
+        anyhow::bail!(
+            "LDAP user entry has no '{}' attribute",
+            config.ldap_email_attr
+        );
+    }
+
+    Ok(LdapUserInfo {
+        dn,
+        email,
+        name,
+        groups,
+    })
+}
+
+/// Verify that the LDAP config can reach the server and (if configured) bind
+/// with the service account. Does not perform a user search or user bind —
+/// this only proves the operator's config works; it does not verify a
+/// specific end-user credential.
+pub async fn ldap_test_connection(secret_key: &[u8; 32], config: &AuthConfig) -> Result<()> {
+    use ldap3::{LdapConnAsync, LdapConnSettings};
+
+    let server_url = config
+        .ldap_server_url
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("LDAP server URL not configured"))?;
+
+    let mode = config.ldap_tls_mode.as_str();
+    let use_starttls = match mode {
+        "ldaps" => {
+            if !server_url.starts_with("ldaps://") {
+                anyhow::bail!("ldap_tls_mode=ldaps requires an ldaps:// URL");
+            }
+            false
+        }
+        "starttls" => {
+            if !server_url.starts_with("ldap://") {
+                anyhow::bail!("ldap_tls_mode=starttls requires an ldap:// URL");
+            }
+            true
+        }
+        "plain" => {
+            if !server_url.starts_with("ldap://") {
+                anyhow::bail!("ldap_tls_mode=plain requires an ldap:// URL");
+            }
+            false
+        }
+        other => anyhow::bail!("invalid ldap_tls_mode: {}", other),
+    };
+
+    let settings = LdapConnSettings::new()
+        .set_conn_timeout(std::time::Duration::from_secs(LDAP_TIMEOUT_SECS))
+        .set_starttls(use_starttls);
+
+    let (conn, mut ldap) = LdapConnAsync::with_settings(settings, server_url)
+        .await
+        .with_context(|| format!("LDAP connect to {} failed", server_url))?;
+    tokio::spawn(async move {
+        if let Err(e) = conn.drive().await {
+            tracing::debug!(error = %e, "LDAP test connection driver error");
+        }
+    });
+
+    if let Some(bind_dn) = config.ldap_bind_dn.as_deref() {
+        if !bind_dn.is_empty() {
+            let bind_pw = match config.ldap_bind_password.as_deref() {
+                Some(enc) if !enc.is_empty() => crate::crypto::decrypt_password(secret_key, enc)
+                    .context("failed to decrypt LDAP bind password")?,
+                _ => anyhow::bail!("LDAP bind DN is set but bind password is missing"),
+            };
+            ldap.simple_bind(bind_dn, &bind_pw)
+                .await
+                .context("LDAP service bind failed")?
+                .success()
+                .context("LDAP service bind rejected")?;
+        }
+    }
+    let _ = ldap.unbind().await;
+    Ok(())
+}
+
+/// Find or link a user by LDAP DN, falling back to email, then auto-registering
+/// if the config allows. Mirrors `find_or_create_oidc_user`.
+async fn find_or_create_ldap_user(
+    pool: &SqlitePool,
+    dn: &str,
+    email: &str,
+    name: &str,
+    auth_config: &AuthConfig,
+) -> Result<String> {
+    // 1. Match by ldap_dn
+    if let Some((id,)) = sqlx::query_as::<_, (String,)>(
+        "SELECT id FROM users WHERE ldap_dn = ? AND auth_provider = 'ldap' AND enabled = 1",
+    )
+    .bind(dn)
+    .fetch_optional(pool)
+    .await?
+    {
+        sqlx::query(
+            "UPDATE users SET name = CASE WHEN name IS NULL OR name = '' THEN ? ELSE name END, email = ?, updated_at = datetime('now') WHERE id = ?",
+        )
+        .bind(name)
+        .bind(email)
+        .bind(&id)
+        .execute(pool)
+        .await?;
+        return Ok(id);
+    }
+
+    // 2. Link existing user by email
+    if let Some((id,)) =
+        sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE email = ? AND enabled = 1")
+            .bind(email)
+            .fetch_optional(pool)
+            .await?
+    {
+        sqlx::query(
+            "UPDATE users SET ldap_dn = ?, auth_provider = 'ldap', updated_at = datetime('now') WHERE id = ?",
+        )
+        .bind(dn)
+        .bind(&id)
+        .execute(pool)
+        .await?;
+        return Ok(id);
+    }
+
+    // 3. Auto-register if enabled
+    if !auth_config.ldap_auto_register {
+        anyhow::bail!("No account found for this user. Contact an administrator.");
+    }
+
+    let is_first = !has_any_users(pool).await?;
+    let role = if is_first { "admin" } else { "user" };
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let username = generate_username(pool, email).await?;
+
+    sqlx::query(
+        "INSERT INTO users (id, email, name, timezone, role, auth_provider, ldap_dn, username) VALUES (?, ?, ?, 'UTC', ?, 'ldap', ?, ?)",
+    )
+    .bind(&user_id)
+    .bind(email)
+    .bind(name)
+    .bind(role)
+    .bind(dn)
+    .bind(&username)
+    .execute(pool)
+    .await?;
+
+    // Link/create matching account row
+    let existing_account: Option<(String,)> =
+        sqlx::query_as("SELECT id FROM accounts WHERE email = ?")
+            .bind(email)
+            .fetch_optional(pool)
+            .await?;
+
+    if let Some((account_id,)) = existing_account {
+        sqlx::query("UPDATE accounts SET user_id = ?, name = ? WHERE id = ?")
+            .bind(&user_id)
+            .bind(name)
+            .bind(&account_id)
+            .execute(pool)
+            .await?;
+    } else {
+        let account_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO accounts (id, name, email, timezone, user_id) VALUES (?, ?, ?, 'UTC', ?)",
+        )
+        .bind(&account_id)
+        .bind(name)
+        .bind(email)
+        .bind(&user_id)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(user_id)
+}
+
+/// Sync a user's group memberships from an LDAP `memberOf` attribute. Mirrors
+/// `sync_user_groups` but with `source='ldap'`. Group names are taken verbatim
+/// from the LDAP values (typically full DNs or `cn=...,ou=...` paths) — the
+/// admin can choose which attribute to sync via `ldap_groups_attr`.
+pub async fn sync_ldap_user_groups(
+    pool: &SqlitePool,
+    user_id: &str,
+    groups: &[String],
+) -> Result<()> {
+    sqlx::query(
+        "DELETE FROM user_groups WHERE user_id = ? AND group_id IN (SELECT id FROM groups WHERE source = 'ldap')",
+    )
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .context("Failed to clear user LDAP groups")?;
+
+    let mut current_group_ids: Vec<String> = Vec::new();
+
+    for group_name in groups {
+        let group_id = uuid::Uuid::new_v4().to_string();
+        let slug = generate_group_slug(group_name);
+
+        sqlx::query(
+            "INSERT INTO groups (id, name, source, oidc_id, slug, created_at) \
+             VALUES (?, ?, 'ldap', NULL, ?, datetime('now')) \
+             ON CONFLICT(name) DO UPDATE SET slug = excluded.slug",
+        )
+        .bind(&group_id)
+        .bind(group_name)
+        .bind(&slug)
+        .execute(pool)
+        .await
+        .context("Failed to upsert LDAP group")?;
+
+        let (actual_group_id,): (String,) = sqlx::query_as("SELECT id FROM groups WHERE name = ?")
+            .bind(group_name)
+            .fetch_one(pool)
+            .await
+            .context("Failed to fetch group id")?;
+
+        sqlx::query("INSERT OR IGNORE INTO user_groups (user_id, group_id) VALUES (?, ?)")
+            .bind(user_id)
+            .bind(&actual_group_id)
+            .execute(pool)
+            .await
+            .context("Failed to insert user_group")?;
+
+        current_group_ids.push(actual_group_id);
+    }
+
+    // Reconcile team memberships derived from group links.
+    for group_id in &current_group_ids {
+        let team_ids: Vec<(String,)> =
+            sqlx::query_as("SELECT team_id FROM team_groups WHERE group_id = ?")
+                .bind(group_id)
+                .fetch_all(pool)
+                .await?;
+
+        for (team_id,) in team_ids {
+            sqlx::query(
+                "INSERT OR IGNORE INTO team_members (team_id, user_id, role, source) VALUES (?, ?, 'member', 'group')",
+            )
+            .bind(&team_id)
+            .bind(user_id)
+            .execute(pool)
+            .await?;
+        }
+    }
+
+    sqlx::query(
+        "DELETE FROM team_members WHERE user_id = ? AND source = 'group' \
+         AND team_id NOT IN ( \
+             SELECT tg.team_id FROM team_groups tg \
+             WHERE tg.group_id IN (SELECT group_id FROM user_groups WHERE user_id = ?) \
+         )",
+    )
+    .bind(user_id)
+    .bind(user_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1690,6 +2241,64 @@ mod tests {
         let claims = extract_claims_from_id_token(&token);
         assert_eq!(claims.title, Some("CTO".to_string()));
         assert_eq!(claims.groups, None);
+    }
+
+    // ===== LDAP filter escaping (RFC 4515) =====
+
+    #[test]
+    fn ldap_filter_plain_string_unchanged() {
+        assert_eq!(escape_ldap_filter("alice"), "alice");
+        assert_eq!(escape_ldap_filter("alice@example.com"), "alice@example.com");
+    }
+
+    #[test]
+    fn ldap_filter_escapes_special_chars() {
+        // Exactly the five bytes called out in RFC 4515 §3.
+        assert_eq!(escape_ldap_filter("*"), "\\2a");
+        assert_eq!(escape_ldap_filter("("), "\\28");
+        assert_eq!(escape_ldap_filter(")"), "\\29");
+        assert_eq!(escape_ldap_filter("\\"), "\\5c");
+        assert_eq!(escape_ldap_filter("\0"), "\\00");
+    }
+
+    #[test]
+    fn ldap_filter_blocks_injection_attempt() {
+        // Classic injection payload: if not escaped, the admin's filter
+        // (uid={username}) becomes (uid=*)(uid=admin)(|(uid=*) — turning an
+        // equality check into a wildcard plus a junk OR. After escaping, the
+        // attacker's parens/stars are literal bytes inside the uid= match.
+        let escaped = escape_ldap_filter("*)(uid=admin)(|(uid=*");
+        assert_eq!(escaped, "\\2a\\29\\28uid=admin\\29\\28|\\28uid=\\2a");
+        assert!(!escaped.contains('('));
+        assert!(!escaped.contains(')'));
+        assert!(!escaped.contains('*'));
+    }
+
+    #[test]
+    fn ldap_filter_mixed_content() {
+        // Confirm escaping is byte-level (so every special char gets replaced,
+        // including ones nested in otherwise valid-looking input).
+        assert_eq!(escape_ldap_filter("a*b(c)d\\e"), "a\\2ab\\28c\\29d\\5ce");
+    }
+
+    // ===== LDAP DN escaping (RFC 4514) =====
+
+    #[test]
+    fn ldap_dn_escapes_reserved() {
+        assert_eq!(escape_ldap_dn("Doe, John"), "Doe\\, John");
+        assert_eq!(escape_ldap_dn("a+b"), "a\\+b");
+        assert_eq!(escape_ldap_dn("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn ldap_dn_escapes_leading_space_and_hash() {
+        assert_eq!(escape_ldap_dn(" leading"), "\\ leading");
+        assert_eq!(escape_ldap_dn("#hash"), "\\#hash");
+    }
+
+    #[test]
+    fn ldap_dn_escapes_trailing_space() {
+        assert_eq!(escape_ldap_dn("trailing "), "trailing\\ ");
     }
 
     // ===== DB-backed integration tests =====
@@ -2035,6 +2644,156 @@ mod tests {
         let config = get_auth_config(&pool).await.unwrap();
         assert!(!config.registration_enabled);
         assert_eq!(config.allowed_email_domains, Some("test.com".to_string()));
+    }
+
+    #[tokio::test]
+    async fn get_auth_config_defaults_for_ldap() {
+        // Migration 046 must supply sane defaults for every LDAP column that
+        // the AuthConfig struct declares non-optional (tls_mode, user_filter,
+        // email_attr, name_attr). Without these, `SELECT *` would fail to
+        // decode into the struct on fresh databases.
+        let pool = setup_db().await;
+        let config = get_auth_config(&pool).await.unwrap();
+        assert!(!config.ldap_enabled);
+        assert_eq!(config.ldap_tls_mode, "starttls");
+        assert_eq!(config.ldap_user_filter, "(uid={username})");
+        assert_eq!(config.ldap_email_attr, "mail");
+        assert_eq!(config.ldap_name_attr, "cn");
+        assert!(config.ldap_auto_register);
+        assert!(config.ldap_server_url.is_none());
+        assert!(config.ldap_bind_dn.is_none());
+        assert!(config.ldap_bind_password.is_none());
+        assert!(config.ldap_groups_attr.is_none());
+    }
+
+    #[tokio::test]
+    async fn ldap_config_roundtrip_encrypts_password() {
+        // Simulate the admin flow: plaintext goes in, the DB column is
+        // ciphertext, and get_auth_config + crypto::decrypt_password round-trip
+        // it back. This guards against a future refactor that accidentally
+        // stores the bind password as plaintext.
+        let pool = setup_db().await;
+        let key = [42u8; 32];
+        let plaintext = "super-secret-bind-pw";
+        let encrypted = crate::crypto::encrypt_password(&key, plaintext).unwrap();
+
+        sqlx::query(
+            "UPDATE auth_config SET ldap_enabled = 1, ldap_server_url = ?, \
+             ldap_tls_mode = ?, ldap_bind_dn = ?, ldap_bind_password = ?, \
+             ldap_user_search_base = ?, ldap_groups_attr = ? WHERE id = 'singleton'",
+        )
+        .bind("ldaps://ldap.example.com")
+        .bind("ldaps")
+        .bind("cn=svc,dc=example,dc=com")
+        .bind(&encrypted)
+        .bind("ou=users,dc=example,dc=com")
+        .bind("memberOf")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let config = get_auth_config(&pool).await.unwrap();
+        assert!(config.ldap_enabled);
+        assert_eq!(config.ldap_tls_mode, "ldaps");
+        assert_eq!(
+            config.ldap_server_url.as_deref(),
+            Some("ldaps://ldap.example.com")
+        );
+        assert_eq!(config.ldap_groups_attr.as_deref(), Some("memberOf"));
+
+        let stored_pw = config.ldap_bind_password.as_deref().unwrap();
+        assert_ne!(stored_pw, plaintext, "bind password must not be plaintext");
+        let decrypted = crate::crypto::decrypt_password(&key, stored_pw).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[tokio::test]
+    async fn ldap_authenticate_rejects_when_disabled() {
+        // Defense in depth: even if login_handler forgets to check ldap_enabled,
+        // ldap_authenticate itself must refuse. Otherwise a misconfigured
+        // deployment could accept LDAP logins nobody asked for.
+        let pool = setup_db().await;
+        let key = [0u8; 32];
+        let config = get_auth_config(&pool).await.unwrap();
+        assert!(!config.ldap_enabled);
+        let err = ldap_authenticate(&key, &config, "alice", "pw")
+            .await
+            .expect_err("must reject when ldap_enabled=0");
+        assert!(err.to_string().to_lowercase().contains("not enabled"));
+    }
+
+    #[tokio::test]
+    async fn ldap_authenticate_rejects_empty_password() {
+        // RFC 4513 §5.1.2 — some servers treat a simple bind with an empty
+        // password as an "unauthenticated bind" and return success. Refusing
+        // early prevents that from being mistaken for successful auth.
+        let pool = setup_db().await;
+        let key = [0u8; 32];
+        sqlx::query("UPDATE auth_config SET ldap_enabled = 1 WHERE id = 'singleton'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let config = get_auth_config(&pool).await.unwrap();
+        let err = ldap_authenticate(&key, &config, "alice", "")
+            .await
+            .expect_err("must reject empty password");
+        assert!(err.to_string().to_lowercase().contains("empty password"));
+    }
+
+    #[tokio::test]
+    async fn ldap_authenticate_rejects_ldaps_mode_with_ldap_url() {
+        // The TLS posture check should refuse a config mismatch rather than
+        // silently downgrade to cleartext.
+        let pool = setup_db().await;
+        let key = [0u8; 32];
+        sqlx::query(
+            "UPDATE auth_config SET ldap_enabled = 1, ldap_server_url = 'ldap://ldap.example.com', \
+             ldap_tls_mode = 'ldaps', ldap_user_search_base = 'ou=u,dc=ex,dc=com' \
+             WHERE id = 'singleton'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let config = get_auth_config(&pool).await.unwrap();
+        let err = ldap_authenticate(&key, &config, "alice", "pw")
+            .await
+            .expect_err("must reject ldaps mode on ldap:// URL");
+        assert!(err.to_string().contains("ldaps://"));
+    }
+
+    #[tokio::test]
+    async fn sync_ldap_user_groups_creates_and_tags_source_ldap() {
+        // New LDAP-sourced groups must land in the groups table with source='ldap',
+        // so OIDC group sync and LDAP group sync don't stomp on each other's
+        // memberships (sync_user_groups filters on source='oidc').
+        let pool = setup_db().await;
+        let user_id = insert_user(&pool, "alice@example.com", "Alice", "user").await;
+
+        sync_ldap_user_groups(
+            &pool,
+            &user_id,
+            &["cn=engineering,ou=groups,dc=ex".to_string()],
+        )
+        .await
+        .unwrap();
+
+        let (source,): (String,) = sqlx::query_as(
+            "SELECT source FROM groups WHERE name = 'cn=engineering,ou=groups,dc=ex'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(source, "ldap");
+
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM user_groups ug JOIN groups g ON g.id = ug.group_id \
+             WHERE ug.user_id = ? AND g.source = 'ldap'",
+        )
+        .bind(&user_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
     }
 
     // --- has_any_users ---

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -60,6 +60,41 @@ pub enum ConfigCommands {
         #[arg(long)]
         auto_register: Option<bool>,
     },
+    /// Configure LDAP authentication
+    Ldap {
+        /// LDAP server URL (ldap:// or ldaps://)
+        #[arg(long)]
+        server_url: Option<String>,
+        /// TLS mode: ldaps, starttls, or plain
+        #[arg(long)]
+        tls_mode: Option<String>,
+        /// Service bind DN (leave empty for anonymous)
+        #[arg(long)]
+        bind_dn: Option<String>,
+        /// User search base DN
+        #[arg(long)]
+        user_search_base: Option<String>,
+        /// User filter with {username} placeholder
+        #[arg(long)]
+        user_filter: Option<String>,
+        /// Email attribute name (default: mail)
+        #[arg(long)]
+        email_attr: Option<String>,
+        /// Name attribute name (default: cn)
+        #[arg(long)]
+        name_attr: Option<String>,
+        /// Groups attribute (e.g. memberOf, leave empty to skip group sync)
+        #[arg(long)]
+        groups_attr: Option<String>,
+        /// Enable or disable LDAP
+        #[arg(long)]
+        enabled: Option<bool>,
+        /// Auto-register users on first LDAP login
+        #[arg(long)]
+        auto_register: Option<bool>,
+    },
+    /// Test the stored LDAP configuration (connect + service bind)
+    LdapTest,
 }
 
 pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Result<()> {
@@ -339,6 +374,252 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                         "✓".green(),
                         if ar { "enabled" } else { "disabled" }
                     );
+                }
+            }
+        }
+        ConfigCommands::Ldap {
+            server_url,
+            tls_mode,
+            bind_dn,
+            user_search_base,
+            user_filter,
+            email_attr,
+            name_attr,
+            groups_attr,
+            enabled,
+            auto_register,
+        } => {
+            let any_flag = server_url.is_some()
+                || tls_mode.is_some()
+                || bind_dn.is_some()
+                || user_search_base.is_some()
+                || user_filter.is_some()
+                || email_attr.is_some()
+                || name_attr.is_some()
+                || groups_attr.is_some()
+                || enabled.is_some()
+                || auto_register.is_some();
+
+            if !any_flag {
+                // Interactive flow.
+                let url = prompt("LDAP server URL (ldap:// or ldaps://)");
+                let mode = {
+                    let m = prompt("TLS mode [ldaps/starttls/plain] (default: starttls)");
+                    if m.trim().is_empty() {
+                        "starttls".to_string()
+                    } else {
+                        m
+                    }
+                };
+                if !matches!(mode.as_str(), "ldaps" | "starttls" | "plain") {
+                    anyhow::bail!("invalid TLS mode: {}", mode);
+                }
+                let b_dn = prompt("Bind DN (leave empty for anonymous)");
+                let b_pw = if b_dn.trim().is_empty() {
+                    String::new()
+                } else {
+                    rpassword::prompt_password("Bind password: ")?
+                };
+                let base = prompt("User search base (e.g. ou=users,dc=example,dc=com)");
+                let filter = {
+                    let f = prompt(
+                        "User filter with {username} placeholder (default: (uid={username}))",
+                    );
+                    if f.trim().is_empty() {
+                        "(uid={username})".to_string()
+                    } else {
+                        f
+                    }
+                };
+                if !filter.contains("{username}") {
+                    anyhow::bail!("user filter must contain the {{username}} placeholder");
+                }
+                let email_a = {
+                    let a = prompt("Email attribute (default: mail)");
+                    if a.trim().is_empty() {
+                        "mail".to_string()
+                    } else {
+                        a
+                    }
+                };
+                let name_a = {
+                    let a = prompt("Name attribute (default: cn)");
+                    if a.trim().is_empty() {
+                        "cn".to_string()
+                    } else {
+                        a
+                    }
+                };
+                let groups_a = {
+                    let a = prompt("Groups attribute (leave empty to skip, typical: memberOf)");
+                    if a.trim().is_empty() {
+                        None
+                    } else {
+                        Some(a)
+                    }
+                };
+                let auto_reg = prompt("Auto-register users on first LDAP login? (y/n)");
+
+                let b_dn_opt = if b_dn.trim().is_empty() {
+                    None
+                } else {
+                    Some(b_dn)
+                };
+                let b_pw_enc = if !b_pw.is_empty() {
+                    Some(crate::crypto::encrypt_password(key, &b_pw)?)
+                } else {
+                    None
+                };
+                let base_opt = if base.trim().is_empty() {
+                    None
+                } else {
+                    Some(base)
+                };
+
+                sqlx::query(
+                    "UPDATE auth_config SET ldap_enabled = 1, ldap_server_url = ?, \
+                     ldap_tls_mode = ?, ldap_bind_dn = ?, ldap_bind_password = ?, \
+                     ldap_user_search_base = ?, ldap_user_filter = ?, \
+                     ldap_email_attr = ?, ldap_name_attr = ?, ldap_groups_attr = ?, \
+                     ldap_auto_register = ?, updated_at = datetime('now') \
+                     WHERE id = 'singleton'",
+                )
+                .bind(&url)
+                .bind(&mode)
+                .bind(&b_dn_opt)
+                .bind(&b_pw_enc)
+                .bind(&base_opt)
+                .bind(&filter)
+                .bind(&email_a)
+                .bind(&name_a)
+                .bind(&groups_a)
+                .bind(auto_reg.starts_with('y') || auto_reg.starts_with('Y'))
+                .execute(pool)
+                .await?;
+
+                println!("{} LDAP configured and enabled", "✓".green());
+            } else {
+                if let Some(url) = server_url {
+                    sqlx::query("UPDATE auth_config SET ldap_server_url = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&url)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP server URL set", "✓".green());
+                }
+                if let Some(m) = tls_mode {
+                    if !matches!(m.as_str(), "ldaps" | "starttls" | "plain") {
+                        anyhow::bail!("invalid TLS mode: {}", m);
+                    }
+                    sqlx::query("UPDATE auth_config SET ldap_tls_mode = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&m)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP TLS mode set to {}", "✓".green(), m);
+                }
+                if let Some(dn) = bind_dn {
+                    let dn_opt = if dn.trim().is_empty() { None } else { Some(dn) };
+                    sqlx::query("UPDATE auth_config SET ldap_bind_dn = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&dn_opt)
+                        .execute(pool)
+                        .await?;
+                    // If a bind DN is being set/changed, prompt for its password.
+                    if dn_opt.is_some() {
+                        let pw = rpassword::prompt_password(
+                            "Bind password (leave blank to keep current): ",
+                        )?;
+                        if !pw.is_empty() {
+                            let enc = crate::crypto::encrypt_password(key, &pw)?;
+                            sqlx::query("UPDATE auth_config SET ldap_bind_password = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                                .bind(&enc)
+                                .execute(pool)
+                                .await?;
+                            println!("{} LDAP bind password updated", "✓".green());
+                        }
+                    } else {
+                        // Clearing bind DN also clears the password.
+                        sqlx::query("UPDATE auth_config SET ldap_bind_password = NULL, updated_at = datetime('now') WHERE id = 'singleton'")
+                            .execute(pool)
+                            .await?;
+                    }
+                    println!("{} LDAP bind DN set", "✓".green());
+                }
+                if let Some(b) = user_search_base {
+                    let b_opt = if b.trim().is_empty() { None } else { Some(b) };
+                    sqlx::query("UPDATE auth_config SET ldap_user_search_base = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&b_opt)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP user search base set", "✓".green());
+                }
+                if let Some(f) = user_filter {
+                    if !f.contains("{username}") {
+                        anyhow::bail!("user filter must contain the {{username}} placeholder");
+                    }
+                    sqlx::query("UPDATE auth_config SET ldap_user_filter = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&f)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP user filter set", "✓".green());
+                }
+                if let Some(a) = email_attr {
+                    sqlx::query("UPDATE auth_config SET ldap_email_attr = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&a)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP email attribute set", "✓".green());
+                }
+                if let Some(a) = name_attr {
+                    sqlx::query("UPDATE auth_config SET ldap_name_attr = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&a)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP name attribute set", "✓".green());
+                }
+                if let Some(a) = groups_attr {
+                    let a_opt = if a.trim().is_empty() { None } else { Some(a) };
+                    sqlx::query("UPDATE auth_config SET ldap_groups_attr = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(&a_opt)
+                        .execute(pool)
+                        .await?;
+                    println!("{} LDAP groups attribute set", "✓".green());
+                }
+                if let Some(en) = enabled {
+                    sqlx::query("UPDATE auth_config SET ldap_enabled = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(en)
+                        .execute(pool)
+                        .await?;
+                    println!(
+                        "{} LDAP {}",
+                        "✓".green(),
+                        if en { "enabled" } else { "disabled" }
+                    );
+                }
+                if let Some(ar) = auto_register {
+                    sqlx::query("UPDATE auth_config SET ldap_auto_register = ?, updated_at = datetime('now') WHERE id = 'singleton'")
+                        .bind(ar)
+                        .execute(pool)
+                        .await?;
+                    println!(
+                        "{} LDAP auto-register {}",
+                        "✓".green(),
+                        if ar { "enabled" } else { "disabled" }
+                    );
+                }
+            }
+        }
+        ConfigCommands::LdapTest => {
+            let config = crate::auth::get_auth_config(pool).await?;
+            if !config.ldap_enabled {
+                println!(
+                    "{} LDAP is disabled — run `calrs config ldap --enabled true` first",
+                    "!".yellow()
+                );
+            }
+            match crate::auth::ldap_test_connection(key, &config).await {
+                Ok(_) => println!("{} LDAP connection OK", "✓".green()),
+                Err(e) => {
+                    println!("{} LDAP test failed: {}", "✗".red(), e);
+                    std::process::exit(1);
                 }
             }
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -227,6 +227,27 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
                 .await?;
 
         if applied.is_none() {
+            // Pre-rebase testers of feat/ldap-auth ran this migration as
+            // 046_ldap. Detect that state via the ldap_enabled sentinel and
+            // record 050_ldap as applied without re-running the SQL, which
+            // would fail on the duplicate auth_config.ldap_enabled column.
+            if *name == "050_ldap" {
+                let has_sentinel: (i64,) = sqlx::query_as(
+                    "SELECT COUNT(*) FROM pragma_table_info('auth_config') WHERE name = 'ldap_enabled'",
+                )
+                .fetch_one(pool)
+                .await?;
+                if has_sentinel.0 > 0 {
+                    sqlx::query("INSERT INTO _migrations (name) VALUES (?)")
+                        .bind(name)
+                        .execute(pool)
+                        .await?;
+                    tracing::info!(migration = %name, "database migration already applied under prior name, recorded");
+                    applied_count += 1;
+                    continue;
+                }
+            }
+
             sqlx::raw_sql(sql).execute(pool).await?;
             sqlx::query("INSERT INTO _migrations (name) VALUES (?)")
                 .bind(name)
@@ -774,6 +795,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 50, "Still 50 migrations after second run");
+    }
+
+    #[tokio::test]
+    async fn migrate_skips_050_ldap_when_pre_rebase_schema_present() {
+        // Pre-rebase testers of feat/ldap-auth ran the LDAP migration as
+        // 046_ldap. After the rebase it became 050_ldap, so their _migrations
+        // table lacks 050_ldap but the auth_config.ldap_enabled column is
+        // already there. The runner must detect the sentinel and record the
+        // migration as applied without re-running it.
+        let pool = memory_pool().await;
+        migrate(&pool).await.unwrap();
+
+        // Simulate the pre-rebase state: drop the 050_ldap record but leave
+        // the schema (ldap_enabled column) in place.
+        sqlx::query("DELETE FROM _migrations WHERE name = '050_ldap'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Running migrate again must succeed despite the duplicate column.
+        migrate(&pool).await.unwrap();
+
+        let recorded: Option<(String,)> =
+            sqlx::query_as("SELECT name FROM _migrations WHERE name = '050_ldap'")
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert!(
+            recorded.is_some(),
+            "050_ldap should be recorded as applied via the sentinel-column path"
+        );
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -215,6 +215,7 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "049_smtp_decouple_account",
             include_str!("../migrations/049_smtp_decouple_account.sql"),
         ),
+        ("050_ldap", include_str!("../migrations/050_ldap.sql")),
     ];
 
     let mut applied_count = 0u32;
@@ -758,7 +759,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 49, "All 49 migrations should be tracked");
+        assert_eq!(count.0, 50, "All 50 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -772,7 +773,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 49, "Still 49 migrations after second run");
+        assert_eq!(count.0, 50, "Still 50 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -54,6 +54,17 @@ pub struct AuthConfig {
     pub oidc_client_id: Option<String>,
     pub oidc_client_secret: Option<String>,
     pub oidc_auto_register: bool,
+    pub ldap_enabled: bool,
+    pub ldap_server_url: Option<String>,
+    pub ldap_tls_mode: String,
+    pub ldap_bind_dn: Option<String>,
+    pub ldap_bind_password: Option<String>,
+    pub ldap_user_search_base: Option<String>,
+    pub ldap_user_filter: String,
+    pub ldap_email_attr: String,
+    pub ldap_name_attr: String,
+    pub ldap_groups_attr: Option<String>,
+    pub ldap_auto_register: bool,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -9,7 +9,10 @@ use chrono::{
     Datelike, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc,
 };
 use chrono_tz::Tz;
+use include_dir::{include_dir, Dir};
 use minijinja::{context, Environment};
+
+static TEMPLATES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates");
 use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
@@ -524,7 +527,12 @@ async fn csrf_cookie_middleware(
 pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8; 32]) -> Router {
     let mut env = Environment::new();
     env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
-    env.set_loader(minijinja::path_loader("templates"));
+    env.set_loader(|name| {
+        Ok(TEMPLATES_DIR
+            .get_file(name)
+            .and_then(|f| f.contents_utf8())
+            .map(|s| s.to_string()))
+    });
     crate::i18n::register(&mut env);
 
     let initial_theme_css = build_theme_css(&pool).await;
@@ -16571,7 +16579,12 @@ mod tests {
     fn slots_template_links_without_reschedule_context() {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
-        env.set_loader(minijinja::path_loader("templates"));
+        env.set_loader(|name| {
+            Ok(TEMPLATES_DIR
+                .get_file(name)
+                .and_then(|f| f.contents_utf8())
+                .map(|s| s.to_string()))
+        });
         crate::i18n::register(&mut env);
 
         let tmpl = env
@@ -16634,7 +16647,12 @@ mod tests {
     fn slots_template_links_with_reschedule_context() {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
-        env.set_loader(minijinja::path_loader("templates"));
+        env.set_loader(|name| {
+            Ok(TEMPLATES_DIR
+                .get_file(name)
+                .and_then(|f| f.contents_utf8())
+                .map(|s| s.to_string()))
+        });
         crate::i18n::register(&mut env);
 
         let tmpl = env
@@ -20106,7 +20124,12 @@ mod tests {
     fn dashboard_event_types_delete_button_no_onclick_interpolation() {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
-        env.set_loader(minijinja::path_loader("templates"));
+        env.set_loader(|name| {
+            Ok(TEMPLATES_DIR
+                .get_file(name)
+                .and_then(|f| f.contents_utf8())
+                .map(|s| s.to_string()))
+        });
         crate::i18n::register(&mut env);
         let tmpl = env
             .get_template("dashboard_event_types.html")
@@ -20156,7 +20179,12 @@ mod tests {
     fn dashboard_sources_remove_button_no_onclick_interpolation() {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
-        env.set_loader(minijinja::path_loader("templates"));
+        env.set_loader(|name| {
+            Ok(TEMPLATES_DIR
+                .get_file(name)
+                .and_then(|f| f.contents_utf8())
+                .map(|s| s.to_string()))
+        });
         crate::i18n::register(&mut env);
         let tmpl = env
             .get_template("dashboard_sources.html")
@@ -20199,7 +20227,12 @@ mod tests {
     fn team_settings_delete_button_no_onclick_interpolation() {
         let mut env = minijinja::Environment::new();
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
-        env.set_loader(minijinja::path_loader("templates"));
+        env.set_loader(|name| {
+            Ok(TEMPLATES_DIR
+                .get_file(name)
+                .and_then(|f| f.contents_utf8())
+                .map(|s| s.to_string()))
+        });
         crate::i18n::register(&mut env);
         let tmpl = env
             .get_template("team_settings.html")

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -671,6 +671,8 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/dashboard/admin/auth", post(admin_update_auth))
         .route("/dashboard/admin/accent", post(admin_update_accent))
         .route("/dashboard/admin/oidc", post(admin_update_oidc))
+        .route("/dashboard/admin/ldap", post(admin_update_ldap))
+        .route("/dashboard/admin/ldap/test", post(admin_test_ldap))
         .route("/dashboard/admin/logo", post(admin_upload_logo))
         .route("/dashboard/admin/logo/delete", post(admin_delete_logo))
         .route(
@@ -11586,6 +11588,47 @@ async fn admin_dashboard(
         .map(|c| c.oidc_auto_register)
         .unwrap_or(true);
 
+    let ldap_enabled = auth_config
+        .as_ref()
+        .map(|c| c.ldap_enabled)
+        .unwrap_or(false);
+    let ldap_server_url = auth_config
+        .as_ref()
+        .and_then(|c| c.ldap_server_url.clone())
+        .unwrap_or_default();
+    let ldap_tls_mode = auth_config
+        .as_ref()
+        .map(|c| c.ldap_tls_mode.clone())
+        .unwrap_or_else(|| "starttls".to_string());
+    let ldap_bind_dn = auth_config
+        .as_ref()
+        .and_then(|c| c.ldap_bind_dn.clone())
+        .unwrap_or_default();
+    let ldap_user_search_base = auth_config
+        .as_ref()
+        .and_then(|c| c.ldap_user_search_base.clone())
+        .unwrap_or_default();
+    let ldap_user_filter = auth_config
+        .as_ref()
+        .map(|c| c.ldap_user_filter.clone())
+        .unwrap_or_else(|| "(uid={username})".to_string());
+    let ldap_email_attr = auth_config
+        .as_ref()
+        .map(|c| c.ldap_email_attr.clone())
+        .unwrap_or_else(|| "mail".to_string());
+    let ldap_name_attr = auth_config
+        .as_ref()
+        .map(|c| c.ldap_name_attr.clone())
+        .unwrap_or_else(|| "cn".to_string());
+    let ldap_groups_attr = auth_config
+        .as_ref()
+        .and_then(|c| c.ldap_groups_attr.clone())
+        .unwrap_or_default();
+    let ldap_auto_register = auth_config
+        .as_ref()
+        .map(|c| c.ldap_auto_register)
+        .unwrap_or(true);
+
     // Fetch SMTP config (first one found)
     let smtp: Option<(String, i32, String, bool)> =
         sqlx::query_as("SELECT host, port, from_email, enabled FROM smtp_config LIMIT 1")
@@ -11626,6 +11669,16 @@ async fn admin_dashboard(
             oidc_issuer_url => oidc_issuer_url,
             oidc_client_id => oidc_client_id,
             oidc_auto_register => oidc_auto_register,
+            ldap_enabled => ldap_enabled,
+            ldap_server_url => ldap_server_url,
+            ldap_tls_mode => ldap_tls_mode,
+            ldap_bind_dn => ldap_bind_dn,
+            ldap_user_search_base => ldap_user_search_base,
+            ldap_user_filter => ldap_user_filter,
+            ldap_email_attr => ldap_email_attr,
+            ldap_name_attr => ldap_name_attr,
+            ldap_groups_attr => ldap_groups_attr,
+            ldap_auto_register => ldap_auto_register,
             smtp_configured => smtp_configured,
             smtp_host => smtp_host,
             smtp_port => smtp_port,
@@ -11902,6 +11955,230 @@ async fn admin_update_oidc(
     tracing::info!(admin = %_admin.0.email, "admin: OIDC config updated");
 
     Redirect::to("/dashboard/admin").into_response()
+}
+
+#[derive(Deserialize)]
+struct AdminLdapForm {
+    _csrf: Option<String>,
+    ldap_enabled: Option<String>,
+    ldap_server_url: Option<String>,
+    ldap_tls_mode: Option<String>,
+    ldap_bind_dn: Option<String>,
+    ldap_bind_password: Option<String>,
+    ldap_user_search_base: Option<String>,
+    ldap_user_filter: Option<String>,
+    ldap_email_attr: Option<String>,
+    ldap_name_attr: Option<String>,
+    ldap_groups_attr: Option<String>,
+    ldap_auto_register: Option<String>,
+}
+
+fn validate_ldap_form(form: &AdminLdapForm) -> Result<(), &'static str> {
+    let mode = form.ldap_tls_mode.as_deref().unwrap_or("starttls");
+    if !matches!(mode, "ldaps" | "starttls" | "plain") {
+        return Err("Invalid TLS mode");
+    }
+    let filter = form.ldap_user_filter.as_deref().unwrap_or("");
+    if !filter.contains("{username}") {
+        return Err("User filter must contain {username} placeholder");
+    }
+    let server_url = form.ldap_server_url.as_deref().unwrap_or("").trim();
+    if !server_url.is_empty()
+        && !server_url.starts_with("ldap://")
+        && !server_url.starts_with("ldaps://")
+    {
+        return Err("Server URL must start with ldap:// or ldaps://");
+    }
+    Ok(())
+}
+
+async fn admin_update_ldap(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminLdapForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+    if let Err(msg) = validate_ldap_form(&form) {
+        return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
+    }
+
+    let ldap_enabled = form.ldap_enabled.is_some();
+    let auto_register = form.ldap_auto_register.is_some();
+    let server_url = form.ldap_server_url.filter(|s| !s.trim().is_empty());
+    let tls_mode = form
+        .ldap_tls_mode
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "starttls".to_string());
+    let bind_dn = form.ldap_bind_dn.filter(|s| !s.trim().is_empty());
+    let user_search_base = form.ldap_user_search_base.filter(|s| !s.trim().is_empty());
+    let user_filter = form
+        .ldap_user_filter
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "(uid={username})".to_string());
+    let email_attr = form
+        .ldap_email_attr
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "mail".to_string());
+    let name_attr = form
+        .ldap_name_attr
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "cn".to_string());
+    let groups_attr = form.ldap_groups_attr.filter(|s| !s.trim().is_empty());
+
+    let password_provided = form
+        .ldap_bind_password
+        .as_ref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+
+    if password_provided {
+        let plaintext = form.ldap_bind_password.unwrap_or_default();
+        let encrypted = match crate::crypto::encrypt_password(&state.secret_key, &plaintext) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to encrypt LDAP bind password");
+                return (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "encryption failed",
+                )
+                    .into_response();
+            }
+        };
+        let _ = sqlx::query(
+            "UPDATE auth_config SET ldap_enabled = ?, ldap_server_url = ?, ldap_tls_mode = ?, \
+             ldap_bind_dn = ?, ldap_bind_password = ?, ldap_user_search_base = ?, \
+             ldap_user_filter = ?, ldap_email_attr = ?, ldap_name_attr = ?, \
+             ldap_groups_attr = ?, ldap_auto_register = ?, updated_at = datetime('now') \
+             WHERE id = 'singleton'",
+        )
+        .bind(ldap_enabled)
+        .bind(&server_url)
+        .bind(&tls_mode)
+        .bind(&bind_dn)
+        .bind(&encrypted)
+        .bind(&user_search_base)
+        .bind(&user_filter)
+        .bind(&email_attr)
+        .bind(&name_attr)
+        .bind(&groups_attr)
+        .bind(auto_register)
+        .execute(&state.pool)
+        .await;
+    } else {
+        let _ = sqlx::query(
+            "UPDATE auth_config SET ldap_enabled = ?, ldap_server_url = ?, ldap_tls_mode = ?, \
+             ldap_bind_dn = ?, ldap_user_search_base = ?, ldap_user_filter = ?, \
+             ldap_email_attr = ?, ldap_name_attr = ?, ldap_groups_attr = ?, \
+             ldap_auto_register = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(ldap_enabled)
+        .bind(&server_url)
+        .bind(&tls_mode)
+        .bind(&bind_dn)
+        .bind(&user_search_base)
+        .bind(&user_filter)
+        .bind(&email_attr)
+        .bind(&name_attr)
+        .bind(&groups_attr)
+        .bind(auto_register)
+        .execute(&state.pool)
+        .await;
+    }
+
+    tracing::info!(admin = %_admin.0.email, "admin: LDAP config updated");
+
+    Redirect::to("/dashboard/admin").into_response()
+}
+
+/// Live connection test. Uses the form values (so admins can try before saving)
+/// but falls back to the stored bind password when the form password is blank.
+async fn admin_test_ldap(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminLdapForm>,
+) -> Response {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+    if let Err(msg) = validate_ldap_form(&form) {
+        return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
+    }
+
+    // Build a transient config from the form. Encrypt the provided password so
+    // ldap_test_connection can decrypt-at-use like it does for the stored one.
+    let bind_password_enc = if form
+        .ldap_bind_password
+        .as_ref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false)
+    {
+        let plaintext = form.ldap_bind_password.clone().unwrap_or_default();
+        match crate::crypto::encrypt_password(&state.secret_key, &plaintext) {
+            Ok(e) => Some(e),
+            Err(e) => {
+                return (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("encryption failed: {}", e),
+                )
+                    .into_response()
+            }
+        }
+    } else {
+        // Reuse stored password (already encrypted).
+        match crate::auth::get_auth_config(&state.pool).await {
+            Ok(c) => c.ldap_bind_password,
+            Err(_) => None,
+        }
+    };
+
+    let config = crate::models::AuthConfig {
+        id: "singleton".to_string(),
+        registration_enabled: true,
+        allowed_email_domains: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+        oidc_enabled: false,
+        oidc_issuer_url: None,
+        oidc_client_id: None,
+        oidc_client_secret: None,
+        oidc_auto_register: true,
+        ldap_enabled: true,
+        ldap_server_url: form.ldap_server_url.filter(|s| !s.trim().is_empty()),
+        ldap_tls_mode: form
+            .ldap_tls_mode
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "starttls".to_string()),
+        ldap_bind_dn: form.ldap_bind_dn.filter(|s| !s.trim().is_empty()),
+        ldap_bind_password: bind_password_enc,
+        ldap_user_search_base: form.ldap_user_search_base.filter(|s| !s.trim().is_empty()),
+        ldap_user_filter: form
+            .ldap_user_filter
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "(uid={username})".to_string()),
+        ldap_email_attr: form
+            .ldap_email_attr
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "mail".to_string()),
+        ldap_name_attr: form
+            .ldap_name_attr
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "cn".to_string()),
+        ldap_groups_attr: form.ldap_groups_attr.filter(|s| !s.trim().is_empty()),
+        ldap_auto_register: true,
+    };
+
+    match crate::auth::ldap_test_connection(&state.secret_key, &config).await {
+        Ok(_) => (axum::http::StatusCode::OK, "LDAP connection OK").into_response(),
+        Err(e) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            format!("LDAP test failed: {}", e),
+        )
+            .into_response(),
+    }
 }
 
 // --- Logo management ---

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -315,6 +315,106 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
   </form>
 </div>
 
+<!-- LDAP settings -->
+<div class="card">
+  <h2>LDAP settings</h2>
+  <div style="margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
+    Status: {% if ldap_enabled %}<strong style="color: var(--success);">enabled</strong>{% else %}<span style="color: var(--text-muted);">disabled</span>{% endif %}
+    {% if ldap_server_url %}&middot; Server: <span style="color: var(--text-muted);">{{ ldap_server_url }}</span>{% endif %}
+  </div>
+  <form method="post" action="/dashboard/admin/ldap">
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="ldap_enabled" value="on" {% if ldap_enabled %}checked{% endif %} style="width: 1rem; height: 1rem;">
+        LDAP enabled
+      </label>
+    </div>
+    <div class="form-group">
+      <label>Server URL <span class="hint">(ldaps://… for implicit TLS, ldap://… for StartTLS or plain)</span></label>
+      <input type="text" name="ldap_server_url" value="{{ ldap_server_url }}" placeholder="ldaps://ldap.example.com:636">
+    </div>
+    <div class="form-group">
+      <label>TLS mode</label>
+      <select name="ldap_tls_mode">
+        <option value="ldaps" {% if ldap_tls_mode == 'ldaps' %}selected{% endif %}>ldaps (implicit TLS)</option>
+        <option value="starttls" {% if ldap_tls_mode == 'starttls' %}selected{% endif %}>StartTLS (upgrade from plain)</option>
+        <option value="plain" {% if ldap_tls_mode == 'plain' %}selected{% endif %}>plain (no encryption — not recommended)</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label>Bind DN <span class="hint">(service account used for searches; leave empty for anonymous bind)</span></label>
+      <input type="text" name="ldap_bind_dn" value="{{ ldap_bind_dn }}" placeholder="cn=calrs,ou=services,dc=example,dc=com">
+    </div>
+    <div class="form-group">
+      <label>Bind password <span class="hint">(leave empty to keep current — stored encrypted)</span></label>
+      <input type="password" name="ldap_bind_password" value="" placeholder="Leave empty to keep unchanged">
+    </div>
+    <div class="form-group">
+      <label>User search base</label>
+      <input type="text" name="ldap_user_search_base" value="{{ ldap_user_search_base }}" placeholder="ou=users,dc=example,dc=com">
+    </div>
+    <div class="form-group">
+      <label>User filter <span class="hint">(use <code>{username}</code> as a placeholder — it is filter-escaped at query time)</span></label>
+      <input type="text" name="ldap_user_filter" value="{{ ldap_user_filter }}" placeholder="(uid={username})">
+    </div>
+    <div class="form-group" style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem;">
+      <div>
+        <label>Email attribute</label>
+        <input type="text" name="ldap_email_attr" value="{{ ldap_email_attr }}" placeholder="mail">
+      </div>
+      <div>
+        <label>Name attribute</label>
+        <input type="text" name="ldap_name_attr" value="{{ ldap_name_attr }}" placeholder="cn">
+      </div>
+      <div>
+        <label>Groups attribute <span class="hint">(blank = skip)</span></label>
+        <input type="text" name="ldap_groups_attr" value="{{ ldap_groups_attr }}" placeholder="memberOf">
+      </div>
+    </div>
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="ldap_auto_register" value="on" {% if ldap_auto_register %}checked{% endif %} style="width: 1rem; height: 1rem;">
+        Auto-register new users from LDAP
+      </label>
+    </div>
+    <div style="display: flex; gap: 0.75rem;">
+      <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save LDAP settings</button>
+      <button type="button" id="ldap-test-btn" class="slot-btn" style="cursor: pointer;">Test connection</button>
+    </div>
+    <div id="ldap-test-result" style="margin-top: 0.75rem; font-size: 0.875rem;"></div>
+  </form>
+</div>
+<script>
+(function() {
+  var btn = document.getElementById('ldap-test-btn');
+  if (!btn) return;
+  btn.addEventListener('click', async function() {
+    var out = document.getElementById('ldap-test-result');
+    out.textContent = 'Testing…';
+    out.style.color = '';
+    try {
+      var params = new URLSearchParams();
+      // Include the current form values so the admin can test changes before saving.
+      var form = btn.closest('form');
+      for (var el of form.elements) {
+        if (el.name && el.type !== 'button') params.append(el.name, el.value);
+      }
+      var resp = await fetch('/dashboard/admin/ldap/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+      var text = await resp.text();
+      out.textContent = text;
+      out.style.color = resp.ok ? 'var(--success)' : 'var(--danger, #c00)';
+    } catch (e) {
+      out.textContent = 'Request failed: ' + e;
+      out.style.color = 'var(--danger, #c00)';
+    }
+  });
+})();
+</script>
+
 <!-- SMTP settings -->
 <div class="card">
   <h2>SMTP settings</h2>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -24,14 +24,19 @@
 
   <form method="post" action="/auth/login">
     <div class="form-group">
+      {% if ldap_enabled %}
+      <label for="email">Email or username</label>
+      <input type="text" id="email" name="email" required placeholder="you@example.com or username" autocomplete="username">
+      {% else %}
       <label for="email">Email</label>
       <input type="email" id="email" name="email" required placeholder="you@example.com" autocomplete="email">
+      {% endif %}
     </div>
     <div class="form-group">
       <label for="password">Password</label>
       <input type="password" id="password" name="password" required autocomplete="current-password">
     </div>
-    <button type="submit" class="btn{% if oidc_enabled %} btn-secondary{% endif %}">Sign in with email</button>
+    <button type="submit" class="btn{% if oidc_enabled %} btn-secondary{% endif %}">{% if ldap_enabled %}Sign in{% else %}Sign in with email{% endif %}</button>
   </form>
 
   {% if registration_enabled %}


### PR DESCRIPTION
## Summary
The admin-controlled \`company_link\` is rendered as a clickable anchor on every public booking page. Without scheme validation, an admin (or an attacker who has compromised an admin account) could set it to \`javascript:alert(1)\` and turn the link into stored XSS for every visitor.

This PR validates the scheme on both ends:

- **Write** (\`admin_update_company_link\`): rejects anything that isn't \`http://\` or \`https://\` and redirects back to \`/dashboard/admin?error=...\` so the admin sees the rejection.
- **Read** (\`get_company_link\`): silently drops a non-http(s) value as defense-in-depth, in case a bad value slipped in via a manual DB edit or older release.

## Why both ends
The write-side check is the primary gate. The read-side check exists because the admin UI was the original ingress and we can't rule out other paths historically writing the column (e.g. a future migration, manual sqlite-cli edit). Cheap belt-and-suspenders.

## Tests added
- \`company_link_accepts_http_and_https\` (valid cases, including upper-case scheme + whitespace)
- \`company_link_rejects_javascript_uri\` (the actual attack)
- \`company_link_rejects_other_dangerous_schemes\` (\`data:\`, \`vbscript:\`, \`file:\`)
- \`company_link_rejects_unschemed_input\` (bare hostname, paths, protocol-relative \`//\`)

## Test plan
- [x] \`cargo build\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` (611 passing)
- [ ] Reviewer: as admin, try saving \`javascript:alert(1)\` in the company-link field. Confirm the admin panel surfaces \"Company link must start with http:// or https://\" and the value is not persisted.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)