### PR TITLE
Fix mailbox and refactorize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 | Estonian locale | 1.10.0 | First community-language slot added beyond the original four (English, French, Spanish, Polish, German, Italian) |
 | Admin user deletion | 1.10.0 | Admins can permanently delete users from the admin panel with cascade rules and confirmation |
 
+## [1.10.2] - 2026-05-14
+
+Hotfix for a production incident in which CalDAV sync was wrongly cancelling live customer bookings. No schema changes, no behaviour changes outside the orphan-cancellation surface.
+
+### Fixed
+
+- **Stop cancelling bookings on phantom sync-collection "deletions"** — `delete_events_by_href` (src/commands/sync.rs:443) cancelled any booking whose UID matched an href the server reported as deleted, regardless of whether the local `events` table had a matching row. In production, BlueMind's sync-collection emitted a "deleted" entry for an href whose local event lived on a different calendar (the booking's write calendar); `cancel_orphaned_booking`'s global UID-only lookup still found the confirmed booking and cancelled it + emailed host and guest "the event was deleted by the host." The cancellation is now gated on `rows_affected > 0` — if we never had a local event for that calendar/href, that's a server-side false positive and we log a warning instead. Two regression tests added: one captures the exact prod failure mode, the other guards the legitimate deletion case from regressing
+
+### Internal
+
+- 634 tests total (up from 632 in 1.10.1), all green on pre-commit
+- Three follow-ups tracked separately for the next release: confirm-before-cancel via HEAD on the resource href (#105), source/account scoping in `cancel_orphaned_booking` (#106), propstat-aware sync-collection XML parser (#107)
+
 ## [1.10.1] - 2026-05-12
 
 Patch release fixing booking-time timezone display across the dashboard, the post-booking emails, and the ICS attachments they carry. No schema changes, no behaviour changes outside the timezone-display surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 | Guest cancel/reschedule notice window | 1.10.0 | Per-event-type minimum lead time before a guest can self-cancel or self-reschedule via the tokenized email links; host actions from the dashboard are unaffected |
 | Estonian locale | 1.10.0 | First community-language slot added beyond the original four (English, French, Spanish, Polish, German, Italian) |
 | Admin user deletion | 1.10.0 | Admins can permanently delete users from the admin panel with cascade rules and confirmation |
+| Capped slots hidden in picker | 1.11.0 | When a frequency limit has been hit for the day/week/month/year, the slot picker skips those times instead of letting a guest pick a doomed slot |
+| Per-member booking frequency limits | 1.11.0 | Opt-in "Per team member" flag on each frequency-limit row so caps apply to individual round-robin members (e.g. 1 demo/day per person) instead of pooled team-wide |
+
+## [1.11.0] - 2026-05-22
+
+Two themes: closing the 1.10.2 sync-robustness hotfix loop (the three follow-ups filed against #105 / #106 / #107) and turning the booking-frequency-limits surface from a half-wired feature into a real one — first by hiding capped slots in the picker, then by adding per-team-member caps.
+
+### Added
+
+- **Hide booking slots when a frequency cap is reached** (closes #115, PR #116) — `compute_slots` now runs `apply_frequency_limit_filter` after slot generation: for each configured `(max, period)` it counts existing confirmed+pending bookings per containing host-local period, then drops slots that fall in any capped period. The submit-time check (`would_exceed_frequency_limit`) stays as a race-condition backstop, but the picker no longer shows times the submit-time check would reject. Limit-reached page also got proper styling (template render instead of bare `Html("...")`)
+- **Per-member booking frequency limits** (closes #117, PR #118) — new `booking_frequency_limits.per_member` flag (migration 051) so a host can express "1 demo/day per team member" instead of "1 demo/day team-wide". Threaded through three sites: `would_exceed_frequency_limit` takes `Option<&str> assigned_user_id` and scopes the count by assignee; `pick_group_member` excludes candidates already at their per-member cap so the picker doesn't route to a doomed user; `apply_frequency_limit_filter` hides a slot only when every eligible team member is at cap. UI gets a "Per team member" checkbox on each limit row, hidden on personal event types
+
+### Fixed
+
+- **CalDAV resource is HEAD-checked before cancelling a booking** (closes #105, PR #108) — sync-collection's "deleted" entries are now treated as a hint, not a verdict: before cancelling a confirmed booking we HEAD the resource href and only act if the server confirms 404. Two new regression tests (one for the BlueMind phantom-deletion case, one for the legitimate deletion case)
+- **`cancel_orphaned_booking` is scoped to its own source/account** (closes #106, PR #111) — previously did a global UID-only lookup against the bookings table, so a sync running on source A could cancel a booking whose CalDAV event lived under source B (different calendar, different account). Now joins through `event_types → accounts → caldav_sources` and only acts on rows whose source matches the one currently syncing
+- **Property-level 404s inside `<d:propstat>` are ignored** (closes #107, PR #109) — the sync-collection parser previously treated *any* 404 status code inside a `<d:response>` as a deletion, including the per-property 404 some servers emit when one of the requested DAV properties is absent on an otherwise-live resource. Parser now distinguishes resource-level status from propstat-level status and only routes resource-level 404s into the deletion handler
+- **Team event type frequency limits actually persist** (PR #114) — `edit_group_event_type_form` never queried `booking_frequency_limits`, and `create_group_event_type` / `update_group_event_type` never wrote to it. Toggling the cap on a team event type was a silent no-op. Three-way fix mirrors the working personal-event-type flow
+
+### Internal
+
+- 650 tests total (up from 634 in 1.10.2), all green on pre-commit
+- Migration 051 (`booking_frequency_limits.per_member`)
+- `render_claim_error` renamed to `render_booking_action_error` since the template (`booking_action_error.html`) isn't claim-specific
+- Coverage CI: `under_tarpaulin()` now uses `cfg!(tarpaulin)` (the previous `CARGO_TARPAULIN_VERSION` env-var check never fired, so the racy tracing-capture tests were leaking through the supposed-to-skip guard); `Cargo.toml` registers `cfg(tarpaulin)` via the `unexpected_cfgs` lint config
 
 ## [1.10.2] - 2026-05-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calrs"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calrs"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calrs"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 description = "A fast, self-hostable scheduling platform. Like Cal.com, but written in Rust."
 license = "AGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,6 @@ unic-langid = "0.9"
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calrs"
-version = "1.10.2"
+version = "1.11.0"
 edition = "2021"
 description = "A fast, self-hostable scheduling platform. Like Cal.com, but written in Rust."
 license = "AGPL-3.0"

--- a/migrations/051_per_member_frequency_limit.sql
+++ b/migrations/051_per_member_frequency_limit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE booking_frequency_limits ADD COLUMN per_member INTEGER NOT NULL DEFAULT 0;

--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -542,15 +542,32 @@ fn parse_sync_response(xml: &str) -> SyncResult {
             continue;
         }
 
-        // Check if this is a deletion (status contains 404)
-        if let Some(status) = extract_tag(response_block, "d:status") {
-            if status.contains("404") {
+        // A `<d:response>` element carries the resource's status in one of two ways
+        // (RFC 4918 §9.1, mutually exclusive):
+        //   1. A direct child `<d:status>` element  — the resource-level status
+        //      (e.g. `404 Not Found` for a deletion in a sync-collection delta).
+        //   2. One or more `<d:propstat>` elements, each with its OWN `<d:status>`
+        //      describing which requested properties were found vs missing on the
+        //      (still-existing) resource.
+        //
+        // The status check below must only look at case (1). Looking at the first
+        // `<d:status>` tag anywhere in the response block misreads a property-level
+        // 404 — for example, a propstat reporting that `<d:getetag>` was not
+        // returned — as if the whole resource had been deleted. That mis-classification
+        // wrongly cancelled live customer bookings in production on 2026-05-14.
+        // Strip `<d:propstat>` subtrees before the status lookup so only the
+        // resource-level status is considered.
+        let stripped = strip_propstat_blocks(response_block);
+        if let Some(status) = extract_tag(&stripped, "d:status") {
+            if status.contains("404") || status.contains("410") {
                 deleted_hrefs.push(href);
                 continue;
             }
         }
 
-        // Otherwise it's an addition/modification — extract calendar data
+        // Otherwise it's an addition/modification — extract calendar data from
+        // the original (un-stripped) block, since calendar-data lives inside a
+        // propstat by definition.
         let ical_data = extract_tag(response_block, "cal:calendar-data")
             .or_else(|| extract_tag(response_block, "c:calendar-data"))
             .unwrap_or_default();
@@ -564,6 +581,50 @@ fn parse_sync_response(xml: &str) -> SyncResult {
         changed,
         deleted_hrefs,
     }
+}
+
+/// Remove every `<propstat>…</propstat>` subtree from a WebDAV response fragment.
+///
+/// Used by `parse_sync_response` to isolate the resource-level `<d:status>` from
+/// any property-level statuses nested inside propstat elements. Handles the three
+/// namespace-prefix patterns seen in the wild for the DAV: namespace: `d:`, `D:`,
+/// and unprefixed. Tolerates malformed XML (leaves any unmatched open tag in
+/// place) rather than failing.
+fn strip_propstat_blocks(s: &str) -> String {
+    let mut result = s.to_string();
+    for (open_prefix, close_tag) in &[
+        ("<d:propstat", "</d:propstat>"),
+        ("<D:propstat", "</D:propstat>"),
+        ("<propstat", "</propstat>"),
+    ] {
+        let mut search_from = 0;
+        while let Some(rel_start) = result[search_from..].find(open_prefix) {
+            let abs_start = search_from + rel_start;
+            // Confirm we matched the real tag and not a longer name like
+            // `<propstats>` — the next byte must be `>` or whitespace.
+            let after = result
+                .as_bytes()
+                .get(abs_start + open_prefix.len())
+                .copied();
+            if !matches!(
+                after,
+                Some(b'>') | Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
+            ) {
+                // Not a propstat element. Advance past this prefix and continue.
+                search_from = abs_start + open_prefix.len();
+                continue;
+            }
+            let Some(rel_close) = result[abs_start..].find(close_tag) else {
+                // Malformed: open tag without close. Stop processing this prefix.
+                break;
+            };
+            let end = abs_start + rel_close + close_tag.len();
+            result.replace_range(abs_start..end, "");
+            // Continue searching from where the block used to start.
+            search_from = abs_start;
+        }
+    }
+    result
 }
 
 fn parse_event_responses(xml: &str) -> Vec<RawEvent> {
@@ -1146,6 +1207,172 @@ END:VCALENDAR</cal:calendar-data>
         let result = parse_sync_response(xml);
         assert!(result.changed.is_empty());
         assert_eq!(result.deleted_hrefs.len(), 2);
+    }
+
+    /// Regression test for issue #107 / 2026-05-14 production incident.
+    ///
+    /// Per RFC 4918 §9.1, a `<d:response>` for an existing resource may carry
+    /// one or more `<d:propstat>` blocks, each with its own `<d:status>` that
+    /// describes which requested properties succeeded vs which were not found.
+    /// A 404 inside a propstat is a property-level "this prop doesn't exist on
+    /// this resource", NOT a resource-level deletion. Before the fix, the
+    /// parser took the first `<d:status>` it found anywhere in the response
+    /// block and misread a property-level 404 as a deleted href — which is
+    /// what cancelled customer bookings in production.
+    ///
+    /// This XML reproduces the failure shape: a response with a 404 propstat
+    /// (a property that doesn't exist on the resource) ordered BEFORE a 200
+    /// propstat that carries the actual calendar-data. The parser must
+    /// classify this as a `changed` event, not as a deletion.
+    #[test]
+    fn parse_sync_ignores_property_level_404_in_propstat() {
+        let xml = r#"
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/cal/live-event.ics</d:href>
+    <d:propstat>
+      <d:prop><d:getetag/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>"abc-123"</d:getetag>
+        <cal:calendar-data>BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:still-here
+END:VEVENT
+END:VCALENDAR</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:sync-token>https://example.com/sync/t1</d:sync-token>
+</d:multistatus>"#;
+
+        let result = parse_sync_response(xml);
+        assert!(
+            result.deleted_hrefs.is_empty(),
+            "a 404 propstat must NOT be classified as a resource-level deletion; \
+             got deleted_hrefs={:?}",
+            result.deleted_hrefs
+        );
+        assert_eq!(result.changed.len(), 1);
+        assert_eq!(result.changed[0].href, "/cal/live-event.ics");
+        assert!(result.changed[0].ical_data.contains("UID:still-here"));
+    }
+
+    /// Companion to the above: confirm a genuine resource-level deletion
+    /// (a single `<d:status>` directly under `<d:response>`, no propstat)
+    /// is still correctly classified as a deleted href. Strip-only-propstat
+    /// must not over-correct and ignore real deletions.
+    #[test]
+    fn parse_sync_still_detects_real_resource_deletion() {
+        let xml = r#"
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/cal/actually-gone.ics</d:href>
+    <d:status>HTTP/1.1 404 Not Found</d:status>
+  </d:response>
+  <d:sync-token>https://example.com/sync/t2</d:sync-token>
+</d:multistatus>"#;
+
+        let result = parse_sync_response(xml);
+        assert_eq!(result.deleted_hrefs, vec!["/cal/actually-gone.ics"]);
+        assert!(result.changed.is_empty());
+    }
+
+    /// 410 Gone (per RFC 7231) means the resource was deliberately removed.
+    /// Some CalDAV servers return 410 instead of 404 for deletions. The parser
+    /// must treat both as resource-level deletions.
+    #[test]
+    fn parse_sync_treats_410_as_deletion() {
+        let xml = r#"
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/cal/gone.ics</d:href>
+    <d:status>HTTP/1.1 410 Gone</d:status>
+  </d:response>
+</d:multistatus>"#;
+
+        let result = parse_sync_response(xml);
+        assert_eq!(result.deleted_hrefs, vec!["/cal/gone.ics"]);
+    }
+
+    /// Mixed response: a true deletion (no propstat, resource-level 404),
+    /// a "changed with property-level 404 propstat" entry, and a vanilla
+    /// 200 addition should all coexist in one multistatus and parse correctly.
+    #[test]
+    fn parse_sync_mixed_real_deletion_and_propstat_404() {
+        let xml = r#"
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/cal/deleted.ics</d:href>
+    <d:status>HTTP/1.1 404 Not Found</d:status>
+  </d:response>
+  <d:response>
+    <d:href>/cal/has-propstat-404.ics</d:href>
+    <d:propstat>
+      <d:prop><d:displayname/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>"e1"</d:getetag>
+        <cal:calendar-data>BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:withpropstat404
+END:VEVENT
+END:VCALENDAR</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/cal/normal.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>"e2"</d:getetag>
+        <cal:calendar-data>BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:normal
+END:VEVENT
+END:VCALENDAR</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>"#;
+
+        let result = parse_sync_response(xml);
+        assert_eq!(result.deleted_hrefs, vec!["/cal/deleted.ics"]);
+        assert_eq!(result.changed.len(), 2);
+        let hrefs: Vec<&str> = result.changed.iter().map(|e| e.href.as_str()).collect();
+        assert!(hrefs.contains(&"/cal/has-propstat-404.ics"));
+        assert!(hrefs.contains(&"/cal/normal.ics"));
+    }
+
+    #[test]
+    fn strip_propstat_blocks_handles_uppercase_and_unprefixed() {
+        // Lowercase prefix
+        let s = "<d:response><d:href>/a</d:href><d:propstat><d:status>404</d:status></d:propstat></d:response>";
+        let out = strip_propstat_blocks(s);
+        assert_eq!(out, "<d:response><d:href>/a</d:href></d:response>");
+
+        // Uppercase prefix (SOGo style)
+        let s = "<D:response><D:href>/b</D:href><D:propstat><D:status>404</D:status></D:propstat></D:response>";
+        let out = strip_propstat_blocks(s);
+        assert_eq!(out, "<D:response><D:href>/b</D:href></D:response>");
+
+        // Unprefixed
+        let s = "<response><href>/c</href><propstat><status>404</status></propstat></response>";
+        let out = strip_propstat_blocks(s);
+        assert_eq!(out, "<response><href>/c</href></response>");
+
+        // `<propstats>` (different element with similar prefix) must NOT be stripped
+        let s = "<d:response><d:propstats-wrapper>keep me</d:propstats-wrapper></d:response>";
+        let out = strip_propstat_blocks(s);
+        assert!(out.contains("propstats-wrapper"));
+        assert!(out.contains("keep me"));
     }
 
     // --- parse_event_responses ---

--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -279,6 +279,62 @@ impl CaldavClient {
         Ok(())
     }
 
+    /// Check whether an event resource still exists on the server.
+    ///
+    /// Returns `Ok(true)` if the server confirms the resource is present (2xx),
+    /// `Ok(false)` if the server confirms it is gone (404/410). Any other
+    /// response — network error, timeout, 5xx, 401/403 — is returned as
+    /// `Err`, and callers must treat that as "can't tell, do not act."
+    ///
+    /// Uses HEAD by default; if the server returns 405 (Method Not Allowed,
+    /// some CalDAV servers refuse HEAD on resources) falls back to PROPFIND
+    /// depth:0 with an empty prop body, which is universally supported.
+    pub async fn event_exists(&self, calendar_href: &str, uid: &str) -> Result<bool> {
+        let href = format!("{}/{}.ics", calendar_href.trim_end_matches('/'), uid);
+        let url = self.resolve_url(&href);
+
+        let resp = self
+            .client
+            .head(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
+        let status = resp.status();
+
+        if status.as_u16() == 405 {
+            // Fall back to PROPFIND depth:0 with an empty prop request.
+            let body = r#"<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:"><d:prop><d:getetag/></d:prop></d:propfind>"#;
+            let resp = self
+                .client
+                .request(reqwest::Method::from_bytes(b"PROPFIND")?, &url)
+                .basic_auth(&self.username, Some(&self.password))
+                .header("Content-Type", "application/xml; charset=utf-8")
+                .header("Depth", "0")
+                .timeout(Duration::from_secs(10))
+                .body(body)
+                .send()
+                .await?;
+            let s = resp.status();
+            if s.is_success() || s.as_u16() == 207 {
+                return Ok(true);
+            }
+            if s.as_u16() == 404 || s.as_u16() == 410 {
+                return Ok(false);
+            }
+            bail!("PROPFIND {} returned {}", url, s);
+        }
+
+        if status.is_success() {
+            return Ok(true);
+        }
+        if status.as_u16() == 404 || status.as_u16() == 410 {
+            return Ok(false);
+        }
+        bail!("HEAD {} returned {}", url, status)
+    }
+
     /// DELETE an event from a calendar
     pub async fn delete_event(&self, calendar_href: &str, uid: &str) -> Result<()> {
         let href = format!("{}/{}.ics", calendar_href.trim_end_matches('/'), uid);

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -120,6 +120,7 @@ pub async fn sync_source(
                             pool,
                             key,
                             Some(client),
+                            source_id,
                             &cal_id,
                             &result.deleted_hrefs,
                         )
@@ -171,8 +172,15 @@ pub async fn sync_source(
                     let count = upsert_raw_events(pool, &cal_id, &raw_events).await;
 
                     // Remove events that no longer exist on the server
-                    let deleted =
-                        remove_orphaned_events(pool, key, Some(client), &cal_id, &raw_events).await;
+                    let deleted = remove_orphaned_events(
+                        pool,
+                        key,
+                        Some(client),
+                        source_id,
+                        &cal_id,
+                        &raw_events,
+                    )
+                    .await;
                     if deleted > 0 {
                         tracing::info!(
                             calendar_name = cal_label,
@@ -450,10 +458,14 @@ async fn upsert_raw_events(pool: &SqlitePool, cal_id: &str, raw_events: &[RawEve
 ///
 /// `client` is forwarded to `cancel_orphaned_booking` for confirm-before-cancel
 /// verification. Tests pass `None` to bypass HTTP verification.
+///
+/// `source_id` scopes booking cancellations to event types owned by this source's
+/// account (issue #106 defense-in-depth).
 async fn delete_events_by_href(
     pool: &SqlitePool,
     key: &[u8; 32],
     client: Option<&CaldavClient>,
+    source_id: &str,
     cal_id: &str,
     hrefs: &[String],
 ) -> u32 {
@@ -483,7 +495,7 @@ async fn delete_events_by_href(
             // (e.g. BlueMind sync-collection emitting spurious 404 propstats) — not
             // proof the host deleted the event. Cancelling on that signal alone has
             // wrongly cancelled live bookings in production.
-            cancel_orphaned_booking(pool, key, client, uid).await;
+            cancel_orphaned_booking(pool, key, client, source_id, uid).await;
         } else {
             tracing::warn!(
                 uid = %uid,
@@ -501,10 +513,14 @@ async fn delete_events_by_href(
 ///
 /// `client` is forwarded to `cancel_orphaned_booking` for confirm-before-cancel
 /// verification. Tests pass `None` to bypass HTTP verification.
+///
+/// `source_id` scopes booking cancellations to event types owned by this source's
+/// account (issue #106 defense-in-depth).
 async fn remove_orphaned_events(
     pool: &SqlitePool,
     key: &[u8; 32],
     client: Option<&CaldavClient>,
+    source_id: &str,
     cal_id: &str,
     raw_events: &[RawEvent],
 ) -> u32 {
@@ -548,7 +564,7 @@ async fn remove_orphaned_events(
                 .bind(event_id)
                 .execute(pool)
                 .await;
-            cancel_orphaned_booking(pool, key, client, uid).await;
+            cancel_orphaned_booking(pool, key, client, source_id, uid).await;
             deleted += 1;
         }
     }
@@ -561,6 +577,11 @@ async fn remove_orphaned_events(
 /// so "missing from server" is the normal state, not a cancellation signal.
 /// Sends cancellation email to the guest (and host) if SMTP is configured.
 ///
+/// `source_id` scopes the lookup: only bookings on event types whose account owns
+/// `source_id` are eligible for cancellation. This is defense-in-depth — a sync
+/// of source A must never be able to cancel a booking on source B (different
+/// account, same UID by collision). See issue #106.
+///
 /// When `client` is `Some` and the booking has a stored `caldav_calendar_href`,
 /// the resource is double-checked against the server via HEAD/PROPFIND before
 /// the cancellation goes through. If the server says the event is still there
@@ -568,15 +589,18 @@ async fn remove_orphaned_events(
 /// the cancellation is skipped and a warning is logged. This is the safety net
 /// against false positives in any orphan path: see issue #105.
 ///
-/// Tests pass `None` to skip the HTTP verification and exercise the DB-only
-/// cancellation behaviour directly.
+/// Tests pass `None` for `client` to skip the HTTP verification and exercise the
+/// DB-only cancellation behaviour directly.
 async fn cancel_orphaned_booking(
     pool: &SqlitePool,
     key: &[u8; 32],
     client: Option<&CaldavClient>,
+    source_id: &str,
     uid: &str,
 ) {
-    // Fetch booking details before cancelling
+    // Fetch booking details before cancelling. Scoped by source_id via the
+    // caldav_sources join: the source's account must match the booking's
+    // event-type account.
     let booking: Option<(
         String,
         String,
@@ -596,9 +620,11 @@ async fn cancel_orphaned_booking(
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
-         WHERE b.uid = ? AND b.status = 'confirmed'",
+         JOIN caldav_sources cs ON cs.account_id = a.id
+         WHERE b.uid = ? AND b.status = 'confirmed' AND cs.id = ?",
     )
     .bind(uid)
+    .bind(source_id)
     .fetch_optional(pool)
     .await
     .unwrap_or(None);
@@ -746,7 +772,7 @@ async fn cancel_orphaned_bookings(
     .unwrap_or_default();
 
     for (uid,) in &orphans {
-        cancel_orphaned_booking(pool, key, client, uid).await;
+        cancel_orphaned_booking(pool, key, client, source_id, uid).await;
     }
 }
 
@@ -896,7 +922,7 @@ mod tests {
         // Simulate BlueMind's sync-collection reporting this href as deleted on
         // the Shared calendar (false positive — the event isn't there locally).
         let href = format!("/calendars/host/shared/{}.ics", booking_uid);
-        let deleted = delete_events_by_href(&pool, &key, None, &cal_id, &[href]).await;
+        let deleted = delete_events_by_href(&pool, &key, None, &source_id, &cal_id, &[href]).await;
         assert_eq!(deleted, 0, "no local row to delete");
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
@@ -960,7 +986,7 @@ mod tests {
         .unwrap();
 
         let href = format!("/calendars/host/default/{}.ics", booking_uid);
-        let deleted = delete_events_by_href(&pool, &key, None, &cal_id, &[href]).await;
+        let deleted = delete_events_by_href(&pool, &key, None, &source_id, &cal_id, &[href]).await;
         assert_eq!(deleted, 1, "local row should have been removed");
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
@@ -1034,7 +1060,8 @@ mod tests {
         let client = CaldavClient::new("http://127.0.0.1:1", "u", "p");
 
         let href = format!("/calendars/host/default/{}.ics", booking_uid);
-        let _ = delete_events_by_href(&pool, &key, Some(&client), &cal_id, &[href]).await;
+        let _ =
+            delete_events_by_href(&pool, &key, Some(&client), &source_id, &cal_id, &[href]).await;
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
             .bind(&booking_id)
@@ -1079,6 +1106,95 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, "cancelled");
+    }
+
+    /// Issue #106 (cross-source isolation defense-in-depth): a sync of source A
+    /// must NEVER cancel a booking that belongs to source B's account, even if
+    /// the UIDs collide. UUIDs make natural collisions vanishingly unlikely, but
+    /// a single-tenant install where an admin imports an iCal feed (or a future
+    /// codepath that generates UIDs from a non-UUID source) could produce one.
+    /// The lookup in `cancel_orphaned_booking` is scoped via a join on
+    /// `caldav_sources.account_id = event_types.account_id`, with the source_id
+    /// filter pinning the side we're acting on. This test verifies that scoping.
+    #[tokio::test]
+    async fn cancel_does_not_cross_source_account_boundary() {
+        let pool = setup_test_db().await;
+        // Account A: gets seeded by the helper. Source A, event type A.
+        // We don't act ON source A in this test — we only verify a sync of
+        // source B can't reach across to cancel a booking on account A.
+        let (_source_a_id, et_a_id) = seed_fixtures(&pool).await;
+
+        // Account B: separate user, account, event type, source.
+        let user_b_id = Uuid::new_v4().to_string();
+        let account_b_id = Uuid::new_v4().to_string();
+        let et_b_id = Uuid::new_v4().to_string();
+        let source_b_id = Uuid::new_v4().to_string();
+        let cal_b_id = Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO users (id, email, name, role, auth_provider, username, enabled) VALUES (?, 'host-b@example.com', 'Host B', 'user', 'local', 'hostb', 1)")
+            .bind(&user_b_id).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO accounts (id, name, email, timezone, user_id) VALUES (?, 'Host B', 'host-b@example.com', 'UTC', ?)")
+            .bind(&account_b_id).bind(&user_b_id).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO event_types (id, account_id, slug, title, duration_min) VALUES (?, ?, 'intro-b', 'Intro B', 30)")
+            .bind(&et_b_id).bind(&account_b_id).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO caldav_sources (id, account_id, name, url, username, write_calendar_href) VALUES (?, ?, 'test-b', 'https://dav-b.example.com/', 'user-b', '/calendars/hostb/default/')")
+            .bind(&source_b_id).bind(&account_b_id).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO calendars (id, source_id, href, display_name) VALUES (?, ?, '/calendars/hostb/default/', 'Default B')")
+            .bind(&cal_b_id).bind(&source_b_id).execute(&pool).await.unwrap();
+
+        let shared_uid = "colliding-uid@calrs";
+        let key = [0u8; 32];
+
+        // Confirmed booking on ACCOUNT A — this is what we're protecting.
+        let booking_a_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone,
+                start_at, end_at, status, cancel_token, reschedule_token, caldav_calendar_href)
+             VALUES (?, ?, ?, 'Guest', 'guest@example.com', 'UTC',
+                '2030-06-15T10:00:00', '2030-06-15T10:30:00', 'confirmed', 'ctok', 'rtok',
+                '/calendars/host/default/')",
+        )
+        .bind(&booking_a_id)
+        .bind(&et_a_id)
+        .bind(shared_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Local event on SOURCE B's calendar with the same UID — so the
+        // DELETE in `delete_events_by_href` will report rows_affected > 0
+        // and the rows_affected gate alone can't save us. Only the
+        // source-scoped lookup keeps booking A safe.
+        sqlx::query(
+            "INSERT INTO events (id, calendar_id, uid, summary, start_at, end_at) \
+             VALUES (?, ?, ?, 'Colliding event on B', '2030-06-15T10:00:00', '2030-06-15T10:30:00')",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&cal_b_id)
+        .bind(shared_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Source B reports the colliding UID as deleted.
+        let href = format!("/calendars/hostb/default/{}.ics", shared_uid);
+        let deleted =
+            delete_events_by_href(&pool, &key, None, &source_b_id, &cal_b_id, &[href]).await;
+        assert_eq!(
+            deleted, 1,
+            "the local event row on source B should have been removed"
+        );
+
+        // Booking on ACCOUNT A must still be confirmed.
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_a_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "confirmed",
+            "a sync of source B must not cancel a booking on account A — \
+             source/account scoping is the defense-in-depth boundary"
+        );
     }
 
     #[tokio::test]

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -116,8 +116,14 @@ pub async fn sync_source(
                         false
                     } else {
                         let changed = upsert_raw_events(pool, &cal_id, &result.changed).await;
-                        let deleted =
-                            delete_events_by_href(pool, key, &cal_id, &result.deleted_hrefs).await;
+                        let deleted = delete_events_by_href(
+                            pool,
+                            key,
+                            Some(client),
+                            &cal_id,
+                            &result.deleted_hrefs,
+                        )
+                        .await;
 
                         // Store new sync-token and ctag
                         update_calendar_sync_state(
@@ -165,7 +171,8 @@ pub async fn sync_source(
                     let count = upsert_raw_events(pool, &cal_id, &raw_events).await;
 
                     // Remove events that no longer exist on the server
-                    let deleted = remove_orphaned_events(pool, key, &cal_id, &raw_events).await;
+                    let deleted =
+                        remove_orphaned_events(pool, key, Some(client), &cal_id, &raw_events).await;
                     if deleted > 0 {
                         tracing::info!(
                             calendar_name = cal_label,
@@ -209,7 +216,7 @@ pub async fn sync_source(
     // Cancel any active bookings whose CalDAV event no longer exists.
     // This catches bookings orphaned before the cancellation code was deployed,
     // or edge cases where the event was deleted in a previous sync cycle.
-    cancel_orphaned_bookings(pool, key, source_id).await;
+    cancel_orphaned_bookings(pool, key, Some(client), source_id).await;
 
     // Update last_synced (and last_full_sync if we did a full fetch)
     if did_full_sync {
@@ -440,9 +447,13 @@ async fn upsert_raw_events(pool: &SqlitePool, cal_id: &str, raw_events: &[RawEve
 /// Delete events by their CalDAV href (used for sync-collection 404 deletions).
 /// Extracts UID from href pattern: /path/to/{uid}.ics
 /// Also cancels any calrs bookings whose UID matches a deleted event and notifies the guest.
+///
+/// `client` is forwarded to `cancel_orphaned_booking` for confirm-before-cancel
+/// verification. Tests pass `None` to bypass HTTP verification.
 async fn delete_events_by_href(
     pool: &SqlitePool,
     key: &[u8; 32],
+    client: Option<&CaldavClient>,
     cal_id: &str,
     hrefs: &[String],
 ) -> u32 {
@@ -472,7 +483,7 @@ async fn delete_events_by_href(
             // (e.g. BlueMind sync-collection emitting spurious 404 propstats) — not
             // proof the host deleted the event. Cancelling on that signal alone has
             // wrongly cancelled live bookings in production.
-            cancel_orphaned_booking(pool, key, uid).await;
+            cancel_orphaned_booking(pool, key, client, uid).await;
         } else {
             tracing::warn!(
                 uid = %uid,
@@ -487,9 +498,13 @@ async fn delete_events_by_href(
 }
 
 /// Remove local events that no longer exist on the server (full sync orphan cleanup).
+///
+/// `client` is forwarded to `cancel_orphaned_booking` for confirm-before-cancel
+/// verification. Tests pass `None` to bypass HTTP verification.
 async fn remove_orphaned_events(
     pool: &SqlitePool,
     key: &[u8; 32],
+    client: Option<&CaldavClient>,
     cal_id: &str,
     raw_events: &[RawEvent],
 ) -> u32 {
@@ -533,7 +548,7 @@ async fn remove_orphaned_events(
                 .bind(event_id)
                 .execute(pool)
                 .await;
-            cancel_orphaned_booking(pool, key, uid).await;
+            cancel_orphaned_booking(pool, key, client, uid).await;
             deleted += 1;
         }
     }
@@ -545,7 +560,22 @@ async fn remove_orphaned_events(
 /// Pending bookings are intentionally excluded: they haven't been pushed to CalDAV yet,
 /// so "missing from server" is the normal state, not a cancellation signal.
 /// Sends cancellation email to the guest (and host) if SMTP is configured.
-async fn cancel_orphaned_booking(pool: &SqlitePool, key: &[u8; 32], uid: &str) {
+///
+/// When `client` is `Some` and the booking has a stored `caldav_calendar_href`,
+/// the resource is double-checked against the server via HEAD/PROPFIND before
+/// the cancellation goes through. If the server says the event is still there
+/// (or the verification can't conclude — network error, 5xx, auth failure),
+/// the cancellation is skipped and a warning is logged. This is the safety net
+/// against false positives in any orphan path: see issue #105.
+///
+/// Tests pass `None` to skip the HTTP verification and exercise the DB-only
+/// cancellation behaviour directly.
+async fn cancel_orphaned_booking(
+    pool: &SqlitePool,
+    key: &[u8; 32],
+    client: Option<&CaldavClient>,
+    uid: &str,
+) {
     // Fetch booking details before cancelling
     let booking: Option<(
         String,
@@ -558,9 +588,10 @@ async fn cancel_orphaned_booking(pool: &SqlitePool, key: &[u8; 32], uid: &str) {
         String,
         String,
         String,
+        Option<String>,
     )> = sqlx::query_as(
         "SELECT b.id, b.guest_name, b.guest_email, COALESCE(b.guest_timezone, 'UTC'), b.start_at, b.end_at, b.uid,
-                et.title, u.name, COALESCE(u.booking_email, u.email)
+                et.title, u.name, COALESCE(u.booking_email, u.email), b.caldav_calendar_href
          FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
@@ -588,7 +619,41 @@ async fn cancel_orphaned_booking(pool: &SqlitePool, key: &[u8; 32], uid: &str) {
         event_title,
         host_name,
         host_email,
+        caldav_calendar_href,
     ) = booking;
+
+    // Confirm-before-cancel: if we have a client and a stored calendar href for
+    // this booking, verify that the resource is actually 404 on the server.
+    // Any non-404 outcome (200 = still there, 5xx = server flake, network = down)
+    // means we cannot prove the host deleted the event, so we skip the cancel.
+    if let (Some(client), Some(cal_href)) = (client, caldav_calendar_href.as_deref()) {
+        match client.event_exists(cal_href, uid).await {
+            Ok(false) => {
+                // Server confirms 404 — legitimate deletion, proceed.
+            }
+            Ok(true) => {
+                tracing::warn!(
+                    uid = %uid,
+                    booking_id = %booking_id,
+                    cal_href = %cal_href,
+                    "skipping booking cancellation: CalDAV resource is still present on the server \
+                     (a sync path reported it as deleted but verification disagrees)"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    uid = %uid,
+                    booking_id = %booking_id,
+                    cal_href = %cal_href,
+                    error = %e,
+                    "skipping booking cancellation: could not verify resource state on the server \
+                     (treating inconclusive verification as not-deleted to avoid false positives)"
+                );
+                return;
+            }
+        }
+    }
 
     // Cancel the booking
     let updated = sqlx::query(
@@ -659,7 +724,12 @@ fn extract_time(dt_str: &str) -> String {
 /// not be auto-cancelled by sync — a guest-initiated reschedule that requires approval
 /// deletes the prior CalDAV event on purpose, and the orphan sweep would otherwise race
 /// the approval flow and cancel the booking before the host clicks approve.
-async fn cancel_orphaned_bookings(pool: &SqlitePool, key: &[u8; 32], source_id: &str) {
+async fn cancel_orphaned_bookings(
+    pool: &SqlitePool,
+    key: &[u8; 32],
+    client: Option<&CaldavClient>,
+    source_id: &str,
+) {
     let orphans: Vec<(String,)> = sqlx::query_as(
         "SELECT b.uid FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
@@ -676,7 +746,7 @@ async fn cancel_orphaned_bookings(pool: &SqlitePool, key: &[u8; 32], source_id: 
     .unwrap_or_default();
 
     for (uid,) in &orphans {
-        cancel_orphaned_booking(pool, key, uid).await;
+        cancel_orphaned_booking(pool, key, client, uid).await;
     }
 }
 
@@ -765,7 +835,7 @@ mod tests {
         .unwrap();
         // Note: no matching row in `events` — the CalDAV event was deleted during reschedule.
 
-        cancel_orphaned_bookings(&pool, &key, &source_id).await;
+        cancel_orphaned_bookings(&pool, &key, None, &source_id).await;
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
             .bind(&booking_id)
@@ -826,7 +896,7 @@ mod tests {
         // Simulate BlueMind's sync-collection reporting this href as deleted on
         // the Shared calendar (false positive — the event isn't there locally).
         let href = format!("/calendars/host/shared/{}.ics", booking_uid);
-        let deleted = delete_events_by_href(&pool, &key, &cal_id, &[href]).await;
+        let deleted = delete_events_by_href(&pool, &key, None, &cal_id, &[href]).await;
         assert_eq!(deleted, 0, "no local row to delete");
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
@@ -890,7 +960,7 @@ mod tests {
         .unwrap();
 
         let href = format!("/calendars/host/default/{}.ics", booking_uid);
-        let deleted = delete_events_by_href(&pool, &key, &cal_id, &[href]).await;
+        let deleted = delete_events_by_href(&pool, &key, None, &cal_id, &[href]).await;
         assert_eq!(deleted, 1, "local row should have been removed");
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
@@ -899,6 +969,83 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, "cancelled");
+    }
+
+    /// Confirm-before-cancel (issue #105): when the verification HTTP call can't
+    /// reach the server (unreachable host, timeout, 5xx), `cancel_orphaned_booking`
+    /// must treat the result as inconclusive and SKIP the cancellation. The
+    /// principle is "never cancel a customer booking unless the server confirms
+    /// the event is gone." A flaky network minute is no basis for cancelling.
+    ///
+    /// This test points the CaldavClient at a closed port so the HEAD fails with
+    /// a connection error; we set up a delta-path scenario where the booking
+    /// would otherwise be cancelled (local event present, server reports deletion).
+    #[tokio::test]
+    async fn delete_events_by_href_skips_cancellation_when_verification_fails() {
+        let pool = setup_test_db().await;
+        let (source_id, et_id) = seed_fixtures(&pool).await;
+        let key = [0u8; 32];
+
+        let cal_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO calendars (id, source_id, href, display_name) \
+             VALUES (?, ?, '/calendars/host/default/', 'Default')",
+        )
+        .bind(&cal_id)
+        .bind(&source_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let booking_uid = "ambiguous-deletion@calrs";
+
+        // Local event row exists — so the DELETE will report rows_affected > 0
+        // and the hotfix gate alone wouldn't save us. Only the verification
+        // layer should keep this booking confirmed.
+        sqlx::query(
+            "INSERT INTO events (id, calendar_id, uid, summary, start_at, end_at) \
+             VALUES (?, ?, ?, 'Demo', '2030-06-15T10:00:00', '2030-06-15T10:30:00')",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&cal_id)
+        .bind(booking_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let booking_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone,
+                start_at, end_at, status, cancel_token, reschedule_token, caldav_calendar_href)
+             VALUES (?, ?, ?, 'Guest', 'guest@example.com', 'UTC',
+                '2030-06-15T10:00:00', '2030-06-15T10:30:00', 'confirmed', 'ctok', 'rtok',
+                '/calendars/host/default/')",
+        )
+        .bind(&booking_id)
+        .bind(&et_id)
+        .bind(booking_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Port 1 is reserved (tcpmux) and ~always closed on a dev box — HEAD will
+        // fail with a connection refusal, exercising the Err(_) arm of the
+        // verification gate.
+        let client = CaldavClient::new("http://127.0.0.1:1", "u", "p");
+
+        let href = format!("/calendars/host/default/{}.ics", booking_uid);
+        let _ = delete_events_by_href(&pool, &key, Some(&client), &cal_id, &[href]).await;
+
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "confirmed",
+            "verification HTTP failure must NOT cancel the booking — \
+             inconclusive evidence cannot justify a customer-visible cancellation"
+        );
     }
 
     /// Positive case: the orphan sweep still cancels a confirmed booking whose CalDAV
@@ -924,7 +1071,7 @@ mod tests {
         .await
         .unwrap();
 
-        cancel_orphaned_bookings(&pool, &key, &source_id).await;
+        cancel_orphaned_bookings(&pool, &key, None, &source_id).await;
 
         let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
             .bind(&booking_id)

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -454,17 +454,33 @@ async fn delete_events_by_href(
             .next()
             .unwrap_or("")
             .trim_end_matches(".ics");
-        if !uid.is_empty() {
-            let result = sqlx::query("DELETE FROM events WHERE calendar_id = ? AND uid = ?")
-                .bind(cal_id)
-                .bind(uid)
-                .execute(pool)
-                .await;
-            if let Ok(r) = result {
-                deleted += r.rows_affected() as u32;
-            }
-            // Cancel any matching booking that was deleted on the CalDAV server
+        if uid.is_empty() {
+            continue;
+        }
+        let rows = sqlx::query("DELETE FROM events WHERE calendar_id = ? AND uid = ?")
+            .bind(cal_id)
+            .bind(uid)
+            .execute(pool)
+            .await
+            .map(|r| r.rows_affected())
+            .unwrap_or(0);
+        if rows > 0 {
+            deleted += rows as u32;
+            // Cancel any matching booking that was deleted on the CalDAV server.
+            // Gated on rows_affected > 0: if the server reports an href as deleted
+            // but we never had a matching local event, that's a server-side quirk
+            // (e.g. BlueMind sync-collection emitting spurious 404 propstats) — not
+            // proof the host deleted the event. Cancelling on that signal alone has
+            // wrongly cancelled live bookings in production.
             cancel_orphaned_booking(pool, key, uid).await;
+        } else {
+            tracing::warn!(
+                uid = %uid,
+                href = %href,
+                calendar_id = %cal_id,
+                "sync-collection reported href as deleted but no matching local event; \
+                 skipping booking cancellation (likely server-side false positive)"
+            );
         }
     }
     deleted
@@ -761,6 +777,128 @@ mod tests {
             "pending bookings must not be auto-cancelled by the orphan sweep — \
              they're awaiting host approval, not tracking a CalDAV event"
         );
+    }
+
+    /// Regression test for production incident 2026-05-14: a sync-collection delta
+    /// reported an href as deleted, but the local `events` table had no matching row
+    /// (the event lived on a different calendar — the booking's write calendar).
+    /// Before the fix, `delete_events_by_href` still called `cancel_orphaned_booking`,
+    /// which scans bookings globally by UID and wrongly cancelled a live booking.
+    /// The fix gates the cancellation on the local DELETE having matched a row.
+    #[tokio::test]
+    async fn delete_events_by_href_skips_cancellation_when_no_local_event() {
+        let pool = setup_test_db().await;
+        let (source_id, et_id) = seed_fixtures(&pool).await;
+        let key = [0u8; 32];
+
+        // Seed a calendar on this source (the one that supposedly reported a
+        // deletion via sync-collection delta).
+        let cal_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO calendars (id, source_id, href, display_name) \
+             VALUES (?, ?, '/calendars/host/shared/', 'Shared')",
+        )
+        .bind(&cal_id)
+        .bind(&source_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The confirmed booking. Note: NO matching row in `events` for this calendar
+        // — the booking's CalDAV event lives elsewhere (or was never synced into
+        // this particular calendar).
+        let booking_uid = "live-booking-uid@calrs";
+        let booking_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone,
+                start_at, end_at, status, cancel_token, reschedule_token, caldav_calendar_href)
+             VALUES (?, ?, ?, 'Guest', 'guest@example.com', 'UTC',
+                '2030-06-15T10:00:00', '2030-06-15T10:30:00', 'confirmed', 'ctok', 'rtok',
+                '/calendars/host/default/')",
+        )
+        .bind(&booking_id)
+        .bind(&et_id)
+        .bind(booking_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Simulate BlueMind's sync-collection reporting this href as deleted on
+        // the Shared calendar (false positive — the event isn't there locally).
+        let href = format!("/calendars/host/shared/{}.ics", booking_uid);
+        let deleted = delete_events_by_href(&pool, &key, &cal_id, &[href]).await;
+        assert_eq!(deleted, 0, "no local row to delete");
+
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "confirmed",
+            "a sync-collection 'deleted' href with no local event MUST NOT cancel the booking"
+        );
+    }
+
+    /// Positive case for `delete_events_by_href`: when the server reports a deletion
+    /// AND we had a matching local event for that calendar, we both remove the event
+    /// and cancel any booking with that UID. This is the legitimate signal.
+    #[tokio::test]
+    async fn delete_events_by_href_cancels_when_local_event_existed() {
+        let pool = setup_test_db().await;
+        let (source_id, et_id) = seed_fixtures(&pool).await;
+        let key = [0u8; 32];
+
+        let cal_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO calendars (id, source_id, href, display_name) \
+             VALUES (?, ?, '/calendars/host/default/', 'Default')",
+        )
+        .bind(&cal_id)
+        .bind(&source_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let booking_uid = "to-be-cancelled@calrs";
+
+        // Seed the local event row (we knew about it before the server signaled deletion).
+        sqlx::query(
+            "INSERT INTO events (id, calendar_id, uid, summary, start_at, end_at) \
+             VALUES (?, ?, ?, 'Demo', '2030-06-15T10:00:00', '2030-06-15T10:30:00')",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&cal_id)
+        .bind(booking_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let booking_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone,
+                start_at, end_at, status, cancel_token, reschedule_token, caldav_calendar_href)
+             VALUES (?, ?, ?, 'Guest', 'guest@example.com', 'UTC',
+                '2030-06-15T10:00:00', '2030-06-15T10:30:00', 'confirmed', 'ctok', 'rtok',
+                '/calendars/host/default/')",
+        )
+        .bind(&booking_id)
+        .bind(&et_id)
+        .bind(booking_uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let href = format!("/calendars/host/default/{}.ics", booking_uid);
+        let deleted = delete_events_by_href(&pool, &key, &cal_id, &[href]).await;
+        assert_eq!(deleted, 1, "local row should have been removed");
+
+        let status: String = sqlx::query_scalar("SELECT status FROM bookings WHERE id = ?")
+            .bind(&booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "cancelled");
     }
 
     /// Positive case: the orphan sweep still cancels a confirmed booking whose CalDAV

--- a/src/db.rs
+++ b/src/db.rs
@@ -219,6 +219,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "050_min_notice_cancel_reschedule",
             include_str!("../migrations/050_min_notice_cancel_reschedule.sql"),
         ),
+        (
+            "051_per_member_frequency_limit",
+            include_str!("../migrations/051_per_member_frequency_limit.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -800,7 +804,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 50, "All 50 migrations should be tracked");
+        assert_eq!(count.0, 51, "All 51 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -814,7 +818,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 50, "Still 50 migrations after second run");
+        assert_eq!(count.0, 51, "Still 51 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -43,7 +43,7 @@ pub struct SmtpConfig {
 }
 
 impl SmtpConfig {
-    /// Get "from" Mailbox, complient with RFC 5322
+    /// Get "from" Mailbox, compliant with RFC 5322
     fn mailbox_from(&self) -> Result<Mailbox> {
         Ok(Mailbox::new(
             self.from_name.clone(),

--- a/src/email.rs
+++ b/src/email.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDateTime;
 use chrono_tz::Tz;
 use fluent_bundle::{FluentArgs, FluentValue};
 use lettre::message::header::ContentType;
-use lettre::message::{Attachment, MultiPart, SinglePart};
+use lettre::message::{Attachment, Mailbox, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 use sqlx::SqlitePool;
@@ -40,6 +40,16 @@ pub struct SmtpConfig {
     pub password: String,
     pub from_email: String,
     pub from_name: Option<String>,
+}
+
+impl SmtpConfig {
+    /// Get "from" Mailbox
+    fn from_mailbox(&self) -> Result<Mailbox> {
+        Ok(Mailbox::new(
+            self.from_name.to_owned(),
+            self.from_email.parse()?,
+        ))
+    }
 }
 
 #[derive(Clone, Default)]
@@ -428,8 +438,6 @@ pub async fn send_guest_confirmation_ex(
     let ics = generate_ics(details, "REQUEST");
     let lang = guest_lang(details);
 
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!(
@@ -598,8 +606,11 @@ pub async fn send_guest_confirmation_ex(
         "email-confirm-subject",
         [("event", &details.event_title), ("date", &details.date)],
     );
+
+    let from = config.from_mailbox()?;
+
     let email = Message::builder()
-        .from(from)
+        .from(from.to_owned())
         .to(to)
         .subject(subject)
         .multipart(
@@ -613,8 +624,6 @@ pub async fn send_guest_confirmation_ex(
     // Send confirmation to additional attendees
     for attendee_email in &details.additional_attendees {
         let ics2 = generate_ics(details, "REQUEST");
-        let from2: lettre::message::Mailbox =
-            format!("{} <{}>", from_display, config.from_email).parse()?;
         let to2: lettre::message::Mailbox = attendee_email.parse()?;
         let plain2 = format!(
             "Hi,\n\n\
@@ -672,7 +681,7 @@ pub async fn send_guest_confirmation_ex(
             ContentType::parse("text/calendar; method=REQUEST; charset=UTF-8")?,
         );
         let email2 = Message::builder()
-            .from(from2)
+            .from(from.to_owned())
             .to(to2)
             .subject(format!(
                 "Invite: {} \u{2014} {}",
@@ -691,8 +700,6 @@ pub async fn send_guest_confirmation_ex(
 pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetails) -> Result<()> {
     let ics = generate_ics(details, "REQUEST");
 
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -770,7 +777,7 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
     );
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "New booking: {} \u{2014} {} ({})",
@@ -791,8 +798,6 @@ pub async fn send_host_booking_confirmed(
     config: &SmtpConfig,
     details: &BookingDetails,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -854,7 +859,7 @@ pub async fn send_host_booking_confirmed(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Confirmed: {} \u{2014} {} ({})",
@@ -872,8 +877,6 @@ pub async fn send_guest_reminder(
     cancel_url: Option<&str>,
 ) -> Result<()> {
     let lang = guest_lang(details);
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!(
@@ -976,7 +979,7 @@ pub async fn send_guest_reminder(
         ],
     );
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(subject)
         .multipart(body)?;
@@ -986,8 +989,6 @@ pub async fn send_guest_reminder(
 
 /// Send booking reminder to the host
 pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -1045,7 +1046,7 @@ pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Reminder: {} \u{2014} {} ({})",
@@ -1064,8 +1065,6 @@ pub async fn send_guest_cancellation(
     let ics = generate_cancel_ics(details);
     let lang = details.guest_language.as_deref().unwrap_or("en");
 
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -1170,7 +1169,7 @@ pub async fn send_guest_cancellation(
         [("event", &details.event_title), ("date", &details.date)],
     );
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(subject)
         .multipart(
@@ -1189,8 +1188,6 @@ pub async fn send_host_cancellation(
 ) -> Result<()> {
     let ics = generate_cancel_ics(details);
 
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -1262,7 +1259,7 @@ pub async fn send_host_cancellation(
     );
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Cancelled: {} \u{2014} {} ({})",
@@ -1292,8 +1289,6 @@ pub async fn send_guest_pending_notice_ex(
     cancel_url: Option<&str>,
     reschedule_url: Option<&str>,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!(
@@ -1384,7 +1379,7 @@ pub async fn send_guest_pending_notice_ex(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Pending: {} \u{2014} {}",
@@ -1403,8 +1398,6 @@ pub async fn send_host_approval_request(
     confirm_token: Option<&str>,
     base_url: Option<&str>,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -1516,7 +1509,7 @@ pub async fn send_host_approval_request(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Action required: {} \u{2014} {} ({})",
@@ -1532,8 +1525,6 @@ pub async fn send_guest_decline_notice(
     config: &SmtpConfig,
     details: &CancellationDetails,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -1596,7 +1587,7 @@ pub async fn send_guest_decline_notice(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Declined: {} \u{2014} {}",
@@ -1636,8 +1627,7 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
 
 /// Send a test email
 pub async fn send_test_email(config: &SmtpConfig, to_email: &str) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
+    let from = Mailbox::new(config.from_name.to_owned(), config.from_email.parse()?);
     let to = to_email.parse()?;
 
     let plain = "This is a test email from calrs. SMTP is working!".to_string();
@@ -1658,6 +1648,7 @@ pub async fn send_test_email(config: &SmtpConfig, to_email: &str) -> Result<()> 
         .subject("calrs \u{2014} SMTP test")
         .multipart(body)?;
 
+    tracing::debug!("Sending: {:?}", email);
     send_email(config, email).await
 }
 
@@ -1672,8 +1663,7 @@ pub async fn send_invite_email(
     invite_url: &str,
     expires_at: Option<&str>,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
+    let from = config.from_mailbox()?;
     let to = format!("{} <{}>", guest_name, guest_email).parse()?;
 
     let expiry_note = expires_at
@@ -1805,8 +1795,7 @@ pub async fn send_guest_pick_new_time(
     reschedule_url: &str,
     cancel_url: Option<&str>,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
+    let from = config.from_mailbox()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!(
@@ -1919,8 +1908,6 @@ pub async fn send_guest_reschedule_notification(
     };
     let ics = generate_ics(&booking_details, "REQUEST");
 
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let plain = format!(
@@ -2016,7 +2003,7 @@ pub async fn send_guest_reschedule_notification(
     );
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Rescheduled: {} \u{2014} {}",
@@ -2043,8 +2030,6 @@ pub async fn send_host_reschedule_request(
         details.new_start_time, details.new_end_time
     );
 
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
     let (approve_url, decline_url) = match (confirm_token, base_url) {
@@ -2147,7 +2132,7 @@ pub async fn send_host_reschedule_request(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Reschedule request: {} \u{2014} {} <{}>",
@@ -2168,8 +2153,6 @@ pub async fn send_watcher_claim_notification(
     assigned_to_name: &str,
     claim_url: &str,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", watcher_name, watcher_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -2245,7 +2228,7 @@ pub async fn send_watcher_claim_notification(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Claim available: {} \u{2014} {} ({})",
@@ -2262,8 +2245,6 @@ pub async fn send_claim_confirmation(
     claimant_name: &str,
     claimant_email: &str,
 ) -> Result<()> {
-    let from_display = config.from_name.as_deref().unwrap_or(&config.from_email);
-    let from = format!("{} <{}>", from_display, config.from_email).parse()?;
     let to = format!("{} <{}>", claimant_name, claimant_email).parse()?;
 
     let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
@@ -2325,7 +2306,7 @@ pub async fn send_claim_confirmation(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.from_mailbox()?)
         .to(to)
         .subject(format!(
             "Booking claimed: {} \u{2014} {} ({})",

--- a/src/email.rs
+++ b/src/email.rs
@@ -43,10 +43,10 @@ pub struct SmtpConfig {
 }
 
 impl SmtpConfig {
-    /// Get "from" Mailbox
-    fn from_mailbox(&self) -> Result<Mailbox> {
+    /// Get "from" Mailbox, complient with RFC 5322
+    fn mailbox_from(&self) -> Result<Mailbox> {
         Ok(Mailbox::new(
-            self.from_name.to_owned(),
+            self.from_name.clone(),
             self.from_email.parse()?,
         ))
     }
@@ -607,10 +607,10 @@ pub async fn send_guest_confirmation_ex(
         [("event", &details.event_title), ("date", &details.date)],
     );
 
-    let from = config.from_mailbox()?;
+    let from = config.mailbox_from()?;
 
     let email = Message::builder()
-        .from(from.to_owned())
+        .from(from.clone())
         .to(to)
         .subject(subject)
         .multipart(
@@ -681,7 +681,7 @@ pub async fn send_guest_confirmation_ex(
             ContentType::parse("text/calendar; method=REQUEST; charset=UTF-8")?,
         );
         let email2 = Message::builder()
-            .from(from.to_owned())
+            .from(from.clone())
             .to(to2)
             .subject(format!(
                 "Invite: {} \u{2014} {}",
@@ -777,7 +777,7 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
     );
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "New booking: {} \u{2014} {} ({})",
@@ -859,7 +859,7 @@ pub async fn send_host_booking_confirmed(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Confirmed: {} \u{2014} {} ({})",
@@ -979,7 +979,7 @@ pub async fn send_guest_reminder(
         ],
     );
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(subject)
         .multipart(body)?;
@@ -1046,7 +1046,7 @@ pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Reminder: {} \u{2014} {} ({})",
@@ -1169,7 +1169,7 @@ pub async fn send_guest_cancellation(
         [("event", &details.event_title), ("date", &details.date)],
     );
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(subject)
         .multipart(
@@ -1259,7 +1259,7 @@ pub async fn send_host_cancellation(
     );
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Cancelled: {} \u{2014} {} ({})",
@@ -1379,7 +1379,7 @@ pub async fn send_guest_pending_notice_ex(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Pending: {} \u{2014} {}",
@@ -1509,7 +1509,7 @@ pub async fn send_host_approval_request(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Action required: {} \u{2014} {} ({})",
@@ -1587,7 +1587,7 @@ pub async fn send_guest_decline_notice(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Declined: {} \u{2014} {}",
@@ -1627,7 +1627,6 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
 
 /// Send a test email
 pub async fn send_test_email(config: &SmtpConfig, to_email: &str) -> Result<()> {
-    let from = Mailbox::new(config.from_name.to_owned(), config.from_email.parse()?);
     let to = to_email.parse()?;
 
     let plain = "This is a test email from calrs. SMTP is working!".to_string();
@@ -1643,11 +1642,12 @@ pub async fn send_test_email(config: &SmtpConfig, to_email: &str) -> Result<()> 
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(from)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject("calrs \u{2014} SMTP test")
         .multipart(body)?;
 
+    // Debug is only useful when sending a test email
     tracing::debug!("Sending: {:?}", email);
     send_email(config, email).await
 }
@@ -1663,7 +1663,7 @@ pub async fn send_invite_email(
     invite_url: &str,
     expires_at: Option<&str>,
 ) -> Result<()> {
-    let from = config.from_mailbox()?;
+    let from = config.mailbox_from()?;
     let to = format!("{} <{}>", guest_name, guest_email).parse()?;
 
     let expiry_note = expires_at
@@ -1795,7 +1795,7 @@ pub async fn send_guest_pick_new_time(
     reschedule_url: &str,
     cancel_url: Option<&str>,
 ) -> Result<()> {
-    let from = config.from_mailbox()?;
+    let from = config.mailbox_from()?;
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
     let time_display = format!(
@@ -2003,7 +2003,7 @@ pub async fn send_guest_reschedule_notification(
     );
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Rescheduled: {} \u{2014} {}",
@@ -2132,7 +2132,7 @@ pub async fn send_host_reschedule_request(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Reschedule request: {} \u{2014} {} <{}>",
@@ -2228,7 +2228,7 @@ pub async fn send_watcher_claim_notification(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Claim available: {} \u{2014} {} ({})",
@@ -2306,7 +2306,7 @@ pub async fn send_claim_confirmation(
     let body = build_multipart_body(&plain, &html);
 
     let email = Message::builder()
-        .from(config.from_mailbox()?)
+        .from(config.mailbox_from()?)
         .to(to)
         .subject(format!(
             "Booking claimed: {} \u{2014} {} ({})",
@@ -2319,7 +2319,43 @@ pub async fn send_claim_confirmation(
 
 #[cfg(test)]
 mod tests {
+    use lettre::Address;
+
     use super::*;
+
+    #[test]
+    fn smtp_config_mailbox_from() {
+        let config = SmtpConfig {
+            host: "host".to_string(),
+            port: 587,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            from_name: None,
+            from_email: "username@example.com".to_string(),
+        };
+        assert_eq!(
+            config.mailbox_from().unwrap(),
+            Mailbox::new(None, Address::new("username", "example.com").unwrap()),
+            "from email with no name"
+        );
+
+        let config = SmtpConfig {
+            host: "host".to_string(),
+            port: 587,
+            username: "username".to_string(),
+            password: "password".to_string(),
+            from_name: Some("Name, With Comma".to_string()),
+            from_email: "username@example.com".to_string(),
+        };
+        assert_eq!(
+            config.mailbox_from().unwrap(),
+            Mailbox::new(
+                Some("Name, With Comma".to_string()),
+                Address::new("username", "example.com").unwrap()
+            ),
+            "from email with name"
+        );
+    }
 
     // --- sanitize_ics ---
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -10139,6 +10139,12 @@ async fn compute_slots(
         &overrides,
     );
 
+    // Drop slots whose host-local period already meets/exceeds a configured
+    // frequency cap. The submit-time check (would_exceed_frequency_limit)
+    // stays as a backstop for the race where two guests grab the last slot
+    // at the same instant.
+    apply_frequency_limit_filter(pool, et_id, &mut result).await;
+
     // If first_slot_only is enabled, keep only the earliest slot per day
     let first_only: i32 =
         sqlx::query_scalar("SELECT first_slot_only FROM event_types WHERE id = ?")
@@ -10154,6 +10160,73 @@ async fn compute_slots(
     }
 
     result
+}
+
+/// Remove slots that fall inside a host-local period already at/over a
+/// configured booking-frequency cap, so the picker doesn't surface times
+/// that the submit-time check would reject.
+async fn apply_frequency_limit_filter(pool: &SqlitePool, et_id: &str, days: &mut [SlotDay]) {
+    let limits: Vec<(i32, String)> = sqlx::query_as(
+        "SELECT max_bookings, period FROM booking_frequency_limits WHERE event_type_id = ?",
+    )
+    .bind(et_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    if limits.is_empty() {
+        return;
+    }
+
+    // Gather every (limit, period_start) pair that any visible slot belongs to,
+    // then resolve each unique (period, period_start) to a count. The same
+    // period covers many slots, so we collapse before querying.
+    let mut needed: HashMap<(String, NaiveDateTime), i64> = HashMap::new();
+    for day in days.iter() {
+        for slot in &day.slots {
+            let Ok(d) = NaiveDate::parse_from_str(&slot.host_date, "%Y-%m-%d") else {
+                continue;
+            };
+            let dt = d.and_hms_opt(12, 0, 0).unwrap();
+            for (_, period) in &limits {
+                let (ps, _) = frequency_period_range(dt, period);
+                needed.entry((period.clone(), ps)).or_insert(0);
+            }
+        }
+    }
+
+    for ((period, ps), count) in needed.iter_mut() {
+        let (rs, re) = frequency_period_range(*ps, period);
+        let rs_str = rs.format("%Y-%m-%dT%H:%M:%S").to_string();
+        let re_str = re.format("%Y-%m-%dT%H:%M:%S").to_string();
+        let c: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM bookings WHERE event_type_id = ? AND status IN ('confirmed', 'pending') AND start_at >= ? AND start_at < ?",
+        )
+        .bind(et_id)
+        .bind(&rs_str)
+        .bind(&re_str)
+        .fetch_one(pool)
+        .await
+        .unwrap_or((0,));
+        *count = c.0;
+    }
+
+    for day in days.iter_mut() {
+        day.slots.retain(|slot| {
+            let Ok(d) = NaiveDate::parse_from_str(&slot.host_date, "%Y-%m-%d") else {
+                return true;
+            };
+            let dt = d.and_hms_opt(12, 0, 0).unwrap();
+            for (max, period) in &limits {
+                let (ps, _) = frequency_period_range(dt, period);
+                let count = needed.get(&(period.clone(), ps)).copied().unwrap_or(0);
+                if count >= *max as i64 {
+                    return false;
+                }
+            }
+            true
+        });
+    }
 }
 
 /// Save booking frequency limits from the serialized form field ("1:day,5:week").
@@ -15753,6 +15826,290 @@ mod tests {
         assert!(
             slot_times.contains(&"09:00"),
             "09:00 should be free (no buffer overlap)"
+        );
+    }
+
+    #[tokio::test]
+    async fn compute_slots_frequency_limit_per_day_drops_capped_day() {
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period) VALUES (?, ?, 1, 'day')")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+
+        let start_at = next_monday
+            .and_hms_opt(10, 0, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        let end_at = next_monday
+            .and_hms_opt(10, 30, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token) VALUES (?, ?, 'uid1', 'Guest', 'g@e.com', 'UTC', ?, ?, 'confirmed', ?, ?)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .bind(&start_at)
+            .bind(&end_at)
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(uuid::Uuid::new_v4().to_string())
+            .execute(&pool).await.unwrap();
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            5,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let monday_date = next_monday.format("%Y-%m-%d").to_string();
+        let monday = slot_days.iter().find(|d| d.date == monday_date);
+        assert!(
+            monday.map(|d| d.slots.is_empty()).unwrap_or(true),
+            "1/day cap reached → Monday should expose no slots, got {:?}",
+            monday.map(|d| d.slots.len())
+        );
+
+        let tuesday_date = (next_monday + Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string();
+        let tuesday = slot_days
+            .iter()
+            .find(|d| d.date == tuesday_date)
+            .expect("Tuesday should be present");
+        assert_eq!(
+            tuesday.slots.len(),
+            16,
+            "Tuesday is unaffected by Monday's per-day cap"
+        );
+    }
+
+    #[tokio::test]
+    async fn compute_slots_frequency_limit_per_week_drops_whole_week() {
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period) VALUES (?, ?, 1, 'week')")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+
+        // One booking on Monday consumes the week's only slot.
+        let start_at = next_monday
+            .and_hms_opt(10, 0, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        let end_at = next_monday
+            .and_hms_opt(10, 30, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token) VALUES (?, ?, 'uid1', 'Guest', 'g@e.com', 'UTC', ?, ?, 'confirmed', ?, ?)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .bind(&start_at)
+            .bind(&end_at)
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(uuid::Uuid::new_v4().to_string())
+            .execute(&pool).await.unwrap();
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            5,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        for day in &slot_days {
+            assert!(
+                day.slots.is_empty(),
+                "Per-week cap of 1 reached → {} should have no slots, got {}",
+                day.date,
+                day.slots.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn compute_slots_frequency_limit_ignores_cancelled_bookings() {
+        // Regression: cancelled bookings must not count toward the cap. If they
+        // did, hosts who frequently cancel would silently shrink their own
+        // availability.
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period) VALUES (?, ?, 1, 'day')")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+
+        // Single cancelled booking on Monday — should not consume the day's cap.
+        let start_at = next_monday
+            .and_hms_opt(10, 0, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        let end_at = next_monday
+            .and_hms_opt(10, 30, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token) VALUES (?, ?, 'uid1', 'Guest', 'g@e.com', 'UTC', ?, ?, 'cancelled', ?, ?)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .bind(&start_at)
+            .bind(&end_at)
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(uuid::Uuid::new_v4().to_string())
+            .execute(&pool).await.unwrap();
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            1,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let monday_date = next_monday.format("%Y-%m-%d").to_string();
+        let monday = slot_days
+            .iter()
+            .find(|d| d.date == monday_date)
+            .expect("Monday should be present");
+        assert_eq!(
+            monday.slots.len(),
+            16,
+            "Cancelled bookings must not consume the day cap; expected full 16 slots, got {}",
+            monday.slots.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn compute_slots_frequency_limit_multiple_caps_each_checked() {
+        // Configure both a 1/day and a 100/year cap. With one booking on
+        // Monday only the day cap fires, so Monday must be hidden but
+        // Tue–Fri must stay visible. This pins that the filter consults every
+        // configured limit independently rather than stopping at the first.
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period) VALUES (?, ?, 1, 'day')")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period) VALUES (?, ?, 100, 'year')")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+
+        let start_at = next_monday
+            .and_hms_opt(10, 0, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        let end_at = next_monday
+            .and_hms_opt(10, 30, 0)
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token) VALUES (?, ?, 'uid1', 'Guest', 'g@e.com', 'UTC', ?, ?, 'confirmed', ?, ?)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .bind(&start_at)
+            .bind(&end_at)
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(uuid::Uuid::new_v4().to_string())
+            .execute(&pool).await.unwrap();
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            5,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let monday_date = next_monday.format("%Y-%m-%d").to_string();
+        let monday = slot_days.iter().find(|d| d.date == monday_date);
+        assert!(
+            monday.map(|d| d.slots.is_empty()).unwrap_or(true),
+            "1/day cap should hide Monday even with a lax year cap, got {:?}",
+            monday.map(|d| d.slots.len())
+        );
+
+        let tuesday_date = (next_monday + Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string();
+        let tuesday = slot_days
+            .iter()
+            .find(|d| d.date == tuesday_date)
+            .expect("Tuesday should be present");
+        assert_eq!(
+            tuesday.slots.len(),
+            16,
+            "Year cap not reached → Tuesday must stay visible"
         );
     }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6647,6 +6647,9 @@ async fn create_group_event_type(
         }
     }
 
+    // Save booking frequency limits
+    save_frequency_limits(&state.pool, &et_id, &form.frequency_limits).await;
+
     Redirect::to("/dashboard/event-types").into_response()
 }
 
@@ -6894,6 +6897,21 @@ async fn edit_group_event_type_form(
         .collect::<Vec<_>>()
         .join(",");
 
+    // Fetch booking frequency limits
+    let freq_limits: Vec<(i32, String)> = sqlx::query_as(
+        "SELECT max_bookings, period FROM booking_frequency_limits WHERE event_type_id = ?",
+    )
+    .bind(&et_id)
+    .fetch_all(&state.pool)
+    .await
+    .unwrap_or_default();
+
+    let form_frequency_limits = freq_limits
+        .iter()
+        .map(|(c, p)| format!("{}:{}", c, p))
+        .collect::<Vec<_>>()
+        .join(",");
+
     let tmpl = match state.templates.get_template("event_type_form.html") {
         Ok(t) => t,
         Err(e) => return internal_error_html("template render", &e),
@@ -6928,6 +6946,7 @@ async fn edit_group_event_type_form(
             form_scheduling_mode => scheduling_mode,
             form_default_calendar_view => default_calendar_view,
             form_first_slot_only => first_slot_only != 0,
+            form_frequency_limits => form_frequency_limits,
             form_timezone => &form_timezone,
             form_cancel_notice_value => form_cancel_notice_value,
             form_cancel_notice_unit => form_cancel_notice_unit,
@@ -7141,6 +7160,13 @@ async fn update_group_event_type(
             }
         }
     }
+
+    // Update booking frequency limits: delete old, insert new
+    let _ = sqlx::query("DELETE FROM booking_frequency_limits WHERE event_type_id = ?")
+        .bind(&et_id)
+        .execute(&state.pool)
+        .await;
+    save_frequency_limits(&state.pool, &et_id, &form.frequency_limits).await;
 
     Redirect::to("/dashboard/event-types").into_response()
 }
@@ -8050,8 +8076,12 @@ async fn handle_group_booking(
     // Check booking frequency limits
     if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
         let _ = tx.rollback().await;
-        return Html("This event type has reached its booking limit for this period.".to_string())
-            .into_response();
+        return render_booking_action_error(
+            &state,
+            &headers,
+            "Not available right now",
+            "The host isn't accepting more bookings for this date. Please pick a different date, or check back later.",
+        );
     }
 
     let insert_result = sqlx::query(
@@ -8781,8 +8811,12 @@ async fn handle_dynamic_group_booking(
 
     // Check booking frequency limits
     if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
-        return Html("This event type has reached its booking limit for this period.".to_string())
-            .into_response();
+        return render_booking_action_error(
+            state,
+            headers,
+            "Not available right now",
+            "The host isn't accepting more bookings for this date. Please pick a different date, or check back later.",
+        );
     }
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -9533,8 +9567,12 @@ async fn handle_booking_for_user(
     // Check booking frequency limits
     if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
         let _ = tx.rollback().await;
-        return Html("This event type has reached its booking limit for this period.".to_string())
-            .into_response();
+        return render_booking_action_error(
+            &state,
+            &headers,
+            "Not available right now",
+            "The host isn't accepting more bookings for this date. Please pick a different date, or check back later.",
+        );
     }
 
     let insert_result = sqlx::query(
@@ -11312,8 +11350,12 @@ async fn handle_booking(
     // Check booking frequency limits
     if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
         let _ = tx.rollback().await;
-        return Html("This event type has reached its booking limit for this period.".to_string())
-            .into_response();
+        return render_booking_action_error(
+            &state,
+            &headers,
+            "Not available right now",
+            "The host isn't accepting more bookings for this date. Please pick a different date, or check back later.",
+        );
     }
 
     let insert_result = sqlx::query(
@@ -14716,7 +14758,7 @@ async fn claim_booking_form(
     let token = match params.get("token") {
         Some(t) => t,
         None => {
-            return render_claim_error(
+            return render_booking_action_error(
                 &state,
                 &headers,
                 "Invalid link",
@@ -14764,7 +14806,7 @@ async fn claim_booking_form(
             .into_response();
         }
 
-        return render_claim_error(
+        return render_booking_action_error(
             &state,
             &headers,
             "Invalid or expired link",
@@ -14788,7 +14830,7 @@ async fn claim_booking_form(
     let (event_title, guest_name, guest_email, start_at, end_at, assigned_to) = match booking {
         Some(b) => b,
         None => {
-            return render_claim_error(
+            return render_booking_action_error(
                 &state,
                 &headers,
                 "Booking not found",
@@ -14881,7 +14923,7 @@ async fn claim_booking(
                 .into_response();
             }
 
-            return render_claim_error(
+            return render_booking_action_error(
                 &state,
                 &headers,
                 "Invalid or expired link",
@@ -14991,7 +15033,7 @@ async fn claim_booking(
     ) = match booking {
         Some(b) => b,
         None => {
-            return render_claim_error(
+            return render_booking_action_error(
                 &state,
                 &headers,
                 "Booking not found",
@@ -15118,7 +15160,7 @@ async fn claim_booking(
     .into_response()
 }
 
-fn render_claim_error(
+fn render_booking_action_error(
     state: &AppState,
     headers: &HeaderMap,
     title: &str,
@@ -16926,8 +16968,12 @@ mod tests {
     /// `cargo test`. Skip those tests under coverage rather than ship a
     /// red CI job, but keep them live everywhere else so the contract is
     /// still enforced.
+    ///
+    /// Detection uses `cfg!(tarpaulin)` since cargo-tarpaulin compiles with
+    /// `--cfg=tarpaulin`. An earlier attempt keyed off `CARGO_TARPAULIN_VERSION`
+    /// but tarpaulin never sets that env var, so the guard never fired.
     fn under_tarpaulin() -> bool {
-        std::env::var_os("CARGO_TARPAULIN_VERSION").is_some()
+        cfg!(tarpaulin)
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4493,8 +4493,8 @@ async fn edit_event_type_form(
     };
 
     // Fetch booking frequency limits
-    let freq_limits: Vec<(i32, String)> = sqlx::query_as(
-        "SELECT max_bookings, period FROM booking_frequency_limits WHERE event_type_id = ?",
+    let freq_limits: Vec<(i32, String, i32)> = sqlx::query_as(
+        "SELECT max_bookings, period, per_member FROM booking_frequency_limits WHERE event_type_id = ?",
     )
     .bind(&et_id)
     .fetch_all(&state.pool)
@@ -4503,7 +4503,13 @@ async fn edit_event_type_form(
 
     let form_frequency_limits = freq_limits
         .iter()
-        .map(|(c, p)| format!("{}:{}", c, p))
+        .map(|(c, p, m)| {
+            if *m != 0 {
+                format!("{}:{}:m", c, p)
+            } else {
+                format!("{}:{}", c, p)
+            }
+        })
         .collect::<Vec<_>>()
         .join(",");
 
@@ -6898,8 +6904,8 @@ async fn edit_group_event_type_form(
         .join(",");
 
     // Fetch booking frequency limits
-    let freq_limits: Vec<(i32, String)> = sqlx::query_as(
-        "SELECT max_bookings, period FROM booking_frequency_limits WHERE event_type_id = ?",
+    let freq_limits: Vec<(i32, String, i32)> = sqlx::query_as(
+        "SELECT max_bookings, period, per_member FROM booking_frequency_limits WHERE event_type_id = ?",
     )
     .bind(&et_id)
     .fetch_all(&state.pool)
@@ -6908,7 +6914,13 @@ async fn edit_group_event_type_form(
 
     let form_frequency_limits = freq_limits
         .iter()
-        .map(|(c, p)| format!("{}:{}", c, p))
+        .map(|(c, p, m)| {
+            if *m != 0 {
+                format!("{}:{}:m", c, p)
+            } else {
+                format!("{}:{}", c, p)
+            }
+        })
         .collect::<Vec<_>>()
         .join(",");
 
@@ -8074,7 +8086,8 @@ async fn handle_group_booking(
     };
 
     // Check booking frequency limits
-    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
+    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start, Some(&assigned_user_id)).await
+    {
         let _ = tx.rollback().await;
         return render_booking_action_error(
             &state,
@@ -8809,8 +8822,10 @@ async fn handle_dynamic_group_booking(
         }
     }
 
-    // Check booking frequency limits
-    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
+    // Check booking frequency limits. The dynamic-group flow doesn't pin a
+    // single assignee on the booking, so per-member caps fall back to
+    // event-type-wide here.
+    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start, None).await {
         return render_booking_action_error(
             state,
             headers,
@@ -9564,8 +9579,9 @@ async fn handle_booking_for_user(
         return Html("This slot is no longer available.".to_string()).into_response();
     }
 
-    // Check booking frequency limits
-    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
+    // Check booking frequency limits. Personal event-type flows don't have a
+    // team assignee, so per-member caps degrade to event-type-wide here.
+    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start, None).await {
         let _ = tx.rollback().await;
         return render_booking_action_error(
             &state,
@@ -9829,6 +9845,18 @@ async fn pick_group_member(
     .await
     .unwrap_or_default();
 
+    // Per-member booking-frequency caps. We exclude any member already at
+    // (or over) their per-period cap so the picker doesn't pick them just to
+    // have the submit-time check reject the booking.
+    let per_member_limits: Vec<(i32, String)> = sqlx::query_as(
+        "SELECT max_bookings, period FROM booking_frequency_limits \
+         WHERE event_type_id = ? AND per_member = 1",
+    )
+    .bind(event_type_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
     let mut available_members = Vec::new();
 
     for (user_id, name, email, weight) in &members {
@@ -9846,9 +9874,38 @@ async fn pick_group_member(
         // returned unconstrained by user_avail_as_busy, matching the slot
         // grid semantics in show_group_slots.
         busy.extend(user_avail_as_busy(pool, user_id, buf_start, buf_end, host_tz).await);
-        if !has_conflict(&busy, buf_start, buf_end) {
-            available_members.push((user_id.clone(), name.clone(), email.clone(), *weight));
+        if has_conflict(&busy, buf_start, buf_end) {
+            continue;
         }
+
+        let mut at_per_member_cap = false;
+        for (max, period) in &per_member_limits {
+            let (rs, re) = frequency_period_range(slot_start, period);
+            let rs_str = rs.format("%Y-%m-%dT%H:%M:%S").to_string();
+            let re_str = re.format("%Y-%m-%dT%H:%M:%S").to_string();
+            let count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM bookings \
+                 WHERE event_type_id = ? AND assigned_user_id = ? \
+                 AND status IN ('confirmed', 'pending') \
+                 AND start_at >= ? AND start_at < ?",
+            )
+            .bind(event_type_id)
+            .bind(user_id)
+            .bind(&rs_str)
+            .bind(&re_str)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
+            if count >= *max as i64 {
+                at_per_member_cap = true;
+                break;
+            }
+        }
+        if at_per_member_cap {
+            continue;
+        }
+
+        available_members.push((user_id.clone(), name.clone(), email.clone(), *weight));
     }
 
     if available_members.is_empty() {
@@ -10165,9 +10222,15 @@ async fn compute_slots(
 /// Remove slots that fall inside a host-local period already at/over a
 /// configured booking-frequency cap, so the picker doesn't surface times
 /// that the submit-time check would reject.
+///
+/// Per-member limits hide a slot only when *every* eligible team member is
+/// already at their cap for the slot's period; if any one of them still has
+/// headroom, the slot stays available and the round-robin picker will route
+/// to that member. On personal event types (no team), per-member limits
+/// degrade to event-type-wide behaviour.
 async fn apply_frequency_limit_filter(pool: &SqlitePool, et_id: &str, days: &mut [SlotDay]) {
-    let limits: Vec<(i32, String)> = sqlx::query_as(
-        "SELECT max_bookings, period FROM booking_frequency_limits WHERE event_type_id = ?",
+    let limits: Vec<(i32, String, i32)> = sqlx::query_as(
+        "SELECT max_bookings, period, per_member FROM booking_frequency_limits WHERE event_type_id = ?",
     )
     .bind(et_id)
     .fetch_all(pool)
@@ -10178,27 +10241,46 @@ async fn apply_frequency_limit_filter(pool: &SqlitePool, et_id: &str, days: &mut
         return;
     }
 
-    // Gather every (limit, period_start) pair that any visible slot belongs to,
-    // then resolve each unique (period, period_start) to a count. The same
-    // period covers many slots, so we collapse before querying.
-    let mut needed: HashMap<(String, NaiveDateTime), i64> = HashMap::new();
+    let has_per_member = limits.iter().any(|(_, _, m)| *m != 0);
+    let team_members: Vec<String> = if has_per_member {
+        sqlx::query_scalar(
+            "SELECT u.id FROM users u \
+             JOIN team_members tm ON tm.user_id = u.id \
+             JOIN event_types et ON et.team_id = tm.team_id \
+             LEFT JOIN event_type_member_weights etw ON etw.user_id = u.id AND etw.event_type_id = et.id \
+             WHERE et.id = ? AND u.enabled = 1 AND COALESCE(etw.weight, 1) > 0",
+        )
+        .bind(et_id)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // Gather unique (period, period_start) pairs the visible slots touch, and
+    // resolve each one to (event-type-wide count, per-member counts).
+    let mut wide_counts: HashMap<(String, NaiveDateTime), i64> = HashMap::new();
+    let mut member_counts: HashMap<(String, NaiveDateTime, String), i64> = HashMap::new();
+
     for day in days.iter() {
         for slot in &day.slots {
             let Ok(d) = NaiveDate::parse_from_str(&slot.host_date, "%Y-%m-%d") else {
                 continue;
             };
             let dt = d.and_hms_opt(12, 0, 0).unwrap();
-            for (_, period) in &limits {
+            for (_, period, _) in &limits {
                 let (ps, _) = frequency_period_range(dt, period);
-                needed.entry((period.clone(), ps)).or_insert(0);
+                wide_counts.entry((period.clone(), ps)).or_insert(0);
             }
         }
     }
 
-    for ((period, ps), count) in needed.iter_mut() {
+    for ((period, ps), wide) in wide_counts.iter_mut() {
         let (rs, re) = frequency_period_range(*ps, period);
         let rs_str = rs.format("%Y-%m-%dT%H:%M:%S").to_string();
         let re_str = re.format("%Y-%m-%dT%H:%M:%S").to_string();
+
         let c: (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM bookings WHERE event_type_id = ? AND status IN ('confirmed', 'pending') AND start_at >= ? AND start_at < ?",
         )
@@ -10208,7 +10290,26 @@ async fn apply_frequency_limit_filter(pool: &SqlitePool, et_id: &str, days: &mut
         .fetch_one(pool)
         .await
         .unwrap_or((0,));
-        *count = c.0;
+        *wide = c.0;
+
+        if has_per_member && !team_members.is_empty() {
+            let rows: Vec<(String, i64)> = sqlx::query_as(
+                "SELECT assigned_user_id, COUNT(*) FROM bookings \
+                 WHERE event_type_id = ? AND assigned_user_id IS NOT NULL \
+                 AND status IN ('confirmed', 'pending') \
+                 AND start_at >= ? AND start_at < ? \
+                 GROUP BY assigned_user_id",
+            )
+            .bind(et_id)
+            .bind(&rs_str)
+            .bind(&re_str)
+            .fetch_all(pool)
+            .await
+            .unwrap_or_default();
+            for (uid, n) in rows {
+                member_counts.insert((period.clone(), *ps, uid), n);
+            }
+        }
     }
 
     for day in days.iter_mut() {
@@ -10217,11 +10318,26 @@ async fn apply_frequency_limit_filter(pool: &SqlitePool, et_id: &str, days: &mut
                 return true;
             };
             let dt = d.and_hms_opt(12, 0, 0).unwrap();
-            for (max, period) in &limits {
+            for (max, period, per_member) in &limits {
                 let (ps, _) = frequency_period_range(dt, period);
-                let count = needed.get(&(period.clone(), ps)).copied().unwrap_or(0);
-                if count >= *max as i64 {
-                    return false;
+                let max_i64 = *max as i64;
+                if *per_member != 0 && !team_members.is_empty() {
+                    // Hide only if every eligible member is at cap.
+                    let all_capped = team_members.iter().all(|uid| {
+                        let count = member_counts
+                            .get(&(period.clone(), ps, uid.clone()))
+                            .copied()
+                            .unwrap_or(0);
+                        count >= max_i64
+                    });
+                    if all_capped {
+                        return false;
+                    }
+                } else {
+                    let count = wide_counts.get(&(period.clone(), ps)).copied().unwrap_or(0);
+                    if count >= max_i64 {
+                        return false;
+                    }
                 }
             }
             true
@@ -10229,7 +10345,10 @@ async fn apply_frequency_limit_filter(pool: &SqlitePool, et_id: &str, days: &mut
     }
 }
 
-/// Save booking frequency limits from the serialized form field ("1:day,5:week").
+/// Save booking frequency limits from the serialized form field.
+/// Format per row: "count:period" or "count:period:m" (the trailing ":m"
+/// marks the row as per-member; absence means event-type-wide). Rows are
+/// comma-separated.
 async fn save_frequency_limits(pool: &SqlitePool, event_type_id: &str, limits_str: &str) {
     if limits_str.is_empty() {
         return;
@@ -10239,20 +10358,27 @@ async fn save_frequency_limits(pool: &SqlitePool, event_type_id: &str, limits_st
         if part.is_empty() {
             continue;
         }
-        if let Some((count_str, period)) = part.split_once(':') {
-            let count: i32 = count_str.parse().unwrap_or(0);
-            if count > 0 && ["day", "week", "month", "year"].contains(&period) {
-                let limit_id = uuid::Uuid::new_v4().to_string();
-                let _ = sqlx::query(
-                    "INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period) VALUES (?, ?, ?, ?)",
-                )
-                .bind(&limit_id)
-                .bind(event_type_id)
-                .bind(count)
-                .bind(period)
-                .execute(pool)
-                .await;
-            }
+        let mut bits = part.splitn(3, ':');
+        let Some(count_str) = bits.next() else {
+            continue;
+        };
+        let Some(period) = bits.next() else {
+            continue;
+        };
+        let per_member = matches!(bits.next(), Some("m"));
+        let count: i32 = count_str.parse().unwrap_or(0);
+        if count > 0 && ["day", "week", "month", "year"].contains(&period) {
+            let limit_id = uuid::Uuid::new_v4().to_string();
+            let _ = sqlx::query(
+                "INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(&limit_id)
+            .bind(event_type_id)
+            .bind(count)
+            .bind(period)
+            .bind(per_member as i32)
+            .execute(pool)
+            .await;
         }
     }
 }
@@ -10304,14 +10430,18 @@ fn frequency_period_range(dt: NaiveDateTime, period: &str) -> (NaiveDateTime, Na
     }
 }
 
-/// Check if booking at the given datetime would exceed any frequency limit for the event type.
+/// Check if a booking at the given datetime would exceed any frequency limit
+/// configured on the event type. `assigned_user_id` is the team member the
+/// booking would land on — required for per-member caps; ignored by
+/// event-type-wide caps. Pass `None` for personal event types (no assignee).
 async fn would_exceed_frequency_limit(
     pool: &SqlitePool,
     event_type_id: &str,
     proposed_start: NaiveDateTime,
+    assigned_user_id: Option<&str>,
 ) -> bool {
-    let limits: Vec<(i32, String)> = sqlx::query_as(
-        "SELECT max_bookings, period FROM booking_frequency_limits WHERE event_type_id = ?",
+    let limits: Vec<(i32, String, i32)> = sqlx::query_as(
+        "SELECT max_bookings, period, per_member FROM booking_frequency_limits WHERE event_type_id = ?",
     )
     .bind(event_type_id)
     .fetch_all(pool)
@@ -10322,19 +10452,46 @@ async fn would_exceed_frequency_limit(
         return false;
     }
 
-    for (max_bookings, period) in &limits {
+    for (max_bookings, period, per_member) in &limits {
         let (range_start, range_end) = frequency_period_range(proposed_start, period);
         let range_start_str = range_start.format("%Y-%m-%dT%H:%M:%S").to_string();
         let range_end_str = range_end.format("%Y-%m-%dT%H:%M:%S").to_string();
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM bookings WHERE event_type_id = ? AND status IN ('confirmed', 'pending') AND start_at >= ? AND start_at < ?",
-        )
-        .bind(event_type_id)
-        .bind(&range_start_str)
-        .bind(&range_end_str)
-        .fetch_one(pool)
-        .await
-        .unwrap_or((0,));
+
+        let count: (i64,) = if *per_member != 0 {
+            // A per-member cap on a personal event type (no assignee) is
+            // meaningless — treat it as event-type-wide for those cases.
+            match assigned_user_id {
+                Some(uid) => sqlx::query_as(
+                    "SELECT COUNT(*) FROM bookings WHERE event_type_id = ? AND assigned_user_id = ? AND status IN ('confirmed', 'pending') AND start_at >= ? AND start_at < ?",
+                )
+                .bind(event_type_id)
+                .bind(uid)
+                .bind(&range_start_str)
+                .bind(&range_end_str)
+                .fetch_one(pool)
+                .await
+                .unwrap_or((0,)),
+                None => sqlx::query_as(
+                    "SELECT COUNT(*) FROM bookings WHERE event_type_id = ? AND status IN ('confirmed', 'pending') AND start_at >= ? AND start_at < ?",
+                )
+                .bind(event_type_id)
+                .bind(&range_start_str)
+                .bind(&range_end_str)
+                .fetch_one(pool)
+                .await
+                .unwrap_or((0,)),
+            }
+        } else {
+            sqlx::query_as(
+                "SELECT COUNT(*) FROM bookings WHERE event_type_id = ? AND status IN ('confirmed', 'pending') AND start_at >= ? AND start_at < ?",
+            )
+            .bind(event_type_id)
+            .bind(&range_start_str)
+            .bind(&range_end_str)
+            .fetch_one(pool)
+            .await
+            .unwrap_or((0,))
+        };
 
         if count.0 >= *max_bookings as i64 {
             return true;
@@ -11420,8 +11577,9 @@ async fn handle_booking(
         return Html("This slot is no longer available.".to_string()).into_response();
     }
 
-    // Check booking frequency limits
-    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start).await {
+    // Check booking frequency limits. Personal event-type flows don't have a
+    // team assignee, so per-member caps degrade to event-type-wide here.
+    if would_exceed_frequency_limit(&state.pool, &et_id, slot_start, None).await {
         let _ = tx.rollback().await;
         return render_booking_action_error(
             &state,
@@ -16111,6 +16269,381 @@ mod tests {
             16,
             "Year cap not reached → Tuesday must stay visible"
         );
+    }
+
+    /// Attach the seeded event type to a team and add two team members
+    /// (alice, bob). Returns their user ids.
+    async fn seed_team_for_event_type(pool: &SqlitePool, et_id: &str) -> (String, String) {
+        let team_id = uuid::Uuid::new_v4().to_string();
+        let alice = uuid::Uuid::new_v4().to_string();
+        let bob = uuid::Uuid::new_v4().to_string();
+
+        sqlx::query(
+            "INSERT INTO teams (id, name, slug, visibility) VALUES (?, 'Team', 'team', 'public')",
+        )
+        .bind(&team_id)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE event_types SET team_id = ? WHERE id = ?")
+            .bind(&team_id)
+            .bind(et_id)
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO users (id, email, name, role, auth_provider, username, enabled) VALUES (?, 'alice@example.com', 'Alice', 'user', 'local', 'alice', 1)")
+            .bind(&alice).execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO users (id, email, name, role, auth_provider, username, enabled) VALUES (?, 'bob@example.com', 'Bob', 'user', 'local', 'bob', 1)")
+            .bind(&bob).execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO team_members (team_id, user_id, role, source) VALUES (?, ?, 'member', 'direct')")
+            .bind(&team_id).bind(&alice).execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO team_members (team_id, user_id, role, source) VALUES (?, ?, 'member', 'direct')")
+            .bind(&team_id).bind(&bob).execute(pool).await.unwrap();
+
+        (alice, bob)
+    }
+
+    async fn insert_booking(
+        pool: &SqlitePool,
+        et_id: &str,
+        assigned_user_id: Option<&str>,
+        start: NaiveDateTime,
+        status: &str,
+    ) {
+        let end = start + Duration::minutes(30);
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token, assigned_user_id) VALUES (?, ?, ?, 'G', 'g@e.com', 'UTC', ?, ?, ?, ?, ?, ?)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(et_id)
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(start.format("%Y-%m-%dT%H:%M:%S").to_string())
+            .bind(end.format("%Y-%m-%dT%H:%M:%S").to_string())
+            .bind(status)
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(assigned_user_id)
+            .execute(pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn would_exceed_frequency_limit_per_member_blocks_only_named_assignee() {
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+        let (alice, bob) = seed_team_for_event_type(&pool, &et_id).await;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, 1, 'day', 1)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+
+        let booked_day = NaiveDate::from_ymd_opt(2026, 3, 16).unwrap();
+        let booked_start = booked_day.and_hms_opt(10, 0, 0).unwrap();
+        insert_booking(&pool, &et_id, Some(&alice), booked_start, "confirmed").await;
+
+        let proposed = booked_day.and_hms_opt(14, 0, 0).unwrap();
+        assert!(
+            would_exceed_frequency_limit(&pool, &et_id, proposed, Some(&alice)).await,
+            "Alice already has one booking that day under 1/day per-member"
+        );
+        assert!(
+            !would_exceed_frequency_limit(&pool, &et_id, proposed, Some(&bob)).await,
+            "Bob has zero bookings; per-member cap should not block him"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_frequency_limit_filter_per_member_keeps_slots_when_one_member_free() {
+        // 1/day per-member, 2 team members, 1 booking on Monday assigned to
+        // Alice → Monday must still show slots because Bob has headroom.
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+        let (alice, _bob) = seed_team_for_event_type(&pool, &et_id).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, 1, 'day', 1)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+        insert_booking(
+            &pool,
+            &et_id,
+            Some(&alice),
+            next_monday.and_hms_opt(10, 0, 0).unwrap(),
+            "confirmed",
+        )
+        .await;
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            1,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let monday_date = next_monday.format("%Y-%m-%d").to_string();
+        let monday = slot_days
+            .iter()
+            .find(|d| d.date == monday_date)
+            .expect("Monday should be present");
+        assert_eq!(
+            monday.slots.len(),
+            16,
+            "Per-member cap consumed by Alice must not hide slots while Bob is free"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_frequency_limit_filter_per_member_drops_slots_when_all_members_capped() {
+        // 1/day per-member, 2 team members, both already booked on Monday →
+        // Monday must show no slots.
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+        let (alice, bob) = seed_team_for_event_type(&pool, &et_id).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, 1, 'day', 1)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+        insert_booking(
+            &pool,
+            &et_id,
+            Some(&alice),
+            next_monday.and_hms_opt(10, 0, 0).unwrap(),
+            "confirmed",
+        )
+        .await;
+        insert_booking(
+            &pool,
+            &et_id,
+            Some(&bob),
+            next_monday.and_hms_opt(11, 0, 0).unwrap(),
+            "confirmed",
+        )
+        .await;
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            1,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let monday_date = next_monday.format("%Y-%m-%d").to_string();
+        let monday = slot_days.iter().find(|d| d.date == monday_date);
+        assert!(
+            monday.map(|d| d.slots.is_empty()).unwrap_or(true),
+            "Every team member at cap → Monday must be empty, got {:?}",
+            monday.map(|d| d.slots.len())
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_frequency_limit_filter_per_member_on_personal_event_type_degrades_to_wide() {
+        // Personal event type (no team) with a per_member flag set. With no
+        // team members to scope by, the cap should behave event-type-wide so
+        // a single booking still hides the day.
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, 1, 'day', 1)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+        insert_booking(
+            &pool,
+            &et_id,
+            None,
+            next_monday.and_hms_opt(10, 0, 0).unwrap(),
+            "confirmed",
+        )
+        .await;
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            1,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let monday_date = next_monday.format("%Y-%m-%d").to_string();
+        let monday = slot_days.iter().find(|d| d.date == monday_date);
+        assert!(
+            monday.map(|d| d.slots.is_empty()).unwrap_or(true),
+            "Per-member flag on a personal event type must still cap the day"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_frequency_limit_filter_mixed_per_member_and_wide_fire_independently() {
+        // Two limits on the same team event type:
+        //   - 1/day per-member
+        //   - 3/week event-type-wide
+        //
+        // Bookings span two consecutive weeks:
+        //   Week 1: three bookings by Alice on Mon/Tue/Wed → wide week count
+        //           hits its cap (3/3).
+        //   Week 2: one booking each by Alice and Bob on Monday → both
+        //           per-member day caps fill, wide week count is 2/3 (lax).
+        //
+        // Expectations:
+        //   - Every weekday in week 1 must be hidden — wide cap dominates,
+        //     even Thu/Fri where per-member alone would still allow bookings.
+        //   - Week 2 Monday must be hidden by the per-member rule (both
+        //     members at cap) while the wide rule still has headroom.
+        //   - Week 2 Tue-Fri must be visible — neither rule fires.
+        //
+        // If a future change ever conflates the two rule paths, this test
+        // will fail in a specific weekday rather than silently allow or
+        // deny everything.
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+        let (alice, bob) = seed_team_for_event_type(&pool, &et_id).await;
+
+        let now = Utc::now().with_timezone(&Tz::UTC).naive_local();
+        let mut next_monday = now.date() + Duration::days(1);
+        while next_monday.weekday() != chrono::Weekday::Mon {
+            next_monday += Duration::days(1);
+        }
+        let days_to_monday = (next_monday - now.date()).num_days() as i32;
+
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, 1, 'day', 1)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO booking_frequency_limits (id, event_type_id, max_bookings, period, per_member) VALUES (?, ?, 3, 'week', 0)")
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&et_id)
+            .execute(&pool).await.unwrap();
+
+        // Week 1: three Alice bookings consume the wide week cap.
+        for offset in 0..3 {
+            insert_booking(
+                &pool,
+                &et_id,
+                Some(&alice),
+                (next_monday + Duration::days(offset))
+                    .and_hms_opt(10, 0, 0)
+                    .unwrap(),
+                "confirmed",
+            )
+            .await;
+        }
+
+        // Week 2 Monday: both members booked, capping per-member.
+        let week2_monday = next_monday + Duration::days(7);
+        insert_booking(
+            &pool,
+            &et_id,
+            Some(&alice),
+            week2_monday.and_hms_opt(10, 0, 0).unwrap(),
+            "confirmed",
+        )
+        .await;
+        insert_booking(
+            &pool,
+            &et_id,
+            Some(&bob),
+            week2_monday.and_hms_opt(11, 0, 0).unwrap(),
+            "confirmed",
+        )
+        .await;
+
+        let slot_days = compute_slots(
+            &pool,
+            &et_id,
+            30,
+            0,
+            0,
+            0,
+            days_to_monday,
+            14,
+            Tz::UTC,
+            Tz::UTC,
+            BusySource::Individual(vec![]),
+        )
+        .await;
+
+        let find_day = |d: NaiveDate| -> Option<&SlotDay> {
+            let key = d.format("%Y-%m-%d").to_string();
+            slot_days.iter().find(|x| x.date == key)
+        };
+
+        // Week 1 Mon-Fri: every weekday hidden because the wide cap is hit.
+        for offset in 0..5 {
+            let d = next_monday + Duration::days(offset);
+            let day = find_day(d);
+            assert!(
+                day.map(|x| x.slots.is_empty()).unwrap_or(true),
+                "Week 1 {} should be hidden by the 3/week wide cap; got {:?}",
+                d,
+                day.map(|x| x.slots.len())
+            );
+        }
+
+        // Week 2 Mon: per-member dominates — wide is lax (2/3) but both
+        // members are at their per-day cap.
+        let w2_mon = find_day(week2_monday);
+        assert!(
+            w2_mon.map(|x| x.slots.is_empty()).unwrap_or(true),
+            "Week 2 Monday should be hidden by per-member rule; got {:?}",
+            w2_mon.map(|x| x.slots.len())
+        );
+
+        // Week 2 Tue-Fri: neither rule fires, full availability.
+        for offset in 1..5 {
+            let d = week2_monday + Duration::days(offset);
+            let day = find_day(d).expect("Week 2 weekday should be present");
+            assert_eq!(
+                day.slots.len(),
+                16,
+                "Week 2 {} should be free; got {} slots",
+                d,
+                day.slots.len()
+            );
+        }
     }
 
     #[tokio::test]

--- a/templates/event_type_form.html
+++ b/templates/event_type_form.html
@@ -1257,23 +1257,50 @@
       addBtn.style.display = used >= periods.length ? 'none' : '';
     }
 
+    // Per-member checkbox only makes sense on team event types. Mirrors the
+    // isTeam detection used by the scheduling-mode block below.
+    function isTeamSelected() {
+      var sel = document.getElementById('team_id');
+      if (sel) return !!sel.value;
+      return {{ is_group is defined and is_group and "true" or "false" }};
+    }
+
     function serialize() {
       if (!toggle.checked) { hidden.value = ''; return; }
       const rows = list.querySelectorAll('[data-freq-row]');
       const parts = [];
+      const team = isTeamSelected();
       rows.forEach(function(row) {
         const count = parseInt(row.querySelector('input[type=number]').value, 10) || 0;
         const period = row.querySelector('select').value;
-        if (count > 0) parts.push(count + ':' + period);
+        const perMember = team && row.querySelector('[data-per-member]').checked;
+        if (count > 0) {
+          parts.push(count + ':' + period + (perMember ? ':m' : ''));
+        }
       });
       hidden.value = parts.join(',');
       updateAddBtn();
     }
 
-    function createRow(count, period) {
+    function applyPerMemberVisibility() {
+      const team = isTeamSelected();
+      list.querySelectorAll('[data-per-member-wrap]').forEach(function(el) {
+        el.style.display = team ? '' : 'none';
+      });
+      if (!team) {
+        // Drop any stale per-member state so we don't quietly save it as a
+        // hidden flag on a personal event type.
+        list.querySelectorAll('[data-per-member]').forEach(function(cb) {
+          cb.checked = false;
+        });
+      }
+      serialize();
+    }
+
+    function createRow(count, period, perMember) {
       const row = document.createElement('div');
       row.setAttribute('data-freq-row', '1');
-      row.style.cssText = 'display: flex; align-items: center; gap: 0.5rem;';
+      row.style.cssText = 'display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;';
 
       const input = document.createElement('input');
       input.type = 'number';
@@ -1294,17 +1321,30 @@
       });
       select.addEventListener('change', serialize);
 
+      const memberWrap = document.createElement('label');
+      memberWrap.setAttribute('data-per-member-wrap', '1');
+      memberWrap.style.cssText = 'display: ' + (isTeamSelected() ? 'inline-flex' : 'none') + '; align-items: center; gap: 0.375rem; font-size: 0.85rem; color: var(--text-muted); cursor: pointer;';
+      const memberCheck = document.createElement('input');
+      memberCheck.type = 'checkbox';
+      memberCheck.setAttribute('data-per-member', '1');
+      memberCheck.checked = !!perMember;
+      memberCheck.style.cssText = 'accent-color: var(--accent); width: 0.95rem; height: 0.95rem;';
+      memberCheck.addEventListener('change', serialize);
+      memberWrap.appendChild(memberCheck);
+      memberWrap.appendChild(document.createTextNode(' Per team member'));
+
       const del = document.createElement('button');
       del.type = 'button';
       del.textContent = '\u{1F5D1}';
       del.title = 'Remove limit';
-      del.style.cssText = 'padding: 0.375rem 0.5rem; border: none; background: none; cursor: pointer; font-size: 1rem; color: var(--text-muted); opacity: 0.6; transition: opacity 0.15s;';
+      del.style.cssText = 'padding: 0.375rem 0.5rem; border: none; background: none; cursor: pointer; font-size: 1rem; color: var(--text-muted); opacity: 0.6; transition: opacity 0.15s; margin-left: auto;';
       del.addEventListener('mouseenter', function() { del.style.opacity = '1'; });
       del.addEventListener('mouseleave', function() { del.style.opacity = '0.6'; });
       del.addEventListener('click', function() { row.remove(); serialize(); updateAddBtn(); });
 
       row.appendChild(input);
       row.appendChild(select);
+      row.appendChild(memberWrap);
       row.appendChild(del);
       list.appendChild(row);
     }
@@ -1316,7 +1356,10 @@
       container.style.display = 'block';
       saved.split(',').forEach(function(part) {
         const s = part.split(':');
-        if (s.length === 2) createRow(parseInt(s[0], 10), s[1]);
+        if (s.length >= 2) {
+          const perMember = s.length >= 3 && s[2] === 'm';
+          createRow(parseInt(s[0], 10), s[1], perMember);
+        }
       });
       updateAddBtn();
     } else {
@@ -1332,7 +1375,7 @@
       updateToggleStyle();
       if (toggle.checked) {
         container.style.display = 'block';
-        if (list.children.length === 0) createRow(1, 'day');
+        if (list.children.length === 0) createRow(1, 'day', false);
         serialize();
       } else {
         container.style.display = 'none';
@@ -1347,9 +1390,16 @@
       list.querySelectorAll('select').forEach(function(s) { used.push(s.value); });
       var next = periods.find(function(p) { return used.indexOf(p) === -1; });
       if (!next) return;
-      createRow(1, next);
+      createRow(1, next, false);
       serialize();
     });
+
+    // Re-evaluate per-member visibility if the user switches team during
+    // creation. On edit forms there's no team selector, so this is a no-op.
+    var teamSelEl = document.getElementById('team_id');
+    if (teamSelEl) {
+      teamSelEl.addEventListener('change', applyPerMemberVisibility);
+    }
   })();
 
   // Auto-generate slug from title


### PR DESCRIPTION
This PR fixes a generic error sending emails, eg.:

```sh
calrs config smtp-test calrs@example.com
… Sending test email to calrs@example.com…
Error: Invalid input
```

The handling of the `from` mailbox is refactorized in all functions.