### PR TITLE
fix(web): show booking times in the correct timezone (host + guest)

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3594,7 +3594,7 @@ async fn cancel_booking(
         String,
         String,
     )> = sqlx::query_as(
-        "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, a.id, COALESCE(b.guest_timezone, 'UTC'), b.status
+        "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, et.id, COALESCE(b.guest_timezone, 'UTC'), b.status
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -3614,7 +3614,7 @@ async fn cancel_booking(
         start_at,
         end_at,
         event_title,
-        _account_id,
+        et_id,
         guest_timezone,
         prev_status,
     ) = match booking {
@@ -3640,9 +3640,11 @@ async fn cancel_booking(
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        let date = start_at.get(..10).unwrap_or(&start_at).to_string();
-        let start_time = extract_time_24h(&start_at);
-        let end_time = extract_time_24h(&end_at);
+        // Convert event-type-local stored times into the guest's tz; see #101.
+        let stored_tz = get_host_tz(&state.pool, &et_id).await;
+        let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+        let (date, start_time, end_time) =
+            booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
 
         let reason = form.reason.filter(|r| !r.trim().is_empty());
 
@@ -13105,8 +13107,9 @@ async fn decline_booking_by_token(
         String,
         String,
         String,
+        String,
     )> = sqlx::query_as(
-        "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), COALESCE(b.guest_timezone, 'UTC')
+        "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), COALESCE(b.guest_timezone, 'UTC'), et.id
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -13128,6 +13131,7 @@ async fn decline_booking_by_token(
         host_name,
         host_email,
         guest_timezone,
+        et_id,
     ) = match booking {
         Some(b) => b,
         None => {
@@ -13152,10 +13156,12 @@ async fn decline_booking_by_token(
 
     tracing::info!(booking_id = %bid, "booking declined via token");
 
-    let date_label = format_date_label(&start_at, lang);
-    let date = start_at.get(..10).unwrap_or(&start_at).to_string();
-    let start_time = extract_time_24h(&start_at);
-    let end_time = extract_time_24h(&end_at);
+    // Convert event-type-local stored times into the guest's tz; see #101.
+    let stored_tz = get_host_tz(&state.pool, &et_id).await;
+    let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+    let (date, start_time, end_time) =
+        booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
+    let date_label = format_date_label(&date, lang);
 
     let reason = form.reason.filter(|r| !r.trim().is_empty());
 
@@ -13410,9 +13416,9 @@ async fn guest_cancel_booking(
         return resp;
     }
     let lang = crate::i18n::detect_from_headers(&headers);
-    let booking: Option<(String, String, String, String, String, String, String, String, String, String)> =
+    let booking: Option<(String, String, String, String, String, String, String, String, String, String, String)> =
         sqlx::query_as(
-            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), COALESCE(b.guest_timezone, 'UTC')
+            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), COALESCE(b.guest_timezone, 'UTC'), et.id
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -13435,6 +13441,7 @@ async fn guest_cancel_booking(
         host_name,
         host_email,
         guest_timezone,
+        et_id,
     ) = match booking {
         Some(b) => b,
         None => {
@@ -13494,10 +13501,12 @@ async fn guest_cancel_booking(
         caldav_delete_booking(&state.pool, &state.secret_key, user_id, &uid).await;
     }
 
-    let date_label = format_date_label(&start_at, lang);
-    let date = start_at.get(..10).unwrap_or(&start_at).to_string();
-    let start_time = extract_time_24h(&start_at);
-    let end_time = extract_time_24h(&end_at);
+    // Convert event-type-local stored times into the guest's tz; see #101.
+    let stored_tz = get_host_tz(&state.pool, &et_id).await;
+    let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+    let (date, start_time, end_time) =
+        booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
+    let date_label = format_date_label(&date, lang);
 
     let reason = form.reason.filter(|r| !r.trim().is_empty());
 
@@ -19013,6 +19022,55 @@ mod tests {
         assert!(
             body.contains("cancel") || body.contains("Cancel"),
             "Cancel form should render"
+        );
+    }
+
+    /// Regression test for #101 (cancel surface): when the event type is in a
+    /// different tz from the guest, the cancellation page (and the cancellation
+    /// email it mirrors) must render the time in the guest's tz, not the
+    /// event-type-local stored time.
+    #[tokio::test]
+    async fn guest_cancel_renders_time_in_guest_timezone() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+
+        sqlx::query("UPDATE event_types SET timezone = 'America/New_York' WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let booking_id = uuid::Uuid::new_v4().to_string();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        // 10:00 NY in June (EDT, UTC-4) == 16:00 Europe/Paris (CEST, UTC+2).
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token) VALUES (?, ?, 'uid-gcancel-tz', 'Guest', 'guest@test.com', 'Europe/Paris', '2026-06-22T10:00:00', '2026-06-22T10:30:00', 'confirmed', ?, ?)")
+            .bind(&booking_id)
+            .bind(&et_id)
+            .bind(&cancel_tok)
+            .bind(&resched_tok)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let csrf = "test-csrf-gcancel-tz";
+        let response = app
+            .oneshot(post_form_unauthed(
+                &format!("/booking/cancel/{}", cancel_tok),
+                csrf,
+                &format!("_csrf={}", csrf),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+
+        assert!(
+            body.contains("16:00") && body.contains("16:30"),
+            "Cancellation page should render times in the guest's tz (Europe/Paris: 16:00 – 16:30)"
+        );
+        assert!(
+            !body.contains("10:00") && !body.contains("10:30"),
+            "Cancellation page should not render the event-type-local time (America/New_York: 10:00)"
         );
     }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8,7 +8,7 @@ use axum::Router;
 use chrono::{
     Datelike, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc,
 };
-use chrono_tz::Tz;
+use chrono_tz::{OffsetName, Tz};
 use minijinja::{context, Environment};
 use serde::Deserialize;
 use sqlx::SqlitePool;
@@ -479,6 +479,115 @@ fn format_booking_range(start_str: &str, end_str: &str) -> String {
     } else {
         format!("{} — {}", start_label, end_str)
     }
+}
+
+/// Convert a naive datetime from one timezone to another, going via UTC. Used
+/// when the dashboard needs to show a stored time (which is naive in the
+/// event-type's timezone) in either the host's profile timezone or the guest's
+/// selected timezone.
+fn convert_naive_between_tz(naive: NaiveDateTime, from: Tz, to: Tz) -> NaiveDateTime {
+    let utc = from
+        .from_local_datetime(&naive)
+        .earliest()
+        .unwrap_or_else(|| from.from_utc_datetime(&naive))
+        .with_timezone(&Utc);
+    utc.with_timezone(&to).naive_local()
+}
+
+/// Short timezone label for display next to a time, e.g. "CEST" or "EST".
+/// Falls back to the IANA name when the abbreviation is numeric (zones like
+/// Asia/Tehran which expose "+0330" rather than a letter code).
+fn tz_short_label(tz: Tz, at: NaiveDateTime) -> String {
+    let dt = tz
+        .from_local_datetime(&at)
+        .earliest()
+        .unwrap_or_else(|| tz.from_utc_datetime(&at));
+    let abbr = dt.offset().abbreviation();
+    if abbr.len() >= 3 && abbr.chars().all(|c| c.is_ascii_alphabetic()) {
+        abbr.to_string()
+    } else {
+        tz.name().to_string()
+    }
+}
+
+/// Format a booking range for dashboard display: returns a primary label in the
+/// host's profile timezone (with tz suffix), and an optional secondary label
+/// showing the guest's view when the two timezones differ.
+///
+/// `start_str`/`end_str` are naive datetimes stored in `stored_tz` (the event
+/// type's timezone, falling back to the host's profile tz for legacy rows).
+fn format_booking_for_dashboard(
+    start_str: &str,
+    end_str: &str,
+    stored_tz: &str,
+    host_tz: &str,
+    guest_tz: &str,
+) -> (String, Option<String>) {
+    let stored = stored_tz.parse::<Tz>().unwrap_or(Tz::UTC);
+    let host = host_tz.parse::<Tz>().unwrap_or(Tz::UTC);
+    let guest = guest_tz.parse::<Tz>().unwrap_or(Tz::UTC);
+
+    let (start, end) = match (
+        parse_booking_datetime(start_str),
+        parse_booking_datetime(end_str),
+    ) {
+        (Some(s), Some(e)) => (s, e),
+        _ => return (format_booking_range(start_str, end_str), None),
+    };
+
+    let host_start = convert_naive_between_tz(start, stored, host);
+    let host_end = convert_naive_between_tz(end, stored, host);
+    let today_host = Utc::now().with_timezone(&host).date_naive();
+    let primary = format_dashboard_range(
+        host_start,
+        host_end,
+        today_host,
+        &tz_short_label(host, host_start),
+    );
+
+    let secondary = if guest != host {
+        let g_start = convert_naive_between_tz(start, stored, guest);
+        let g_end = convert_naive_between_tz(end, stored, guest);
+        let g_time_start = g_start.time().format("%-I:%M %p").to_string();
+        let g_time_end = g_end.time().format("%-I:%M %p").to_string();
+        Some(format!(
+            "{} — {} {}",
+            g_time_start,
+            g_time_end,
+            tz_short_label(guest, g_start)
+        ))
+    } else {
+        None
+    };
+
+    (primary, secondary)
+}
+
+fn format_dashboard_range(
+    start: NaiveDateTime,
+    end: NaiveDateTime,
+    today: NaiveDate,
+    tz_label: &str,
+) -> String {
+    let date = start.date();
+    let time_start = start.time().format("%-I:%M %p").to_string();
+    let time_end = end.time().format("%-I:%M %p").to_string();
+    let day_diff = (date - today).num_days();
+    let date_part = if day_diff == 0 {
+        "Today".to_string()
+    } else if day_diff == 1 {
+        "Tomorrow".to_string()
+    } else if (1..7).contains(&day_diff) {
+        date.format("%A").to_string()
+    } else if date.year() == today.year() {
+        date.format("%a, %b %-d").to_string()
+    } else {
+        date.format("%a, %b %-d, %Y").to_string()
+    };
+    format!(
+        "{} at {} — {} {}",
+        date_part, time_start, time_end, tz_label
+    )
 }
 
 /// Format a raw date string (YYYY-MM-DD or from datetime) into a human-friendly
@@ -1079,11 +1188,23 @@ async fn dashboard(
             .await
             .unwrap_or(0);
 
-    let pending_bookings: Vec<(String, String, String, String, String, String)> = sqlx::query_as(
-        "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title
+    let pending_bookings: Vec<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )> = sqlx::query_as(
+        "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title,
+                COALESCE(NULLIF(et.timezone, ''), u.timezone) AS stored_tz,
+                COALESCE(NULLIF(b.guest_timezone, ''), 'UTC') AS guest_tz
          FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
+         JOIN users u ON u.id = a.user_id
          WHERE a.user_id = ? AND b.status = 'pending'
          ORDER BY b.start_at",
     )
@@ -1124,11 +1245,23 @@ async fn dashboard(
         Err(e) => return internal_error_html("template render", &e),
     };
 
+    let host_tz = &user.timezone;
     let pending_ctx: Vec<minijinja::Value> = pending_bookings
         .iter()
-        .map(|(id, name, email, start, end, title)| {
-            context! { id => id, guest_name => name, guest_email => email, start_at => format_booking_range(start, end), event_title => title }
-        })
+        .map(
+            |(id, name, email, start, end, title, stored_tz, guest_tz)| {
+                let (primary, secondary) =
+                    format_booking_for_dashboard(start, end, stored_tz, host_tz, guest_tz);
+                context! {
+                    id => id,
+                    guest_name => name,
+                    guest_email => email,
+                    start_at => primary,
+                    start_at_guest => secondary,
+                    event_title => title,
+                }
+            },
+        )
         .collect();
 
     let pending_count = pending_ctx.len() as i64;
@@ -1312,11 +1445,23 @@ async fn dashboard_bookings(
 ) -> impl IntoResponse {
     let user = &auth_user.user;
 
-    let pending_bookings: Vec<(String, String, String, String, String, String)> = sqlx::query_as(
-        "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title
+    let pending_bookings: Vec<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )> = sqlx::query_as(
+        "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title,
+                COALESCE(NULLIF(et.timezone, ''), u.timezone) AS stored_tz,
+                COALESCE(NULLIF(b.guest_timezone, ''), 'UTC') AS guest_tz
          FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
+         JOIN users u ON u.id = a.user_id
          WHERE a.user_id = ? AND b.status = 'pending'
          ORDER BY b.start_at",
     )
@@ -1325,12 +1470,15 @@ async fn dashboard_bookings(
     .await
     .unwrap_or_default();
 
-    let upcoming_bookings: Vec<(String, String, String, String, String, String, i32)> =
+    let upcoming_bookings: Vec<(String, String, String, String, String, String, i32, String, String)> =
         sqlx::query_as(
-            "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, b.reschedule_by_host
+            "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, b.reschedule_by_host,
+                    COALESCE(NULLIF(et.timezone, ''), u.timezone) AS stored_tz,
+                    COALESCE(NULLIF(b.guest_timezone, ''), 'UTC') AS guest_tz
          FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
+         JOIN users u ON u.id = a.user_id
          WHERE a.user_id = ? AND b.status = 'confirmed' AND b.start_at >= datetime('now')
          ORDER BY b.start_at
          LIMIT 50",
@@ -1340,10 +1488,14 @@ async fn dashboard_bookings(
         .await
         .unwrap_or_default();
 
-    // Claimable bookings: unclaimed bookings on event types watched by the user's teams
-    let claimable_bookings: Vec<(String, String, String, String, String, String, String, String)> =
+    // Claimable bookings: unclaimed bookings on event types watched by the user's teams.
+    // For team event types et.account_id may be null, so the timezone falls back to the
+    // event type's own tz column (always set since migration 046's backfill).
+    let claimable_bookings: Vec<(String, String, String, String, String, String, String, String, String, String)> =
         sqlx::query_as(
-            "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, t.name, bct.token \
+            "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, t.name, bct.token, \
+                    COALESCE(NULLIF(et.timezone, ''), 'UTC') AS stored_tz, \
+                    COALESCE(NULLIF(b.guest_timezone, ''), 'UTC') AS guest_tz \
              FROM bookings b \
              JOIN event_types et ON et.id = b.event_type_id \
              JOIN event_type_watchers ew ON ew.event_type_id = et.id \
@@ -1365,40 +1517,62 @@ async fn dashboard_bookings(
         Err(e) => return internal_error_html("template render", &e),
     };
 
+    let host_tz = &user.timezone;
     let claimable_ctx: Vec<minijinja::Value> = claimable_bookings
         .iter()
-        .map(|(id, name, email, start, end, title, team_name, token)| {
-            context! {
-                id => id,
-                guest_name => name,
-                guest_email => email,
-                start_at => format_booking_range(start, end),
-                event_title => title,
-                team_name => team_name,
-                claim_token => token,
-            }
-        })
+        .map(
+            |(id, name, email, start, end, title, team_name, token, stored_tz, guest_tz)| {
+                let (primary, secondary) =
+                    format_booking_for_dashboard(start, end, stored_tz, host_tz, guest_tz);
+                context! {
+                    id => id,
+                    guest_name => name,
+                    guest_email => email,
+                    start_at => primary,
+                    start_at_guest => secondary,
+                    event_title => title,
+                    team_name => team_name,
+                    claim_token => token,
+                }
+            },
+        )
         .collect();
 
     let pending_ctx: Vec<minijinja::Value> = pending_bookings
         .iter()
-        .map(|(id, name, email, start, end, title)| {
-            context! { id => id, guest_name => name, guest_email => email, start_at => format_booking_range(start, end), event_title => title }
-        })
+        .map(
+            |(id, name, email, start, end, title, stored_tz, guest_tz)| {
+                let (primary, secondary) =
+                    format_booking_for_dashboard(start, end, stored_tz, host_tz, guest_tz);
+                context! {
+                    id => id,
+                    guest_name => name,
+                    guest_email => email,
+                    start_at => primary,
+                    start_at_guest => secondary,
+                    event_title => title,
+                }
+            },
+        )
         .collect();
 
     let bookings_ctx: Vec<minijinja::Value> = upcoming_bookings
         .iter()
-        .map(|(id, name, email, start, end, title, resched)| {
-            context! {
-                id => id,
-                guest_name => name,
-                guest_email => email,
-                start_at => format_booking_range(start, end),
-                event_title => title,
-                awaiting_reschedule => *resched != 0,
-            }
-        })
+        .map(
+            |(id, name, email, start, end, title, resched, stored_tz, guest_tz)| {
+                let (primary, secondary) =
+                    format_booking_for_dashboard(start, end, stored_tz, host_tz, guest_tz);
+                context! {
+                    id => id,
+                    guest_name => name,
+                    guest_email => email,
+                    start_at => primary,
+                    start_at_guest => secondary,
+                    event_title => title,
+                    awaiting_reschedule => *resched != 0,
+                }
+            },
+        )
         .collect();
 
     let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
@@ -16045,6 +16219,74 @@ mod tests {
     fn format_booking_range_end_unparseable() {
         let result = format_booking_range("2099-07-20T09:00:00", "bad");
         assert_eq!(result, "Mon, Jul 20, 2099 at 9:00 AM — bad");
+    }
+
+    // --- format_booking_for_dashboard tests ---
+    //
+    // Regression for issue #100: when the event type's stored timezone differs
+    // from the host's profile timezone, the dashboard previously displayed the
+    // raw stored time with no timezone label, which the host read as their own
+    // time. The fix shifts the primary label into the host's profile tz and
+    // adds a secondary guest-tz line.
+
+    #[test]
+    fn dashboard_label_converts_stored_tz_to_host_profile_tz() {
+        // The user's exact scenario: event type set to America/New_York
+        // (UTC-5 in winter), host's profile is Europe/Paris (UTC+1 in winter),
+        // guest booked from America/New_York at 10:00 → stored as "10:00".
+        // Host should see "4:00 PM" (Paris equivalent), guest line shows "10:00 EST".
+        let (primary, secondary) = format_booking_for_dashboard(
+            "2099-01-20T10:00:00",
+            "2099-01-20T10:30:00",
+            "America/New_York",
+            "Europe/Paris",
+            "America/New_York",
+        );
+        assert!(
+            primary.contains("4:00 PM") && primary.contains("4:30 PM"),
+            "primary should be in Europe/Paris, got: {primary}"
+        );
+        assert!(
+            primary.contains("CET"),
+            "primary should label tz, got: {primary}"
+        );
+        let sec = secondary.expect("secondary line expected when guest tz differs from host tz");
+        assert!(
+            sec.contains("10:00 AM"),
+            "secondary should show guest 10:00 AM, got: {sec}"
+        );
+        assert!(
+            sec.contains("EST"),
+            "secondary should label guest tz, got: {sec}"
+        );
+    }
+
+    #[test]
+    fn dashboard_label_omits_secondary_when_guest_tz_equals_host_tz() {
+        let (_primary, secondary) = format_booking_for_dashboard(
+            "2099-07-20T14:00:00",
+            "2099-07-20T14:30:00",
+            "Europe/Paris",
+            "Europe/Paris",
+            "Europe/Paris",
+        );
+        assert!(
+            secondary.is_none(),
+            "no secondary line when host and guest share tz"
+        );
+    }
+
+    #[test]
+    fn dashboard_label_falls_back_for_unparseable_input() {
+        let (primary, secondary) = format_booking_for_dashboard(
+            "garbage",
+            "also-garbage",
+            "Europe/Paris",
+            "Europe/Paris",
+            "America/New_York",
+        );
+        assert_eq!(primary, "garbage — also-garbage");
+        assert!(secondary.is_none());
     }
 
     // --- format_date_label tests ---

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -494,6 +494,39 @@ fn convert_naive_between_tz(naive: NaiveDateTime, from: Tz, to: Tz) -> NaiveDate
     utc.with_timezone(&to).naive_local()
 }
 
+/// Convert stored booking start/end (naive in `stored_tz`) to the guest's
+/// timezone and return (date, start_time, end_time) strings used to populate
+/// `BookingDetails`. `email::generate_ics` calls `convert_to_utc(date,
+/// start_time, end_time, guest_timezone)`, so these fields must be guest-local
+/// for the ICS and the rendered email body to match what the guest booked.
+/// Fixes #101.
+fn booking_strings_in_guest_tz(
+    start_at: &str,
+    end_at: &str,
+    stored_tz: Tz,
+    guest_tz: Tz,
+) -> (String, String, String) {
+    match (
+        parse_booking_datetime(start_at),
+        parse_booking_datetime(end_at),
+    ) {
+        (Some(s), Some(e)) => {
+            let gs = convert_naive_between_tz(s, stored_tz, guest_tz);
+            let ge = convert_naive_between_tz(e, stored_tz, guest_tz);
+            (
+                gs.date().format("%Y-%m-%d").to_string(),
+                gs.time().format("%H:%M").to_string(),
+                ge.time().format("%H:%M").to_string(),
+            )
+        }
+        _ => (
+            start_at.get(..10).unwrap_or(start_at).to_string(),
+            extract_time_24h(start_at),
+            extract_time_24h(end_at),
+        ),
+    }
+}
+
 /// Short timezone label for display next to a time, e.g. "CEST" or "EST".
 /// Falls back to the IANA name when the abbreviation is numeric (zones like
 /// Asia/Tehran which expose "+0330" rather than a letter code).
@@ -3710,9 +3743,13 @@ async fn confirm_booking(
 
     tracing::info!(booking_id = %bid, "booking confirmed by host");
 
-    let date = start_at.get(..10).unwrap_or(&start_at).to_string();
-    let start_time = extract_time_24h(&start_at);
-    let end_time = extract_time_24h(&end_at);
+    // start_at/end_at are naive in the event type's timezone; convert to the
+    // guest's tz so the confirmation email body and the ICS attachment match
+    // what the guest booked. See #101.
+    let stored_tz = get_host_tz(&state.pool, &et_id).await;
+    let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+    let (date, start_time, end_time) =
+        booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
 
     let details = crate::email::BookingDetails {
         event_title,
@@ -12888,10 +12925,14 @@ async fn approve_booking_by_token(
 
     tracing::info!(booking_id = %bid, "booking approved via token");
 
-    let date_label = format_date_label(&start_at, lang);
-    let date = start_at.get(..10).unwrap_or(&start_at).to_string();
-    let start_time = extract_time_24h(&start_at);
-    let end_time = extract_time_24h(&end_at);
+    // start_at/end_at are naive in the event type's timezone; convert to the
+    // guest's tz so the email body and the ICS attachment match what the
+    // guest booked. See #101.
+    let stored_tz = get_host_tz(&state.pool, &event_type_id).await;
+    let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+    let (date, start_time, end_time) =
+        booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
+    let date_label = format_date_label(&date, lang);
 
     // Get host email for BookingDetails
     let host_email: String =
@@ -18864,6 +18905,54 @@ mod tests {
             status.unwrap().0,
             "confirmed",
             "Booking should be confirmed via POST token"
+        );
+    }
+
+    /// Regression test for #101: when the event type's timezone differs from
+    /// the guest's timezone, approving a pending booking must render (and
+    /// email) the time in the guest's timezone, not the event-type-local time
+    /// the row was stored as.
+    #[tokio::test]
+    async fn approve_booking_renders_time_in_guest_timezone() {
+        let (app, pool, _, et_id) = setup_test_app().await;
+
+        // Event type stored in America/New_York. 10:00 NY in June (EDT, UTC-4)
+        // == 14:00 UTC == 16:00 in Europe/Paris (CEST, UTC+2).
+        sqlx::query("UPDATE event_types SET timezone = 'America/New_York' WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let booking_id = uuid::Uuid::new_v4().to_string();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        let confirm_tok = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token, confirm_token) VALUES (?, ?, 'uid-approve-tz', 'Guest', 'guest@test.com', 'Europe/Paris', '2026-06-20T10:00:00', '2026-06-20T10:30:00', 'pending', ?, ?, ?)")
+            .bind(&booking_id)
+            .bind(&et_id)
+            .bind(&cancel_tok)
+            .bind(&resched_tok)
+            .bind(&confirm_tok)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(post_bare(&format!("/booking/approve/{}", confirm_tok)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = body_string(response).await;
+
+        assert!(
+            body.contains("16:00") && body.contains("16:30"),
+            "Approval page should render times in the guest's tz (Europe/Paris: 16:00 – 16:30), got body fragment: {}",
+            &body[..body.len().min(2000)]
+        );
+        assert!(
+            !body.contains("10:00") && !body.contains("10:30"),
+            "Approval page should not render the event-type-local time (America/New_York: 10:00)"
         );
     }
 

--- a/templates/dashboard_bookings.html
+++ b/templates/dashboard_bookings.html
@@ -9,6 +9,7 @@
     <div class="booking-info">
       <div><strong>{{ b.event_title }}</strong> with {{ b.guest_name }}</div>
       <div style="color: var(--text-muted); font-size: 0.85rem;">{{ b.start_at }} &middot; {{ b.guest_email }}</div>
+      {% if b.start_at_guest %}<div style="color: var(--text-muted); font-size: 0.75rem;">Guest booked: {{ b.start_at_guest }}</div>{% endif %}
     </div>
     <div class="booking-actions">
       <form method="post" action="/dashboard/bookings/{{ b.id }}/confirm" style="margin: 0;">
@@ -35,6 +36,7 @@
         <span class="badge" style="margin-left: 0.25rem; background: #3b82f6; color: #fff;">{{ b.team_name }}</span>
       </div>
       <div style="color: var(--text-muted); font-size: 0.85rem;">{{ b.start_at }} &middot; {{ b.guest_email }}</div>
+      {% if b.start_at_guest %}<div style="color: var(--text-muted); font-size: 0.75rem;">Guest booked: {{ b.start_at_guest }}</div>{% endif %}
     </div>
     <div class="booking-actions">
       <a href="/booking/claim/{{ b.id }}?token={{ b.claim_token }}" class="slot-btn" style="font-size: 0.8rem; text-decoration: none; color: #3b82f6; border-color: #3b82f6; font-weight: 600; cursor: pointer;">Claim</a>
@@ -57,6 +59,7 @@
           {% endif %}
         </div>
         <div style="color: var(--text-muted); font-size: 0.85rem;">{{ b.start_at }} &middot; {{ b.guest_email }}</div>
+        {% if b.start_at_guest %}<div style="color: var(--text-muted); font-size: 0.75rem;">Guest booked: {{ b.start_at_guest }}</div>{% endif %}
       </div>
       <div class="booking-actions">
         {% if not (b.awaiting_reschedule is defined and b.awaiting_reschedule) %}

--- a/templates/dashboard_overview.html
+++ b/templates/dashboard_overview.html
@@ -82,6 +82,7 @@
     <div class="booking-info">
       <div><strong>{{ b.event_title }}</strong> with {{ b.guest_name }} <span class="badge badge-pending">pending</span></div>
       <div style="color: var(--text-muted); font-size: 0.85rem;">{{ b.start_at }}</div>
+      {% if b.start_at_guest %}<div style="color: var(--text-muted); font-size: 0.75rem;">Guest booked: {{ b.start_at_guest }}</div>{% endif %}
     </div>
     <div class="booking-actions">
       <form method="post" action="/dashboard/bookings/{{ b.id }}/confirm" style="margin: 0;">


### PR DESCRIPTION
## Summary

Fixes two related timezone-display bugs around bookings, both reported on the same event-type setup (event type configured in `America/New_York`, host in `Europe/Paris`, guest also in `Europe/Paris`).

- **Closes #100** — Dashboard listings rendered booking times using the raw naive datetime from the DB plus the server's local clock for the "Today"/"Tomorrow" label. The time was never converted into the host's profile tz and never carried a tz suffix, so a 10:00 NY booking displayed as "10:00" with no qualifier, leading the host to believe it was 10:00 Paris time.
- **Closes #101** — When a host approved a pending booking (either from the dashboard "Approve" button or from the approve-by-email link), the confirmation email and the ICS attachment sent to the guest carried the event-type-local time, not the guest's. The same row that displayed correctly on the host's dashboard arrived in the guest's inbox at the wrong wall-clock time, and the ICS UTC was off too — so the CalDAV write-back landed at a different absolute time than the host expected.

## What changed

**`src/web/mod.rs`**

- `convert_naive_between_tz` / `tz_short_label` / `format_booking_for_dashboard`: new utilities that read `et.timezone` (with fallback to `users.timezone`) as the stored tz, convert into the host's profile tz for the primary label, append a tz abbreviation, and (when the guest's tz differs) render a muted secondary line in the guest's tz. Wired into the bookings dashboard and overview templates so the host sees both views.
- `booking_strings_in_guest_tz`: new helper that converts stored `start_at`/`end_at` (event-type-tz naive) into guest-local `(date, start_time, end_time)` strings. Used in both approval handlers before building `BookingDetails`, because `email::generate_ics` calls `convert_to_utc(date, start_time, end_time, guest_timezone)` and only produces correct UTC when those fields are guest-local. This fixes the email body, the ICS attachment, and the CalDAV write-back in one shot.

**Templates**

- `templates/dashboard_bookings.html` and `templates/dashboard_overview.html`: render the new primary/secondary tz labels.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 631 pass; new regression test `approve_booking_renders_time_in_guest_timezone` covers an event-type-tz `America/New_York` booking made by a `Europe/Paris` guest at 10:00 NY, asserts the approve response renders `16:00 – 16:30` and not `10:00`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [ ] Manual: re-run the reporter's scenario end-to-end (event type in `America/New_York`, host in `Europe/Paris`, book at 16:00 Paris with `requires_confirmation`, host approves, verify the guest's confirmation email shows 16:00 Paris and the ICS lands at the correct absolute time)