### PR TITLE
feat: add 'config dump' CLI command

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -305,6 +305,9 @@ pub async fn delete_user(
 
 // --- Auth config helpers ---
 
+// Uses SELECT * intentionally: oidc_client_secret is encrypted at rest (AES-256-GCM)
+// and encrypted in memory. Accidental serialization is prevented by #[serde(skip)]
+// on the AuthConfig.oidc_client_secret field.
 pub async fn get_auth_config(pool: &SqlitePool) -> Result<AuthConfig> {
     let config =
         sqlx::query_as::<_, AuthConfig>("SELECT * FROM auth_config WHERE id = 'singleton'")

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
 use colored::Colorize;
 use sqlx::SqlitePool;
@@ -42,6 +42,12 @@ pub enum ConfigCommands {
         #[arg(long)]
         allowed_domains: Option<String>,
     },
+    /// Dump all configuration as JSON
+    Dump {
+        /// Pretty-print the JSON output
+        #[arg(long)]
+        pretty: bool,
+    },
     /// Configure OIDC (OpenID Connect) for SSO login
     Oidc {
         /// OIDC issuer URL (e.g. https://keycloak.example.com/realms/myrealm)
@@ -60,6 +66,207 @@ pub enum ConfigCommands {
         #[arg(long)]
         auto_register: Option<bool>,
     },
+}
+
+// ── Dump-specific structs (no secret fields) ──
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct AuthConfigDump {
+    registration_enabled: bool,
+    allowed_email_domains: Option<String>,
+    oidc_enabled: bool,
+    oidc_issuer_url: Option<String>,
+    oidc_client_id: Option<String>,
+    oidc_auto_register: bool,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct SmtpConfigDump {
+    id: String,
+    host: String,
+    port: i32,
+    username: String,
+    from_email: String,
+    from_name: Option<String>,
+    enabled: bool,
+}
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct UserDump {
+    id: String,
+    email: String,
+    name: String,
+    timezone: String,
+    role: String,
+    auth_provider: String,
+    oidc_subject: Option<String>,
+    enabled: bool,
+    created_at: String,
+    username: Option<String>,
+    booking_email: Option<String>,
+    title: Option<String>,
+    bio: Option<String>,
+    allow_dynamic_group: bool,
+    language: Option<String>,
+}
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct CaldavSourceDump {
+    id: String,
+    account_id: String,
+    name: String,
+    url: String,
+    username: String,
+    last_synced: Option<String>,
+    sync_token: Option<String>,
+    enabled: bool,
+    created_at: String,
+}
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct EventTypeDump {
+    id: String,
+    account_id: String,
+    slug: String,
+    title: String,
+    duration_min: i32,
+    location_type: String,
+    location_value: Option<String>,
+    buffer_before: i32,
+    buffer_after: i32,
+    min_notice_min: i32,
+    enabled: bool,
+    requires_confirmation: bool,
+    reminder_minutes: Option<i32>,
+    max_additional_guests: Option<i32>,
+    scheduling_mode: String,
+    first_slot_only: bool,
+    default_calendar_view: String,
+    visibility: String,
+    created_at: String,
+    description: Option<String>,
+}
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct TeamDump {
+    id: String,
+    name: String,
+    slug: Option<String>,
+    description: Option<String>,
+    avatar_path: Option<String>,
+    visibility: String,
+    created_at: String,
+}
+
+#[derive(serde::Serialize, sqlx::FromRow)]
+#[serde(rename_all = "snake_case")]
+struct GroupDump {
+    id: String,
+    name: String,
+    source: String,
+    oidc_id: Option<String>,
+    created_at: String,
+    slug: Option<String>,
+    description: Option<String>,
+    avatar_path: Option<String>,
+}
+
+/// Build the full dump output as a JSON value, querying each config section.
+async fn build_dump_output(pool: &SqlitePool) -> Result<serde_json::Value> {
+    // Auth config — SELECT only non-secret columns (omit oidc_client_secret)
+    let auth_json = sqlx::query_as::<_, AuthConfigDump>(
+        "SELECT registration_enabled, allowed_email_domains, oidc_enabled, \
+         oidc_issuer_url, oidc_client_id, oidc_auto_register, created_at, updated_at \
+         FROM auth_config WHERE id = 'singleton'",
+    )
+    .fetch_one(pool)
+    .await?;
+    let auth_json = serde_json::to_value(&auth_json)?;
+
+    // SMTP config — skip password_enc (secret)
+    let smtp_json: serde_json::Value =
+        match sqlx::query_as::<_, SmtpConfigDump>(
+            "SELECT id, host, port, username, from_email, from_name, enabled \
+             FROM smtp_config LIMIT 1",
+        )
+        .fetch_optional(pool)
+        .await?
+        {
+            Some(row) => serde_json::to_value(&row)?,
+            None => serde_json::Value::Null,
+        };
+
+    // Users — only enabled users; skip password_hash (secret)
+    let users: Vec<UserDump> = sqlx::query_as::<_, UserDump>(
+        "SELECT id, email, name, timezone, role, auth_provider, \
+         oidc_subject, enabled, created_at, username, booking_email, \
+         title, bio, allow_dynamic_group, language \
+         FROM users WHERE enabled = 1 ORDER BY email",
+    )
+    .fetch_all(pool)
+    .await?;
+    let users_json = serde_json::to_value(&users)?;
+
+    // CalDAV sources — skip password_enc (secret)
+    let caldav_sources: Vec<CaldavSourceDump> = sqlx::query_as::<_, CaldavSourceDump>(
+        "SELECT id, account_id, name, url, username, \
+         last_synced, sync_token, enabled, created_at \
+         FROM caldav_sources ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await?;
+    let caldav_sources_json = serde_json::to_value(&caldav_sources)?;
+
+    // Event types — selected config fields, no operational data
+    let event_types: Vec<EventTypeDump> = sqlx::query_as::<_, EventTypeDump>(
+        "SELECT id, account_id, slug, title, duration_min, location_type, \
+         location_value, buffer_before, buffer_after, min_notice_min, enabled, \
+         requires_confirmation, reminder_minutes, max_additional_guests, \
+         scheduling_mode, first_slot_only, default_calendar_view, visibility, \
+         created_at, description \
+         FROM event_types ORDER BY title",
+    )
+    .fetch_all(pool)
+    .await?;
+    let event_types_json = serde_json::to_value(&event_types)?;
+
+    // Teams
+    let teams: Vec<TeamDump> = sqlx::query_as::<_, TeamDump>(
+        "SELECT id, name, slug, description, avatar_path, \
+         visibility, created_at \
+         FROM teams ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await?;
+    let teams_json = serde_json::to_value(&teams)?;
+
+    // Groups (legacy — kept for OIDC identity sync)
+    let groups: Vec<GroupDump> = sqlx::query_as::<_, GroupDump>(
+        "SELECT id, name, source, oidc_id, created_at, \
+         slug, description, avatar_path \
+         FROM groups ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await?;
+    let groups_json = serde_json::to_value(&groups)?;
+
+    Ok(serde_json::json!({
+        "auth": auth_json,
+        "smtp": smtp_json,
+        "users": users_json,
+        "caldav_sources": caldav_sources_json,
+        "event_types": event_types_json,
+        "teams": teams_json,
+        "groups": groups_json,
+    }))
 }
 
 pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Result<()> {
@@ -262,6 +469,16 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                     }
                 }
             }
+        }
+        ConfigCommands::Dump { pretty } => {
+            let output = build_dump_output(pool).await?;
+            let json = if pretty {
+                serde_json::to_string_pretty(&output)
+            } else {
+                serde_json::to_string(&output)
+            }
+            .context("Failed to serialize dump output")?;
+            println!("{json}");
         }
         ConfigCommands::Oidc {
             issuer_url,
@@ -575,5 +792,182 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn config_dump_default() {
+        let pool = setup_db().await;
+        let output = build_dump_output(&pool).await.unwrap();
+        assert!(output["auth"]["registration_enabled"].as_bool().unwrap());
+        assert!(output["smtp"].is_null());
+        assert!(output["users"].as_array().unwrap().is_empty());
+        assert!(output["caldav_sources"].as_array().unwrap().is_empty());
+        assert!(output["event_types"].as_array().unwrap().is_empty());
+        assert!(output["teams"].as_array().unwrap().is_empty());
+        assert!(output["groups"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn config_dump_pretty() {
+        let pool = setup_db().await;
+        let key = [0u8; 32];
+        let result = run(&pool, &key, ConfigCommands::Dump { pretty: true }).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn config_dump_with_smtp() {
+        let pool = setup_db().await;
+
+        let smtp_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO smtp_config (id, host, port, username, password_enc, from_email, from_name, enabled) \
+             VALUES (?, 'smtp.test.com', 587, 'user', 'enc', 'noreply@test.com', 'Test', 1)",
+        )
+        .bind(&smtp_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let output = build_dump_output(&pool).await.unwrap();
+        let smtp = output["smtp"].as_object().unwrap();
+        assert_eq!(smtp["host"], "smtp.test.com");
+        assert_eq!(smtp["port"], 587);
+        assert_eq!(smtp["username"], "user");
+        assert_eq!(smtp["from_email"], "noreply@test.com");
+        assert_eq!(smtp["from_name"], "Test");
+        assert!(smtp["enabled"].as_bool().unwrap());
+        // Verify secret is NOT in output
+        assert!(!smtp.contains_key("password_enc"));
+    }
+
+    #[tokio::test]
+    async fn config_dump_with_users_and_event_types() {
+        let pool = setup_db().await;
+
+        // Insert a user
+        let user_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO users (id, email, name, password_hash, role, auth_provider) \
+             VALUES (?, 'alice@test.com', 'Alice', 'hash', 'admin', 'local')",
+        )
+        .bind(&user_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Insert an account (required by event_types FK)
+        let account_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO accounts (id, name, email) VALUES (?, 'Alice', 'alice@test.com')",
+        )
+        .bind(&account_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Insert an event type
+        let et_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO event_types (id, account_id, slug, title, duration_min, visibility) \
+             VALUES (?, ?, 'intro', 'Intro Call', 30, 'public')",
+        )
+        .bind(&et_id)
+        .bind(&account_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Insert a team
+        let team_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO teams (id, name, slug, visibility) VALUES (?, 'My Team', 'my-team', 'public')",
+        )
+        .bind(&team_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Insert a group
+        let group_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO groups (id, name, source) VALUES (?, 'Engineering', 'local')",
+        )
+        .bind(&group_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let output = build_dump_output(&pool).await.unwrap();
+        assert_eq!(output["users"].as_array().unwrap().len(), 1);
+        assert_eq!(output["users"][0]["email"], "alice@test.com");
+        assert!(!output["users"][0]
+            .as_object()
+            .unwrap()
+            .contains_key("password_hash"));
+        assert_eq!(output["event_types"].as_array().unwrap().len(), 1);
+        assert_eq!(output["event_types"][0]["title"], "Intro Call");
+        assert_eq!(output["teams"].as_array().unwrap().len(), 1);
+        assert_eq!(output["groups"].as_array().unwrap().len(), 1);
+
+        // Test with a disabled user — should not appear
+        let disabled_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO users (id, email, name, password_hash, role, auth_provider, enabled) \
+             VALUES (?, 'bob@test.com', 'Bob', 'hash', 'user', 'local', 0)",
+        )
+        .bind(&disabled_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let output = build_dump_output(&pool).await.unwrap();
+        assert_eq!(
+            output["users"].as_array().unwrap().len(),
+            1,
+            "disabled user should not appear"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_dump_caldav_no_secrets() {
+        let pool = setup_db().await;
+
+        let user_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO users (id, email, name, role, auth_provider, enabled) \
+             VALUES (?, 'test@test.com', 'Test', 'user', 'local', 1)",
+        )
+        .bind(&user_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let account_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO accounts (id, name, email, user_id) VALUES (?, 'Test', 'test@test.com', ?)",
+        )
+        .bind(&account_id)
+        .bind(&user_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let source_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO caldav_sources (id, account_id, name, url, username, password_enc) \
+             VALUES (?, ?, 'Test', 'https://caldav.test', 'user', 'secret-encrypted')",
+        )
+        .bind(&source_id)
+        .bind(&account_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let output = build_dump_output(&pool).await.unwrap();
+        let sources = output["caldav_sources"].as_array().unwrap();
+        assert_eq!(sources.len(), 1);
+        assert!(!sources[0]
+            .as_object()
+            .unwrap()
+            .contains_key("password_enc"));
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -52,6 +52,7 @@ pub struct AuthConfig {
     pub oidc_enabled: bool,
     pub oidc_issuer_url: Option<String>,
     pub oidc_client_id: Option<String>,
+    #[serde(skip)]
     pub oidc_client_secret: Option<String>,
     pub oidc_auto_register: bool,
 }


### PR DESCRIPTION
Add a `calrs config dump [--pretty]` subcommand that prints the configuration in JSON format, from the database: 
```bash
$ calrs config dump --data-dir . --pretty
{
  "auth": {
    "allowed_email_domains": null,
    "created_at": "2026-04-29 14:52:25",
    "oidc_auto_register": true,
    "oidc_client_id": "calrs",
    "oidc_enabled": false,
    "oidc_issuer_url": "https://keycloak.example.com/realms/your-realm",
    "registration_enabled": true,
    "updated_at": "2026-05-15 10:26:09"
  },
  "caldav_sources": [],
  "event_types": [],
  "groups": [],
  "smtp": null,
  "teams": [],
  "users": [
    {
      "allow_dynamic_group": true,
      "auth_provider": "local",
      "bio": null,
      "booking_email": null,
      "created_at": "2026-04-29 19:12:39",
      "email": "mvalois@example.com",
      "enabled": true,
      "id": "513a192d-4b6a-4afe-8164-9f2f4a01d2c0",
      "language": null,
      "name": "MV",
      "oidc_subject": null,
      "role": "admin",
      "timezone": "Europe/Paris",
      "title": null,
      "username": "mvalois"
    }
  ]
}

```