### PR TITLE
feat: minimum notice for guest cancel and reschedule

### DIFF
--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -223,6 +223,11 @@ email-cancel-headline-by-guest = Your booking has been cancelled.
 email-cancel-ics-attached-plain = A calendar cancellation is attached.
 email-cancel-ics-attached-html = A calendar cancellation is attached to this email.
 
+# Confirmation email: notice-window policy lines (src/email.rs)
+
+email-confirm-cancel-notice = Note: cancellation requires at least { $minutes } minutes notice.
+email-confirm-reschedule-notice = Note: rescheduling requires at least { $minutes } minutes notice.
+
 # Event type form: cancel/reschedule minimum notice (templates/event_type_form.html)
 
 event-type-form-cancel-notice-label = Minimum notice to cancel

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -222,3 +222,23 @@ email-cancel-headline-by-host = Your booking has been cancelled by { $host }.
 email-cancel-headline-by-guest = Your booking has been cancelled.
 email-cancel-ics-attached-plain = A calendar cancellation is attached.
 email-cancel-ics-attached-html = A calendar cancellation is attached to this email.
+
+# Event type form: cancel/reschedule minimum notice (templates/event_type_form.html)
+
+event-type-form-cancel-notice-label = Minimum notice to cancel
+event-type-form-reschedule-notice-label = Minimum notice to reschedule
+event-type-form-notice-help = Leave empty for no restriction.
+event-type-form-notice-unit-minutes = minutes
+event-type-form-notice-unit-hours = hours
+event-type-form-notice-unit-days = days
+
+# Booking confirmation: cancel/reschedule policy notices (templates/confirmed.html)
+
+confirmed-cancel-notice-info = Cancellation requires at least { $minutes } minutes notice before the meeting.
+confirmed-reschedule-notice-info = Rescheduling requires at least { $minutes } minutes notice before the meeting.
+
+# Booking action blocked page (templates/booking_action_blocked.html)
+
+booking-blocked-title-cancel = This booking can no longer be cancelled online
+booking-blocked-title-reschedule = This booking can no longer be rescheduled online
+booking-blocked-body = The host requires at least { $minutes } minutes of notice. If you cannot attend, please email <a href="mailto:{ $host_email }">{ $host_email }</a> directly.

--- a/migrations/050_min_notice_cancel_reschedule.sql
+++ b/migrations/050_min_notice_cancel_reschedule.sql
@@ -1,0 +1,6 @@
+-- Per-event-type minimum notice window for guest-initiated cancel and reschedule.
+-- NULL or 0 means no restriction (the existing behaviour).
+-- Values are stored in minutes; the form lets the user pick minutes/hours/days
+-- and converts to minutes before INSERT/UPDATE.
+ALTER TABLE event_types ADD COLUMN cancel_notice_min INTEGER;
+ALTER TABLE event_types ADD COLUMN reschedule_notice_min INTEGER;

--- a/src/db.rs
+++ b/src/db.rs
@@ -215,6 +215,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "049_smtp_decouple_account",
             include_str!("../migrations/049_smtp_decouple_account.sql"),
         ),
+        (
+            "050_min_notice_cancel_reschedule",
+            include_str!("../migrations/050_min_notice_cancel_reschedule.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -796,7 +800,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 49, "All 49 migrations should be tracked");
+        assert_eq!(count.0, 50, "All 50 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -810,7 +814,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 49, "Still 49 migrations after second run");
+        assert_eq!(count.0, 50, "Still 50 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -453,14 +453,22 @@ pub async fn send_guest_confirmation_ex(
     let ics_attached_html = t(lang, "email-confirm-ics-attached-html");
     let signature = t(lang, "email-signature");
 
-    // Plain English notice lines, mentioned just before the cancel link in
-    // both the plain and HTML bodies. The frontend agent will localize.
-    let cancel_notice_line = cancel_notice_min
-        .filter(|m| *m > 0)
-        .map(|m| format!("Note: cancellation requires at least {} minutes notice.", m));
-    let reschedule_notice_line = reschedule_notice_min
-        .filter(|m| *m > 0)
-        .map(|m| format!("Note: rescheduling requires at least {} minutes notice.", m));
+    // Notice-window policy lines, mentioned just before the cancel link in
+    // both the plain and HTML bodies. Translated to the guest's language.
+    let cancel_notice_line = cancel_notice_min.filter(|m| *m > 0).map(|m| {
+        ta(
+            lang,
+            "email-confirm-cancel-notice",
+            [("minutes", m.to_string().as_str())],
+        )
+    });
+    let reschedule_notice_line = reschedule_notice_min.filter(|m| *m > 0).map(|m| {
+        ta(
+            lang,
+            "email-confirm-reschedule-notice",
+            [("minutes", m.to_string().as_str())],
+        )
+    });
 
     let plain = format!(
         "{}\n\n\

--- a/src/email.rs
+++ b/src/email.rs
@@ -414,7 +414,7 @@ pub async fn send_guest_confirmation(
     details: &BookingDetails,
     cancel_url: Option<&str>,
 ) -> Result<()> {
-    send_guest_confirmation_ex(config, details, cancel_url, None).await
+    send_guest_confirmation_ex(config, details, cancel_url, None, None, None).await
 }
 
 pub async fn send_guest_confirmation_ex(
@@ -422,6 +422,8 @@ pub async fn send_guest_confirmation_ex(
     details: &BookingDetails,
     cancel_url: Option<&str>,
     reschedule_url: Option<&str>,
+    cancel_notice_min: Option<i32>,
+    reschedule_notice_min: Option<i32>,
 ) -> Result<()> {
     let ics = generate_ics(details, "REQUEST");
     let lang = guest_lang(details);
@@ -451,6 +453,15 @@ pub async fn send_guest_confirmation_ex(
     let ics_attached_html = t(lang, "email-confirm-ics-attached-html");
     let signature = t(lang, "email-signature");
 
+    // Plain English notice lines, mentioned just before the cancel link in
+    // both the plain and HTML bodies. The frontend agent will localize.
+    let cancel_notice_line = cancel_notice_min
+        .filter(|m| *m > 0)
+        .map(|m| format!("Note: cancellation requires at least {} minutes notice.", m));
+    let reschedule_notice_line = reschedule_notice_min
+        .filter(|m| *m > 0)
+        .map(|m| format!("Note: rescheduling requires at least {} minutes notice.", m));
+
     let plain = format!(
         "{}\n\n\
          {}\n\n\
@@ -460,7 +471,7 @@ pub async fn send_guest_confirmation_ex(
          {} {}\n\
          {}{}\
          {}\n\
-         {}\n\
+         {}{}{}\
          {}",
         greeting,
         headline,
@@ -483,6 +494,14 @@ pub async fn send_guest_confirmation_ex(
             .map(|n| format!("{} {}\n", label_notes, n))
             .unwrap_or_default(),
         ics_attached_plain,
+        reschedule_notice_line
+            .as_ref()
+            .map(|l| format!("\n{}\n", l))
+            .unwrap_or_default(),
+        cancel_notice_line
+            .as_ref()
+            .map(|l| format!("\n{}\n", l))
+            .unwrap_or_default(),
         cancel_url
             .map(|u| format!(
                 "\n{}\n",
@@ -539,12 +558,23 @@ pub async fn send_guest_confirmation_ex(
         });
     }
 
+    // Append notice lines to the footer note so they sit just below the
+    // action buttons, alongside the existing "ICS attached" copy.
+    let mut footer_note_html = ics_attached_html.clone();
+    if let Some(line) = &reschedule_notice_line {
+        footer_note_html.push('\n');
+        footer_note_html.push_str(line);
+    }
+    if let Some(line) = &cancel_notice_line {
+        footer_note_html.push('\n');
+        footer_note_html.push_str(line);
+    }
     let html = render_html_email_with_actions(
         &h(&greeting),
         &headline,
         "#16a34a",
         &rows,
-        Some(&ics_attached_html),
+        Some(&footer_note_html),
         &actions,
     );
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -128,8 +128,14 @@ pub struct EventType {
     pub created_at: String,
     pub group_id: Option<String>,
     pub created_by_user_id: Option<String>,
-    pub is_private: bool, // deprecated — use `visibility` column
+    pub is_private: bool, // deprecated, use `visibility` column
     pub visibility: String,
+    /// Minimum notice (in minutes) required for a guest-initiated cancel.
+    /// `None` or `Some(0)` means no restriction.
+    pub cancel_notice_min: Option<i32>,
+    /// Minimum notice (in minutes) required for a guest-initiated reschedule.
+    /// `None` or `Some(0)` means no restriction.
+    pub reschedule_notice_min: Option<i32>,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1484,6 +1484,44 @@ fn parse_optional_positive_int(s: &str) -> Option<i32> {
     }
 }
 
+/// Convert a (value, unit) pair from the event type form into a minute count
+/// suitable for storage. Returns `None` when the value is blank, zero, or
+/// invalid (no restriction). Unit defaults to minutes if missing or unknown.
+fn parse_notice_to_minutes(value: &str, unit: &str) -> Option<i32> {
+    let v = value.trim();
+    if v.is_empty() {
+        return None;
+    }
+    let n: i32 = match v.parse() {
+        Ok(n) if n > 0 => n,
+        _ => return None,
+    };
+    let multiplier = match unit.trim() {
+        "days" => 1440,
+        "hours" => 60,
+        _ => 1, // minutes (default)
+    };
+    n.checked_mul(multiplier).filter(|m| *m > 0)
+}
+
+/// Pick the most natural unit for displaying a stored minute value back in
+/// the form: divisible by 1440 → days, divisible by 60 → hours, else
+/// minutes. Returns `(value, unit)`. Zero / negative / NULL all collapse to
+/// `(0, "minutes")` so the form shows an empty restriction.
+fn minutes_to_notice_form(min: Option<i32>) -> (i32, &'static str) {
+    let m = min.unwrap_or(0);
+    if m <= 0 {
+        return (0, "minutes");
+    }
+    if m % 1440 == 0 {
+        (m / 1440, "days")
+    } else if m % 60 == 0 {
+        (m / 60, "hours")
+    } else {
+        (m, "minutes")
+    }
+}
+
 fn parse_dynamic_group_usernames(combined: &str) -> Result<Vec<String>, String> {
     let mut seen = std::collections::HashSet::new();
     let unique: Vec<String> = combined
@@ -3354,19 +3392,31 @@ async fn confirm_booking(
     let user = &auth_user.user;
 
     // Verify the booking belongs to this user and is pending
-    let booking: Option<(String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>)> =
-        sqlx::query_as(
-            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, et.location_value, b.cancel_token, COALESCE(b.guest_timezone, 'UTC'), b.reschedule_token
+    let booking: Option<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        Option<String>,
+        String,
+    )> = sqlx::query_as(
+        "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, et.location_value, b.cancel_token, COALESCE(b.guest_timezone, 'UTC'), b.reschedule_token, et.id
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
              WHERE b.id = ? AND a.user_id = ? AND b.status = 'pending'",
-        )
-        .bind(&booking_id)
-        .bind(&user.id)
-        .fetch_optional(&state.pool)
-        .await
-        .unwrap_or(None);
+    )
+    .bind(&booking_id)
+    .bind(&user.id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
 
     let (
         bid,
@@ -3380,6 +3430,7 @@ async fn confirm_booking(
         cancel_token,
         guest_timezone,
         reschedule_token,
+        et_id,
     ) = match booking {
         Some(b) => b,
         None => return Redirect::to("/dashboard/bookings").into_response(),
@@ -3436,15 +3487,19 @@ async fn confirm_booking(
                 .as_ref()
                 .map(|base| format!("{}/booking/reschedule/{}", base.trim_end_matches('/'), t))
         });
+        let (cancel_notice_min, reschedule_notice_min) =
+            fetch_event_type_notice_minutes(&state.pool, &et_id).await;
         let _ = crate::email::send_guest_confirmation_ex(
             &smtp_config,
             &details,
             guest_cancel_url.as_deref(),
             guest_reschedule_url.as_deref(),
+            cancel_notice_min,
+            reschedule_notice_min,
         )
         .await;
 
-        // Also send host a confirmation email (no ICS — event pushed via CalDAV)
+        // Also send host a confirmation email (no ICS, event pushed via CalDAV)
         if let Err(e) = crate::email::send_host_booking_confirmed(&smtp_config, &details).await {
             tracing::error!(error = %e, host_email = %details.host_email, "host confirmation email failed");
         }
@@ -3509,6 +3564,18 @@ struct EventTypeForm {
     // (e.g. "Europe/Paris"). Optional on submit — if blank, create falls back
     // to the submitting user's timezone.
     timezone: Option<String>,
+    // Minimum notice required for guest-initiated cancel. The form posts a
+    // numeric value plus a unit (minutes / hours / days); the handler
+    // converts to minutes and stores NULL when the value is empty.
+    #[serde(default)]
+    cancel_notice_value: String,
+    #[serde(default)]
+    cancel_notice_unit: String,
+    // Minimum notice required for guest-initiated reschedule. Same shape.
+    #[serde(default)]
+    reschedule_notice_value: String,
+    #[serde(default)]
+    reschedule_notice_unit: String,
 }
 
 async fn new_event_type_form(
@@ -3622,6 +3689,10 @@ async fn new_event_type_form(
             form_first_slot_only => false,
             form_frequency_limits => "",
             form_timezone => &user.timezone,
+            form_cancel_notice_value => 0,
+            form_cancel_notice_unit => "minutes",
+            form_reschedule_notice_value => 0,
+            form_reschedule_notice_unit => "minutes",
             tz_options => common_timezones_with(&user.timezone)
                 .iter()
                 .map(|(iana, label)| context! { value => iana, label => label })
@@ -3776,10 +3847,14 @@ async fn create_event_type(
 
     let first_slot_only = form.first_slot_only.as_deref() == Some("on");
     let timezone = normalize_event_type_tz(form.timezone.as_deref(), &user.timezone);
+    let cancel_notice_min =
+        parse_notice_to_minutes(&form.cancel_notice_value, &form.cancel_notice_unit);
+    let reschedule_notice_min =
+        parse_notice_to_minutes(&form.reschedule_notice_value, &form.reschedule_notice_unit);
 
     let _ = sqlx::query(
-        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, reminder_minutes, visibility, max_additional_guests, default_calendar_view, first_slot_only, timezone)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, reminder_minutes, visibility, max_additional_guests, default_calendar_view, first_slot_only, timezone, cancel_notice_min, reschedule_notice_min)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&et_id)
     .bind(&account_id)
@@ -3802,6 +3877,8 @@ async fn create_event_type(
     .bind(&default_calendar_view)
     .bind(first_slot_only as i32)
     .bind(&timezone)
+    .bind(cancel_notice_min)
+    .bind(reschedule_notice_min)
     .execute(&state.pool)
     .await;
 
@@ -3963,6 +4040,29 @@ async fn edit_event_type_form(
             .flatten()
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| user.timezone.clone());
+
+    // Min-notice for guest-initiated cancel and reschedule (NULL = no
+    // restriction). Pulled separately to keep the existing tuple compact.
+    let cancel_notice_min: Option<i32> = sqlx::query_scalar::<_, Option<i32>>(
+        "SELECT cancel_notice_min FROM event_types WHERE id = ?",
+    )
+    .bind(&et_id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten();
+    let reschedule_notice_min: Option<i32> = sqlx::query_scalar::<_, Option<i32>>(
+        "SELECT reschedule_notice_min FROM event_types WHERE id = ?",
+    )
+    .bind(&et_id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten();
+    let (form_cancel_notice_value, form_cancel_notice_unit) =
+        minutes_to_notice_form(cancel_notice_min);
+    let (form_reschedule_notice_value, form_reschedule_notice_unit) =
+        minutes_to_notice_form(reschedule_notice_min);
 
     // Get current availability rules
     let all_rules: Vec<(i32, String, String)> = sqlx::query_as(
@@ -4160,6 +4260,10 @@ async fn edit_event_type_form(
             form_first_slot_only => first_slot_only != 0,
             form_frequency_limits => form_frequency_limits,
             form_timezone => &form_timezone,
+            form_cancel_notice_value => form_cancel_notice_value,
+            form_cancel_notice_unit => form_cancel_notice_unit,
+            form_reschedule_notice_value => form_reschedule_notice_value,
+            form_reschedule_notice_unit => form_reschedule_notice_unit,
             tz_options => common_timezones_with(&form_timezone)
                 .iter()
                 .map(|(iana, label)| context! { value => iana, label => label })
@@ -4269,9 +4373,13 @@ async fn update_event_type(
     };
 
     let timezone = normalize_event_type_tz(form.timezone.as_deref(), &user.timezone);
+    let cancel_notice_min =
+        parse_notice_to_minutes(&form.cancel_notice_value, &form.cancel_notice_unit);
+    let reschedule_notice_min =
+        parse_notice_to_minutes(&form.reschedule_notice_value, &form.reschedule_notice_unit);
 
     let _ = sqlx::query(
-        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ? WHERE id = ?",
+        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ?, cancel_notice_min = ?, reschedule_notice_min = ? WHERE id = ?",
     )
     .bind(&new_slug)
     .bind(form.title.trim())
@@ -4291,6 +4399,8 @@ async fn update_event_type(
     .bind(&default_calendar_view)
     .bind(if form.first_slot_only.as_deref() == Some("on") { 1 } else { 0 })
     .bind(&timezone)
+    .bind(cancel_notice_min)
+    .bind(reschedule_notice_min)
     .bind(&et_id)
     .execute(&state.pool)
     .await;
@@ -5224,6 +5334,18 @@ fn render_event_type_form_error(
             form_first_slot_only => form.first_slot_only.as_deref() == Some("on"),
             form_frequency_limits => form.frequency_limits.as_str(),
             form_timezone => form.timezone.as_deref().unwrap_or(&auth_user.user.timezone),
+            form_cancel_notice_value => parse_int_field(&form.cancel_notice_value, 0),
+            form_cancel_notice_unit => match form.cancel_notice_unit.as_str() {
+                "hours" => "hours",
+                "days" => "days",
+                _ => "minutes",
+            },
+            form_reschedule_notice_value => parse_int_field(&form.reschedule_notice_value, 0),
+            form_reschedule_notice_unit => match form.reschedule_notice_unit.as_str() {
+                "hours" => "hours",
+                "days" => "days",
+                _ => "minutes",
+            },
             tz_options => common_timezones_with(form.timezone.as_deref().unwrap_or(&auth_user.user.timezone))
                 .iter()
                 .map(|(iana, label)| context! { value => iana, label => label })
@@ -6134,10 +6256,14 @@ async fn create_group_event_type(
 
     let first_slot_only = form.first_slot_only.as_deref() == Some("on");
     let timezone = normalize_event_type_tz(form.timezone.as_deref(), &user.timezone);
+    let cancel_notice_min =
+        parse_notice_to_minutes(&form.cancel_notice_value, &form.cancel_notice_unit);
+    let reschedule_notice_min =
+        parse_notice_to_minutes(&form.reschedule_notice_value, &form.reschedule_notice_unit);
 
     let _ = sqlx::query(
-        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, default_calendar_view, first_slot_only, timezone)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, default_calendar_view, first_slot_only, timezone, cancel_notice_min, reschedule_notice_min)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&et_id)
     .bind(&account_id)
@@ -6157,6 +6283,8 @@ async fn create_group_event_type(
     .bind(&default_calendar_view)
     .bind(first_slot_only as i32)
     .bind(&timezone)
+    .bind(cancel_notice_min)
+    .bind(reschedule_notice_min)
     .execute(&state.pool)
     .await;
 
@@ -6312,6 +6440,29 @@ async fn edit_group_event_type_form(
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| user.timezone.clone());
 
+    // Min-notice for guest-initiated cancel and reschedule (NULL = no
+    // restriction). Pulled separately to keep the existing tuple compact.
+    let cancel_notice_min: Option<i32> = sqlx::query_scalar::<_, Option<i32>>(
+        "SELECT cancel_notice_min FROM event_types WHERE id = ?",
+    )
+    .bind(&et_id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten();
+    let reschedule_notice_min: Option<i32> = sqlx::query_scalar::<_, Option<i32>>(
+        "SELECT reschedule_notice_min FROM event_types WHERE id = ?",
+    )
+    .bind(&et_id)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten();
+    let (form_cancel_notice_value, form_cancel_notice_unit) =
+        minutes_to_notice_form(cancel_notice_min);
+    let (form_reschedule_notice_value, form_reschedule_notice_unit) =
+        minutes_to_notice_form(reschedule_notice_min);
+
     // Get current availability rules
     let all_rules: Vec<(i32, String, String)> = sqlx::query_as(
         "SELECT day_of_week, start_time, end_time FROM availability_rules WHERE event_type_id = ? ORDER BY day_of_week, start_time",
@@ -6462,6 +6613,10 @@ async fn edit_group_event_type_form(
             form_default_calendar_view => default_calendar_view,
             form_first_slot_only => first_slot_only != 0,
             form_timezone => &form_timezone,
+            form_cancel_notice_value => form_cancel_notice_value,
+            form_cancel_notice_unit => form_cancel_notice_unit,
+            form_reschedule_notice_value => form_reschedule_notice_value,
+            form_reschedule_notice_unit => form_reschedule_notice_unit,
             tz_options => common_timezones_with(&form_timezone)
                 .iter()
                 .map(|(iana, label)| context! { value => iana, label => label })
@@ -6581,9 +6736,13 @@ async fn update_group_event_type(
     };
 
     let timezone = normalize_event_type_tz(form.timezone.as_deref(), &user.timezone);
+    let cancel_notice_min =
+        parse_notice_to_minutes(&form.cancel_notice_value, &form.cancel_notice_unit);
+    let reschedule_notice_min =
+        parse_notice_to_minutes(&form.reschedule_notice_value, &form.reschedule_notice_unit);
 
     let _ = sqlx::query(
-        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ? WHERE id = ?",
+        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ?, cancel_notice_min = ?, reschedule_notice_min = ? WHERE id = ?",
     )
     .bind(&new_slug)
     .bind(form.title.trim())
@@ -6603,6 +6762,8 @@ async fn update_group_event_type(
     .bind(&default_calendar_view)
     .bind(if form.first_slot_only.as_deref() == Some("on") { 1 } else { 0 })
     .bind(&timezone)
+    .bind(cancel_notice_min)
+    .bind(reschedule_notice_min)
     .bind(&et_id)
     .execute(&state.pool)
     .await;
@@ -7685,6 +7846,9 @@ async fn handle_group_booking(
         .await;
     }
 
+    let (cancel_notice_min, reschedule_notice_min) =
+        fetch_event_type_notice_minutes(&state.pool, &et_id).await;
+
     // Send emails if SMTP is configured.
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
@@ -7727,6 +7891,8 @@ async fn handle_group_booking(
                 &details,
                 guest_cancel_url.as_deref(),
                 guest_reschedule_url.as_deref(),
+                cancel_notice_min,
+                reschedule_notice_min,
             )
             .await;
             let _ = crate::email::send_host_notification(&smtp_config, &details).await;
@@ -7752,6 +7918,8 @@ async fn handle_group_booking(
             location_type => loc_type,
             location_value => loc_value,
             additional_attendees => additional_attendees,
+            cancel_notice_min => cancel_notice_min,
+            reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
         })
@@ -8430,6 +8598,9 @@ async fn handle_dynamic_group_booking(
         .await;
     }
 
+    let (cancel_notice_min, reschedule_notice_min) =
+        fetch_event_type_notice_minutes(&state.pool, &et_id).await;
+
     // Send emails if SMTP is configured.
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
@@ -8472,6 +8643,8 @@ async fn handle_dynamic_group_booking(
                 &details,
                 guest_cancel_url.as_deref(),
                 guest_reschedule_url.as_deref(),
+                cancel_notice_min,
+                reschedule_notice_min,
             )
             .await;
             let _ = crate::email::send_host_notification(&smtp_config, &details).await;
@@ -8502,6 +8675,8 @@ async fn handle_dynamic_group_booking(
             location_type => loc_type,
             location_value => loc_value,
             additional_attendees => all_additional,
+            cancel_notice_min => cancel_notice_min,
+            reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
         })
@@ -9154,6 +9329,9 @@ async fn handle_booking_for_user(
             }
         }
 
+        let (cancel_notice_min, reschedule_notice_min) =
+            fetch_event_type_notice_minutes(&state.pool, &et_id).await;
+
         // Send emails if SMTP is configured.
         if let Ok(Some(smtp_config)) =
             crate::email::load_smtp_config(&state.pool, &state.secret_key).await
@@ -9196,6 +9374,8 @@ async fn handle_booking_for_user(
                     &details,
                     guest_cancel_url.as_deref(),
                     guest_reschedule_url.as_deref(),
+                    cancel_notice_min,
+                    reschedule_notice_min,
                 )
                 .await;
                 let _ = crate::email::send_host_notification(&smtp_config, &details).await;
@@ -9211,6 +9391,8 @@ async fn handle_booking_for_user(
         .unwrap_or_else(|| "Host".to_string());
 
     let date_label = crate::i18n::format_long_date(date, lang);
+    let (cancel_notice_min, reschedule_notice_min) =
+        fetch_event_type_notice_minutes(&state.pool, &et_id).await;
 
     let tmpl = match state.templates.get_template("confirmed.html") {
         Ok(t) => t,
@@ -9229,6 +9411,8 @@ async fn handle_booking_for_user(
             location_type => loc_type,
             location_value => loc_value,
             additional_attendees => additional_attendees,
+            cancel_notice_min => cancel_notice_min,
+            reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
         })
@@ -10909,6 +11093,9 @@ async fn handle_booking(
             }
         }
 
+        let (cancel_notice_min, reschedule_notice_min) =
+            fetch_event_type_notice_minutes(&state.pool, &et_id).await;
+
         // Send emails if SMTP is configured.
         if let Ok(Some(smtp_config)) =
             crate::email::load_smtp_config(&state.pool, &state.secret_key).await
@@ -10951,6 +11138,8 @@ async fn handle_booking(
                     &details,
                     guest_cancel_url.as_deref(),
                     guest_reschedule_url.as_deref(),
+                    cancel_notice_min,
+                    reschedule_notice_min,
                 )
                 .await;
                 let _ = crate::email::send_host_notification(&smtp_config, &details).await;
@@ -10969,6 +11158,8 @@ async fn handle_booking(
     .unwrap_or_else(|| "Host".to_string());
 
     let date_label = crate::i18n::format_long_date(date, lang);
+    let (cancel_notice_min, reschedule_notice_min) =
+        fetch_event_type_notice_minutes(&state.pool, &et_id).await;
 
     let tmpl = match state.templates.get_template("confirmed.html") {
         Ok(t) => t,
@@ -10985,6 +11176,8 @@ async fn handle_booking(
             notes => form.notes,
             pending => needs_approval,
             additional_attendees => additional_attendees,
+            cancel_notice_min => cancel_notice_min,
+            reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
         })
@@ -12469,15 +12662,19 @@ async fn approve_booking_by_token(
                 .as_ref()
                 .map(|base| format!("{}/booking/reschedule/{}", base.trim_end_matches('/'), t))
         });
+        let (cancel_notice_min, reschedule_notice_min) =
+            fetch_event_type_notice_minutes(&state.pool, &event_type_id).await;
         let _ = crate::email::send_guest_confirmation_ex(
             &smtp_config,
             &details,
             guest_cancel_url.as_deref(),
             guest_reschedule_url.as_deref(),
+            cancel_notice_min,
+            reschedule_notice_min,
         )
         .await;
 
-        // Also send host a confirmation email (no ICS — event pushed via CalDAV)
+        // Also send host a confirmation email (no ICS, event pushed via CalDAV)
         if let Err(e) = crate::email::send_host_booking_confirmed(&smtp_config, &details).await {
             tracing::error!(error = %e, host_email = %details.host_email, "host confirmation email failed");
         }
@@ -12680,6 +12877,103 @@ async fn decline_booking_by_token(
 
 // --- Guest cancel booking by token ---
 
+/// Fetch `(cancel_notice_min, reschedule_notice_min)` for an event type by
+/// id. Either column may be NULL (no restriction).
+async fn fetch_event_type_notice_minutes(
+    pool: &SqlitePool,
+    event_type_id: &str,
+) -> (Option<i32>, Option<i32>) {
+    sqlx::query_as::<_, (Option<i32>, Option<i32>)>(
+        "SELECT cancel_notice_min, reschedule_notice_min FROM event_types WHERE id = ?",
+    )
+    .bind(event_type_id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or((None, None))
+}
+
+/// Look up a notice-window column on the booking's event type. Returns
+/// `(notice_min, host_email)` where `notice_min` is `None`/`Some(0)` when
+/// no restriction applies. The `column` argument MUST be one of the two
+/// known column names — it is interpolated into SQL but never sourced from
+/// the request, so this is safe.
+async fn fetch_notice_min_and_host_email(
+    pool: &SqlitePool,
+    booking_token_column: &str,
+    token: &str,
+    notice_column: &str,
+) -> Option<(Option<i32>, String)> {
+    debug_assert!(matches!(
+        notice_column,
+        "cancel_notice_min" | "reschedule_notice_min"
+    ));
+    debug_assert!(matches!(
+        booking_token_column,
+        "cancel_token" | "reschedule_token"
+    ));
+    let sql = format!(
+        "SELECT et.{notice}, COALESCE(u.booking_email, u.email) \
+         FROM bookings b \
+         JOIN event_types et ON et.id = b.event_type_id \
+         JOIN accounts a ON a.id = et.account_id \
+         JOIN users u ON u.id = a.user_id \
+         WHERE b.{tok} = ?",
+        notice = notice_column,
+        tok = booking_token_column
+    );
+    sqlx::query_as::<_, (Option<i32>, String)>(&sql)
+        .bind(token)
+        .fetch_optional(pool)
+        .await
+        .unwrap_or(None)
+}
+
+/// If `notice_min` is set and the booking starts inside the notice window,
+/// render the blocked page and return it. Otherwise return `None` so the
+/// caller can proceed.
+///
+/// Note on time semantics: `start_at` is the host-local naive timestamp
+/// (matching how bookings are stored elsewhere) so we compare against
+/// `Local::now().naive_local()` to mirror the existing `slot_start < now +
+/// Duration::minutes(min_notice as i64)` precedent in the reschedule POST
+/// path.
+fn check_notice_window(
+    state: &AppState,
+    notice_min: Option<i32>,
+    start_at: &str,
+    host_email: &str,
+    action: &'static str,
+    lang: &'static str,
+) -> Option<Response> {
+    let n = notice_min.unwrap_or(0);
+    if n <= 0 {
+        return None;
+    }
+    let start = match NaiveDateTime::parse_from_str(start_at, "%Y-%m-%dT%H:%M:%S") {
+        Ok(dt) => dt,
+        Err(_) => return None,
+    };
+    let cutoff = start - chrono::Duration::minutes(n as i64);
+    if Local::now().naive_local() <= cutoff {
+        return None;
+    }
+    let tmpl = match state.templates.get_template("booking_action_blocked.html") {
+        Ok(t) => t,
+        Err(e) => return Some(internal_error_response("internal", &e)),
+    };
+    let rendered = tmpl
+        .render(context! {
+            notice_min => n,
+            host_email => host_email,
+            action => action,
+            lang => lang,
+        })
+        .unwrap_or_else(|e| internal_error_body("template render", &e));
+    Some(Html(rendered).into_response())
+}
+
 async fn guest_cancel_form(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -12739,6 +13033,20 @@ async fn guest_cancel_form(
             return Html(rendered).into_response();
         }
     };
+
+    // Block the GET form before any state mutation if the booking falls
+    // inside the host's configured cancel-notice window.
+    if let Some((notice_min, host_email)) =
+        fetch_notice_min_and_host_email(&state.pool, "cancel_token", &token, "cancel_notice_min")
+            .await
+    {
+        if let Some(resp) =
+            check_notice_window(&state, notice_min, &start_at, &host_email, "cancel", lang)
+        {
+            tracing::info!(action = "cancel", "guest action blocked by notice window");
+            return resp;
+        }
+    }
 
     let date_label = format_date_label(&start_at, lang);
     let date = start_at.get(..10).unwrap_or(&start_at).to_string();
@@ -12817,6 +13125,25 @@ async fn guest_cancel_booking(
             return Html(rendered).into_response();
         }
     };
+
+    // Defensive notice-window check on POST too: the GET may have been
+    // cached, or the cutoff may have rolled over between page load and
+    // submit. Either way, never mutate state inside the blocked window.
+    if let Some((notice_min, _)) =
+        fetch_notice_min_and_host_email(&state.pool, "cancel_token", &token, "cancel_notice_min")
+            .await
+    {
+        if let Some(resp) =
+            check_notice_window(&state, notice_min, &start_at, &host_email, "cancel", lang)
+        {
+            tracing::info!(
+                action = "cancel",
+                booking_id = %bid,
+                "guest action blocked by notice window (POST)"
+            );
+            return resp;
+        }
+    }
 
     // Cancel the booking
     let _ = sqlx::query("UPDATE bookings SET status = 'cancelled' WHERE id = ?")
@@ -12951,6 +13278,34 @@ async fn guest_reschedule_slots(
             return Html(rendered).into_response();
         }
     };
+
+    // Block the slot picker before any costly work (CalDAV sync, slot
+    // computation, template render) if the booking falls inside the host's
+    // configured reschedule-notice window.
+    if let Some((notice_min, host_email)) = fetch_notice_min_and_host_email(
+        &state.pool,
+        "reschedule_token",
+        &token,
+        "reschedule_notice_min",
+    )
+    .await
+    {
+        if let Some(resp) = check_notice_window(
+            &state,
+            notice_min,
+            &start_at,
+            &host_email,
+            "reschedule",
+            lang,
+        ) {
+            tracing::info!(
+                action = "reschedule",
+                booking_id = %booking_id,
+                "guest action blocked by notice window"
+            );
+            return resp;
+        }
+    }
 
     // Fetch event type + host details
     let et_info: Option<(
@@ -13252,6 +13607,34 @@ async fn guest_reschedule_booking(
         }
     };
 
+    // Defensive notice-window check on POST too: the GET may have been
+    // cached, or the cutoff may have rolled over between page load and
+    // submit. Either way, never mutate state inside the blocked window.
+    if let Some((notice_min, host_email)) = fetch_notice_min_and_host_email(
+        &state.pool,
+        "reschedule_token",
+        &token,
+        "reschedule_notice_min",
+    )
+    .await
+    {
+        if let Some(resp) = check_notice_window(
+            &state,
+            notice_min,
+            &old_start_at,
+            &host_email,
+            "reschedule",
+            lang,
+        ) {
+            tracing::info!(
+                action = "reschedule",
+                booking_id = %booking_id,
+                "guest action blocked by notice window (POST)"
+            );
+            return resp;
+        }
+    }
+
     let date = match NaiveDate::parse_from_str(&form.date, "%Y-%m-%d") {
         Ok(d) => d,
         Err(_) => return Html("Invalid date.".to_string()).into_response(),
@@ -13525,6 +13908,8 @@ async fn guest_reschedule_booking(
     }
 
     let date_label = crate::i18n::format_long_date(date, lang);
+    let (cancel_notice_min, reschedule_notice_min) =
+        fetch_event_type_notice_minutes(&state.pool, &et_id).await;
 
     let tmpl = match state.templates.get_template("confirmed.html") {
         Ok(t) => t,
@@ -13540,6 +13925,8 @@ async fn guest_reschedule_booking(
             guest_email => guest_email,
             pending => needs_approval,
             rescheduled => true,
+            cancel_notice_min => cancel_notice_min,
+            reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
         })
@@ -18512,6 +18899,352 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, "cancelled", "Booking should be cancelled by guest");
+    }
+
+    // --- Min-notice for guest cancel / reschedule ---
+
+    /// Format a `start_at` value `offset` from now, using the same shape
+    /// (`%Y-%m-%dT%H:%M:%S`) that booking handlers persist. Booking times
+    /// are stored as naive host-local timestamps; the notice check uses
+    /// `Local::now().naive_local()` so we mirror that here.
+    fn booking_start_at(offset: chrono::Duration) -> String {
+        (Local::now().naive_local() + offset)
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string()
+    }
+
+    fn booking_end_at(offset: chrono::Duration, duration_min: i64) -> String {
+        (Local::now().naive_local() + offset + chrono::Duration::minutes(duration_min))
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string()
+    }
+
+    async fn insert_booking_at(
+        pool: &SqlitePool,
+        et_id: &str,
+        cancel_tok: &str,
+        resched_tok: &str,
+        offset: chrono::Duration,
+    ) -> String {
+        let booking_id = uuid::Uuid::new_v4().to_string();
+        let start_at = booking_start_at(offset);
+        let end_at = booking_end_at(offset, 30);
+        sqlx::query(
+            "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token) VALUES (?, ?, 'uid-notice', 'Guest', 'guest@test.com', 'UTC', ?, ?, 'confirmed', ?, ?)",
+        )
+        .bind(&booking_id)
+        .bind(et_id)
+        .bind(&start_at)
+        .bind(&end_at)
+        .bind(cancel_tok)
+        .bind(resched_tok)
+        .execute(pool)
+        .await
+        .unwrap();
+        booking_id
+    }
+
+    #[tokio::test]
+    async fn guest_cancel_no_notice_succeeds() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+        // No cancel_notice_min set on event type. Booking starts in 30 min.
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let booking_id = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(30),
+        )
+        .await;
+
+        let csrf = "csrf-cancel-no-notice";
+        let response = app
+            .oneshot(post_form_unauthed(
+                &format!("/booking/cancel/{}", cancel_tok),
+                csrf,
+                &format!("_csrf={}", csrf),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "cancelled",
+            "Without a notice window the cancel must succeed"
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_cancel_within_notice_window_blocked() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+        // Notice window of 60 min, booking starts in 30 min: blocked.
+        sqlx::query("UPDATE event_types SET cancel_notice_min = 60 WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let booking_id = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(30),
+        )
+        .await;
+
+        // GET should already block.
+        let response = app
+            .clone()
+            .oneshot(get(&format!("/booking/cancel/{}", cancel_tok)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+        assert!(
+            body.contains("notice") || body.contains("60") || body.contains("minutes"),
+            "Blocked page should mention the notice (got body length {})",
+            body.len()
+        );
+
+        // POST must also be blocked, and the booking must not transition.
+        let csrf = "csrf-cancel-blocked";
+        let response = app
+            .oneshot(post_form_unauthed(
+                &format!("/booking/cancel/{}", cancel_tok),
+                csrf,
+                &format!("_csrf={}", csrf),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "confirmed", "Blocked POST must not mutate state");
+    }
+
+    #[tokio::test]
+    async fn guest_cancel_outside_notice_window_succeeds() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+        // Notice window of 60 min, booking starts in 120 min: allowed.
+        sqlx::query("UPDATE event_types SET cancel_notice_min = 60 WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let booking_id = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(120),
+        )
+        .await;
+
+        let csrf = "csrf-cancel-allowed";
+        let response = app
+            .oneshot(post_form_unauthed(
+                &format!("/booking/cancel/{}", cancel_tok),
+                csrf,
+                &format!("_csrf={}", csrf),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "cancelled");
+    }
+
+    #[tokio::test]
+    async fn guest_reschedule_no_notice_succeeds() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let _ = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(30),
+        )
+        .await;
+
+        // GET the slot picker. With no notice, it should render the slot
+        // page (status 200 and contains the event title or slot markers).
+        let response = app
+            .oneshot(get(&format!("/booking/reschedule/{}", resched_tok)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+        assert!(
+            body.contains("Test Meeting") || body.contains("reschedul"),
+            "No notice -> slot page should render, body length {}",
+            body.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_reschedule_within_notice_window_blocked() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+        sqlx::query("UPDATE event_types SET reschedule_notice_min = 60 WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let booking_id = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(30),
+        )
+        .await;
+
+        // GET blocks before the slot picker is rendered.
+        let response = app
+            .clone()
+            .oneshot(get(&format!("/booking/reschedule/{}", resched_tok)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+        assert!(
+            body.contains("notice") || body.contains("60") || body.contains("minutes"),
+            "Blocked page should mention the notice"
+        );
+
+        // POST also blocked: booking start_at must not change.
+        let csrf = "csrf-resched-blocked";
+        // Submit a new date 10 days out so we don't hit other guards.
+        let new_date = (Local::now().naive_local().date() + chrono::Duration::days(10))
+            .format("%Y-%m-%d")
+            .to_string();
+        let original_start: String =
+            sqlx::query_scalar("SELECT start_at FROM bookings WHERE id = ?")
+                .bind(&booking_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let response = app
+            .oneshot(post_form_unauthed(
+                &format!("/booking/reschedule/{}", resched_tok),
+                csrf,
+                &format!("_csrf={}&date={}&time=10%3A00&tz=UTC", csrf, new_date),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let still: String = sqlx::query_scalar("SELECT start_at FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            still, original_start,
+            "Blocked POST must not move the booking"
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_reschedule_outside_notice_window_succeeds() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+        sqlx::query("UPDATE event_types SET reschedule_notice_min = 60 WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let _ = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(120),
+        )
+        .await;
+
+        // GET should render the slot picker (not the blocked page).
+        let response = app
+            .oneshot(get(&format!("/booking/reschedule/{}", resched_tok)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+        // Slot picker contains the event title; the blocked page does
+        // not. Either presence of "Test Meeting" or absence of the
+        // notice-line is fine.
+        assert!(
+            body.contains("Test Meeting") || body.contains("reschedul"),
+            "Outside notice window the slot picker should render"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_cancel_unaffected_by_notice() {
+        // The dashboard cancel handler must bypass the guest notice window.
+        // Set a 24h cancel_notice and a booking 30 min out: the host should
+        // still be able to cancel via /dashboard/bookings/{id}/cancel.
+        let (app, pool, session, et_id) = setup_test_app().await;
+        sqlx::query("UPDATE event_types SET cancel_notice_min = 1440 WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let booking_id = insert_booking_at(
+            &pool,
+            &et_id,
+            &cancel_tok,
+            &resched_tok,
+            chrono::Duration::minutes(30),
+        )
+        .await;
+
+        let csrf = "csrf-host-cancel";
+        let response = app
+            .oneshot(post_form(
+                &format!("/dashboard/bookings/{}/cancel", booking_id),
+                &session,
+                csrf,
+                &format!("_csrf={}", csrf),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            response.status().is_redirection(),
+            "Host cancel should redirect, got {}",
+            response.status()
+        );
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "cancelled",
+            "Host cancel must succeed regardless of guest notice window"
+        );
     }
 
     // --- Host reschedule ---

--- a/templates/booking_action_blocked.html
+++ b/templates/booking_action_blocked.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}{% if action == "reschedule" %}{{ t("booking-blocked-title-reschedule") }}{% else %}{{ t("booking-blocked-title-cancel") }}{% endif %}{% endblock %}
+
+{% block content %}
+<div class="card" style="text-align: center;">
+  <div class="check" style="background: var(--text-muted);">!</div>
+  <h1>{% if action == "reschedule" %}{{ t("booking-blocked-title-reschedule") }}{% else %}{{ t("booking-blocked-title-cancel") }}{% endif %}</h1>
+  <p class="subtitle">{{ t("booking-blocked-body", minutes=notice_min, host_email=host_email) | safe }}</p>
+</div>
+{% endblock %}

--- a/templates/confirmed.html
+++ b/templates/confirmed.html
@@ -39,6 +39,12 @@
   {% if additional_attendees is defined and additional_attendees %}
     <div class="detail"><strong>{{ t("confirmed-detail-additional-guests") }}</strong> {{ additional_attendees | join(", ") }}</div>
   {% endif %}
+  {% if cancel_notice_min is defined and cancel_notice_min and cancel_notice_min > 0 %}
+    <p class="muted" style="font-size: 0.875rem; color: var(--text-muted); margin-top: 0.75rem;">{{ t("confirmed-cancel-notice-info", minutes=cancel_notice_min) }}</p>
+  {% endif %}
+  {% if reschedule_notice_min is defined and reschedule_notice_min and reschedule_notice_min > 0 %}
+    <p class="muted" style="font-size: 0.875rem; color: var(--text-muted); margin-top: 0.25rem;">{{ t("confirmed-reschedule-notice-info", minutes=reschedule_notice_min) }}</p>
+  {% endif %}
 </div>
 <div style="text-align: center; margin-top: 1.5rem;">
   {% if team_slug %}<a href="/team/{{ team_slug }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>

--- a/templates/event_type_form.html
+++ b/templates/event_type_form.html
@@ -260,7 +260,7 @@
 </details>
 
 <!-- Collapsible: Buffers & notice -->
-<details class="card collapsible-section" style="margin-top: 1rem;"{% if editing and ((form_buffer_before is defined and form_buffer_before and form_buffer_before != "0") or (form_buffer_after is defined and form_buffer_after and form_buffer_after != "0") or (form_min_notice is defined and form_min_notice and form_min_notice != "0")) %} open{% endif %}>
+<details class="card collapsible-section" style="margin-top: 1rem;"{% if editing and ((form_buffer_before is defined and form_buffer_before and form_buffer_before != "0") or (form_buffer_after is defined and form_buffer_after and form_buffer_after != "0") or (form_min_notice is defined and form_min_notice and form_min_notice != "0") or (form_cancel_notice_value is defined and form_cancel_notice_value and form_cancel_notice_value > 0) or (form_reschedule_notice_value is defined and form_reschedule_notice_value and form_reschedule_notice_value > 0)) %} open{% endif %}>
   <summary class="collapsible-header">
     <h2>Buffers &amp; notice</h2>
     <span class="collapsible-hint" id="buffers-hint"></span>
@@ -289,6 +289,36 @@
       </div>
       <input type="hidden" id="min_notice_min" name="min_notice_min" value="{{ form_min_notice }}">
       <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">How far in advance someone must book.</span>
+    </div>
+
+    <div class="form-group">
+      <label for="cancel_notice_value">{{ t("event-type-form-cancel-notice-label") }}</label>
+      <div style="display: flex; gap: 0.5rem; align-items: center;">
+        <input type="number" min="0" step="1" id="cancel_notice_value" name="cancel_notice_value"
+               value="{% if form_cancel_notice_value is defined and form_cancel_notice_value > 0 %}{{ form_cancel_notice_value }}{% endif %}"
+               placeholder="0" style="flex: 1; max-width: 120px;">
+        <select name="cancel_notice_unit" id="cancel_notice_unit" style="padding: 0.625rem 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.925rem; font-family: inherit; background: var(--surface); color: var(--text);">
+          <option value="minutes" {% if form_cancel_notice_unit is defined and form_cancel_notice_unit == "minutes" %}selected{% endif %}>{{ t("event-type-form-notice-unit-minutes") }}</option>
+          <option value="hours" {% if form_cancel_notice_unit is defined and form_cancel_notice_unit == "hours" %}selected{% endif %}>{{ t("event-type-form-notice-unit-hours") }}</option>
+          <option value="days" {% if form_cancel_notice_unit is defined and form_cancel_notice_unit == "days" %}selected{% endif %}>{{ t("event-type-form-notice-unit-days") }}</option>
+        </select>
+      </div>
+      <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">{{ t("event-type-form-notice-help") }}</span>
+    </div>
+
+    <div class="form-group">
+      <label for="reschedule_notice_value">{{ t("event-type-form-reschedule-notice-label") }}</label>
+      <div style="display: flex; gap: 0.5rem; align-items: center;">
+        <input type="number" min="0" step="1" id="reschedule_notice_value" name="reschedule_notice_value"
+               value="{% if form_reschedule_notice_value is defined and form_reschedule_notice_value > 0 %}{{ form_reschedule_notice_value }}{% endif %}"
+               placeholder="0" style="flex: 1; max-width: 120px;">
+        <select name="reschedule_notice_unit" id="reschedule_notice_unit" style="padding: 0.625rem 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.925rem; font-family: inherit; background: var(--surface); color: var(--text);">
+          <option value="minutes" {% if form_reschedule_notice_unit is defined and form_reschedule_notice_unit == "minutes" %}selected{% endif %}>{{ t("event-type-form-notice-unit-minutes") }}</option>
+          <option value="hours" {% if form_reschedule_notice_unit is defined and form_reschedule_notice_unit == "hours" %}selected{% endif %}>{{ t("event-type-form-notice-unit-hours") }}</option>
+          <option value="days" {% if form_reschedule_notice_unit is defined and form_reschedule_notice_unit == "days" %}selected{% endif %}>{{ t("event-type-form-notice-unit-days") }}</option>
+        </select>
+      </div>
+      <span class="hint" style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">{{ t("event-type-form-notice-help") }}</span>
     </div>
   </div>
 </details>


### PR DESCRIPTION
Closes #95.

## Summary

Hosts can now require a minimum lead time before a guest can self-cancel or self-reschedule via the tokenized email links, set per event type from the event type form. `NULL` or `0` means no restriction (current behavior).

Within the notice window, the four guest token endpoints render a friendly `booking_action_blocked` page with the host's contact email instead of mutating booking state. Host- and admin-initiated cancellations from the dashboard are unaffected.

The policy is also surfaced inline on the confirmed page and in the confirmation email so guests aren't surprised at click time.

## What changed

| Area | File(s) | Change |
|---|---|---|
| Schema | `migrations/050_min_notice_cancel_reschedule.sql` | New `cancel_notice_min` + `reschedule_notice_min` INTEGER columns on `event_types` |
| Schema | `src/db.rs` | Migration registered (per CLAUDE.md) |
| Model | `src/models.rs` | `EventType.cancel_notice_min: Option<i32>` + `reschedule_notice_min: Option<i32>` |
| Validation | `src/web/mod.rs` | New `check_notice_window` helper called before any state mutation in `guest_cancel_form` (GET), `guest_cancel_booking` (POST), `guest_reschedule_slots` (GET), `guest_reschedule_booking` (POST) |
| Form | `src/web/mod.rs` + `templates/event_type_form.html` | Numeric input + minutes/hours/days select, value/unit converted on submit, natural unit recovered on edit |
| Confirmed page | `src/web/mod.rs` + `templates/confirmed.html` | Policy surfaced inline when set |
| Email | `src/email.rs` | Notice line appended to plain text + HTML when set |
| Blocked page | `templates/booking_action_blocked.html` (new) | Friendly page with host's `mailto:` link |
| i18n | `i18n/en/main.ftl` | 11 new English keys (other locales fall back to English at runtime) |

The hardest piece is the contract between handler context and templates: the form submits `(cancel_notice_value, cancel_notice_unit)` and `(reschedule_notice_value, reschedule_notice_unit)`; backend converts to minutes and stores. On render, backend computes the natural unit (1440-divisible → days, 60-divisible → hours, else minutes) and passes that back to the form for display.

## Worth a careful look

- **Time semantics**: `bookings.start_at` is stored as a naive host-local string, not UTC. The check uses `Local::now().naive_local()` rather than `Utc::now()`, mirroring the existing `slot_start < now + Duration::minutes(min_notice as i64)` precedent in `guest_reschedule_booking`. The issue's example used `Utc::now()` but the file's own conventions are host-local.
- **`booking_action_blocked.html` uses `| safe`** on the `booking-blocked-body` Fluent key because the body contains an inline `<a href="mailto:...">`. The `host_email` placeholder is sourced from the user record (validated at registration), so practical XSS surface is small, but a stricter version could split the template (escape the email separately, keep the `<a>` from Fluent). Flagged as a follow-up rather than a blocker.

## Tests

7 new tests in `src/web/mod.rs::tests`:

- `guest_cancel_no_notice_succeeds`
- `guest_cancel_within_notice_window_blocked` (covers GET + POST)
- `guest_cancel_outside_notice_window_succeeds`
- `guest_reschedule_no_notice_succeeds`
- `guest_reschedule_within_notice_window_blocked` (covers GET + POST)
- `guest_reschedule_outside_notice_window_succeeds`
- `host_cancel_unaffected_by_notice` (host route bypasses the check)

Test count went from 617 → 624. Helper `insert_booking_at(pool, et_id, cancel_tok, resched_tok, offset)` writes a booking at `Local::now() + offset` so the tests exercise real time semantics rather than fixed dates.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (624 passing)
- [ ] Reviewer: create an event type with a 60-minute cancel notice; book it 30 min in the future; click the cancel link in the email and confirm you land on the blocked page with the correct host email. Then book it 2 hours out and confirm cancel still works.
- [ ] Reviewer: confirm the host's own dashboard cancel of a booking inside the guest notice window still works (the check is guest-side only).

## Acceptance criteria from #95

- [x] Migration added and registered in `src/db.rs`
- [x] `cancel_notice_min` and `reschedule_notice_min` settable from the event type form
- [x] Guest cancel via tokenized link blocked inside the notice window with a friendly host-contact page
- [x] Guest reschedule via tokenized link blocked under the same rule
- [x] Host and admin cancel/reschedule from the dashboard unaffected
- [x] Notice policy surfaced on confirmation email and booking-confirmed page when set
- [x] Strings added to `i18n/en/main.ftl` (this PR's `main` already includes the recent `i18n → main` merge)
- [x] Tests cover all four cases listed in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)