### PR TITLE
fix(email): display host timezone in host-targeted emails

### DIFF
--- a/src/commands/booking.rs
+++ b/src/commands/booking.rs
@@ -235,15 +235,15 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
 
             // Send email notifications if SMTP is configured
             if let Some(smtp_config) = crate::email::load_smtp_config(pool, key).await? {
-                // Fetch host info
-                let host: Option<(String, String)> = sqlx::query_as(
-                    "SELECT u.name, COALESCE(u.booking_email, u.email) FROM users u JOIN accounts a ON a.user_id = u.id WHERE a.id = (SELECT account_id FROM event_types WHERE id = ?)",
+                // Fetch host info (name, booking email, timezone)
+                let host: Option<(String, String, Option<String>)> = sqlx::query_as(
+                    "SELECT u.name, COALESCE(u.booking_email, u.email), u.timezone FROM users u JOIN accounts a ON a.user_id = u.id WHERE a.id = (SELECT account_id FROM event_types WHERE id = ?)",
                 )
                 .bind(&et_id)
                 .fetch_optional(pool)
                 .await?;
 
-                if let Some((host_name, host_email)) = host {
+                if let Some((host_name, host_email, host_timezone)) = host {
                     let details = crate::email::BookingDetails {
                         event_title: et_title.clone(),
                         date: date_str.clone(),
@@ -259,6 +259,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                         location: None,
                         reminder_minutes: None,
                         additional_attendees: vec![],
+                        host_timezone: host_timezone.unwrap_or_default(),
                         ..Default::default()
                     };
 
@@ -371,8 +372,8 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
 
                     // Send cancellation emails
                     if let Some(smtp_config) = crate::email::load_smtp_config(pool, key).await? {
-                        let host: Option<(String, String)> = sqlx::query_as(
-                            "SELECT u.name, COALESCE(u.booking_email, u.email) FROM users u
+                        let host: Option<(String, String, Option<String>)> = sqlx::query_as(
+                            "SELECT u.name, COALESCE(u.booking_email, u.email), u.timezone FROM users u
                              JOIN accounts a ON a.user_id = u.id
                              JOIN event_types et ON et.account_id = a.id
                              JOIN bookings b ON b.event_type_id = et.id
@@ -382,7 +383,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                         .fetch_optional(pool)
                         .await?;
 
-                        if let Some((host_name, host_email)) = host {
+                        if let Some((host_name, host_email, host_timezone)) = host {
                             let date = if start_at.len() >= 10 {
                                 &start_at[..10]
                             } else {
@@ -412,6 +413,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                                 uid,
                                 reason,
                                 cancelled_by_host: true,
+                                host_timezone: host_timezone.unwrap_or_default(),
                                 ..Default::default()
                             };
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -613,9 +613,10 @@ async fn cancel_orphaned_booking(
         String,
         String,
         Option<String>,
+        Option<String>,
     )> = sqlx::query_as(
         "SELECT b.id, b.guest_name, b.guest_email, COALESCE(b.guest_timezone, 'UTC'), b.start_at, b.end_at, b.uid,
-                et.title, u.name, COALESCE(u.booking_email, u.email), b.caldav_calendar_href
+                et.title, u.name, COALESCE(u.booking_email, u.email), b.caldav_calendar_href, u.timezone
          FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
@@ -646,6 +647,7 @@ async fn cancel_orphaned_booking(
         host_name,
         host_email,
         caldav_calendar_href,
+        host_timezone,
     ) = booking;
 
     // Confirm-before-cancel: if we have a client and a stored calendar href for
@@ -723,6 +725,7 @@ async fn cancel_orphaned_booking(
         uid: booking_uid,
         reason: Some("The calendar event was deleted by the host.".to_string()),
         cancelled_by_host: true,
+        host_timezone: host_timezone.unwrap_or_default(),
         ..Default::default()
     };
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -116,8 +116,9 @@ pub struct BookingDetails {
     /// Host's saved UI-language preference (from `users.language`).
     /// `None` falls back to English at send time.
     pub host_language: Option<String>,
-    /// Host's IANA timezone (from `users.timezone`). When set and different
-    /// from `guest_timezone`, host-targeted emails display the wall-clock time
+    /// Host's IANA timezone — the event type's tz when set (via `get_host_tz`),
+    /// otherwise the host user's tz. When set and different from
+    /// `guest_timezone`, host-targeted emails display the wall-clock time
     /// converted into this zone. Empty string falls back to guest-zone display.
     pub host_timezone: String,
 }
@@ -372,7 +373,7 @@ fn convert_time_between_tz(
 /// converted into the host's zone. Otherwise the original guest-zone values are
 /// kept. The returned `time_display` always includes a `(TZ)` suffix so the
 /// host can tell which zone they're looking at.
-fn host_time_display(
+pub(crate) fn host_time_display(
     date: &str,
     start_time: &str,
     end_time: &str,

--- a/src/email.rs
+++ b/src/email.rs
@@ -116,6 +116,10 @@ pub struct BookingDetails {
     /// Host's saved UI-language preference (from `users.language`).
     /// `None` falls back to English at send time.
     pub host_language: Option<String>,
+    /// Host's IANA timezone (from `users.timezone`). When set and different
+    /// from `guest_timezone`, host-targeted emails display the wall-clock time
+    /// converted into this zone. Empty string falls back to guest-zone display.
+    pub host_timezone: String,
 }
 
 #[derive(Default)]
@@ -134,6 +138,8 @@ pub struct CancellationDetails {
     pub cancelled_by_host: bool,
     pub guest_language: Option<String>,
     pub host_language: Option<String>,
+    /// Host's IANA timezone (from `users.timezone`). See `BookingDetails::host_timezone`.
+    pub host_timezone: String,
 }
 
 // --- HTML email template helpers ---
@@ -315,6 +321,90 @@ fn convert_to_utc(
         start_utc.format("%Y%m%dT%H%M%SZ").to_string(),
         end_utc.format("%Y%m%dT%H%M%SZ").to_string(),
     )
+}
+
+/// Convert a (date, start_time, end_time) tuple from `from_tz` into `to_tz`,
+/// returning the wall-clock equivalents.
+///
+/// Returns `(date, start_time, end_time)` formatted as `YYYY-MM-DD` / `HH:MM`.
+/// The date can roll over (e.g. LA 22:00 → Paris 07:00 next day), so the
+/// returned date may differ from the input. If either timezone fails to parse
+/// or the local time is invalid (DST gap), returns `None` and the caller
+/// should fall back to displaying the original values.
+fn convert_time_between_tz(
+    date: &str,
+    start_time: &str,
+    end_time: &str,
+    from_tz: &str,
+    to_tz: &str,
+) -> Option<(String, String, String)> {
+    use chrono::TimeZone;
+
+    let from: Tz = from_tz.parse().ok()?;
+    let to: Tz = to_tz.parse().ok()?;
+
+    let start_naive =
+        NaiveDateTime::parse_from_str(&format!("{} {}:00", date, start_time), "%Y-%m-%d %H:%M:%S")
+            .ok()?;
+    let end_naive =
+        NaiveDateTime::parse_from_str(&format!("{} {}:00", date, end_time), "%Y-%m-%d %H:%M:%S")
+            .ok()?;
+
+    let start_target = from
+        .from_local_datetime(&start_naive)
+        .earliest()?
+        .with_timezone(&to);
+    let end_target = from
+        .from_local_datetime(&end_naive)
+        .earliest()?
+        .with_timezone(&to);
+
+    Some((
+        start_target.format("%Y-%m-%d").to_string(),
+        start_target.format("%H:%M").to_string(),
+        end_target.format("%H:%M").to_string(),
+    ))
+}
+
+/// Build the date + time strings to display in a host-targeted email.
+///
+/// When `host_timezone` is set and differs from `guest_timezone`, the times are
+/// converted into the host's zone. Otherwise the original guest-zone values are
+/// kept. The returned `time_display` always includes a `(TZ)` suffix so the
+/// host can tell which zone they're looking at.
+fn host_time_display(
+    date: &str,
+    start_time: &str,
+    end_time: &str,
+    guest_timezone: &str,
+    host_timezone: &str,
+) -> (String, String) {
+    if !host_timezone.is_empty() && host_timezone != guest_timezone {
+        if let Some((host_date, host_start, host_end)) =
+            convert_time_between_tz(date, start_time, end_time, guest_timezone, host_timezone)
+        {
+            return (
+                host_date,
+                format!("{} \u{2013} {} ({})", host_start, host_end, host_timezone),
+            );
+        }
+    }
+
+    let tz_label = if !guest_timezone.is_empty() {
+        guest_timezone
+    } else if !host_timezone.is_empty() {
+        host_timezone
+    } else {
+        ""
+    };
+
+    let time_display = if tz_label.is_empty() {
+        format!("{} \u{2013} {}", start_time, end_time)
+    } else {
+        format!("{} \u{2013} {} ({})", start_time, end_time, tz_label)
+    };
+
+    (date.to_string(), time_display)
 }
 
 /// Generate an .ics VCALENDAR string for a booking
@@ -744,7 +834,13 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
 
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let (date_display, time_display) = host_time_display(
+        &details.date,
+        &details.start_time,
+        &details.end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
+    );
 
     let plain = format!(
         "New booking!\n\n\
@@ -756,7 +852,7 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
          A calendar invite is attached.\n\n\
          \u{2014} calrs",
         details.event_title,
-        details.date,
+        date_display,
         time_display,
         details.guest_name,
         details.guest_email,
@@ -779,7 +875,7 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
         },
         EmailRow {
             label: "Date".to_string(),
-            value: details.date.clone(),
+            value: date_display.clone(),
         },
         EmailRow {
             label: "Time".to_string(),
@@ -823,7 +919,7 @@ pub async fn send_host_notification(config: &SmtpConfig, details: &BookingDetail
         .to(to)
         .subject(format!(
             "New booking: {} \u{2014} {} ({})",
-            details.event_title, details.guest_name, details.date
+            details.event_title, details.guest_name, date_display
         ))
         .multipart(
             MultiPart::mixed()
@@ -842,7 +938,13 @@ pub async fn send_host_booking_confirmed(
 ) -> Result<()> {
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let (date_display, time_display) = host_time_display(
+        &details.date,
+        &details.start_time,
+        &details.end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
+    );
 
     let plain = format!(
         "Booking confirmed!\n\n\
@@ -854,7 +956,7 @@ pub async fn send_host_booking_confirmed(
          The event has been added to your calendar.\n\n\
          \u{2014} calrs",
         details.event_title,
-        details.date,
+        date_display,
         time_display,
         details.guest_name,
         details.guest_email,
@@ -872,7 +974,7 @@ pub async fn send_host_booking_confirmed(
         },
         EmailRow {
             label: "Date".to_string(),
-            value: details.date.clone(),
+            value: date_display.clone(),
         },
         EmailRow {
             label: "Time".to_string(),
@@ -905,7 +1007,7 @@ pub async fn send_host_booking_confirmed(
         .to(to)
         .subject(format!(
             "Confirmed: {} \u{2014} {} ({})",
-            details.event_title, details.guest_name, details.date
+            details.event_title, details.guest_name, date_display
         ))
         .multipart(body)?;
 
@@ -1033,7 +1135,13 @@ pub async fn send_guest_reminder(
 pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -> Result<()> {
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let (date_display, time_display) = host_time_display(
+        &details.date,
+        &details.start_time,
+        &details.end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
+    );
 
     let plain = format!(
         "Reminder: you have an upcoming booking.\n\n\
@@ -1044,7 +1152,7 @@ pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -
          {}\n\
          \u{2014} calrs",
         details.event_title,
-        details.date,
+        date_display,
         time_display,
         details.guest_name,
         details.guest_email,
@@ -1062,7 +1170,7 @@ pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -
         },
         EmailRow {
             label: "Date".to_string(),
-            value: details.date.clone(),
+            value: date_display.clone(),
         },
         EmailRow {
             label: "Time".to_string(),
@@ -1092,7 +1200,7 @@ pub async fn send_host_reminder(config: &SmtpConfig, details: &BookingDetails) -
         .to(to)
         .subject(format!(
             "Reminder: {} \u{2014} {} ({})",
-            details.event_title, details.guest_name, details.date
+            details.event_title, details.guest_name, date_display
         ))
         .multipart(body)?;
 
@@ -1109,7 +1217,14 @@ pub async fn send_guest_cancellation(
 
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let time_display = if details.guest_timezone.is_empty() {
+        format!("{} \u{2013} {}", details.start_time, details.end_time)
+    } else {
+        format!(
+            "{} \u{2013} {} ({})",
+            details.start_time, details.end_time, details.guest_timezone
+        )
+    };
 
     let greeting = ta(
         lang,
@@ -1232,7 +1347,13 @@ pub async fn send_host_cancellation(
 
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let (date_display, time_display) = host_time_display(
+        &details.date,
+        &details.start_time,
+        &details.end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
+    );
     let reason_text = details
         .reason
         .as_ref()
@@ -1249,7 +1370,7 @@ pub async fn send_host_cancellation(
          A calendar cancellation is attached.\n\n\
          \u{2014} calrs",
         details.event_title,
-        details.date,
+        date_display,
         time_display,
         details.guest_name,
         details.guest_email,
@@ -1263,7 +1384,7 @@ pub async fn send_host_cancellation(
         },
         EmailRow {
             label: "Date".to_string(),
-            value: details.date.clone(),
+            value: date_display.clone(),
         },
         EmailRow {
             label: "Time".to_string(),
@@ -1305,7 +1426,7 @@ pub async fn send_host_cancellation(
         .to(to)
         .subject(format!(
             "Cancelled: {} \u{2014} {} ({})",
-            details.event_title, details.guest_name, details.date
+            details.event_title, details.guest_name, date_display
         ))
         .multipart(
             MultiPart::mixed()
@@ -1442,7 +1563,13 @@ pub async fn send_host_approval_request(
 ) -> Result<()> {
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let (date_display, time_display) = host_time_display(
+        &details.date,
+        &details.start_time,
+        &details.end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
+    );
 
     let (approve_url, decline_url) = match (confirm_token, base_url) {
         (Some(token), Some(url)) => (
@@ -1475,7 +1602,7 @@ pub async fn send_host_approval_request(
          {}\n\n\
          \u{2014} calrs",
         details.event_title,
-        details.date,
+        date_display,
         time_display,
         details.guest_name,
         details.guest_email,
@@ -1499,7 +1626,7 @@ pub async fn send_host_approval_request(
         },
         EmailRow {
             label: "Date".to_string(),
-            value: details.date.clone(),
+            value: date_display.clone(),
         },
         EmailRow {
             label: "Time".to_string(),
@@ -1555,7 +1682,7 @@ pub async fn send_host_approval_request(
         .to(to)
         .subject(format!(
             "Action required: {} \u{2014} {} ({})",
-            details.event_title, details.guest_name, details.date
+            details.event_title, details.guest_name, date_display
         ))
         .multipart(body)?;
 
@@ -1569,7 +1696,14 @@ pub async fn send_guest_decline_notice(
 ) -> Result<()> {
     let to = format!("{} <{}>", details.guest_name, details.guest_email).parse()?;
 
-    let time_display = format!("{} \u{2013} {}", details.start_time, details.end_time);
+    let time_display = if details.guest_timezone.is_empty() {
+        format!("{} \u{2013} {}", details.start_time, details.end_time)
+    } else {
+        format!(
+            "{} \u{2013} {} ({})",
+            details.start_time, details.end_time, details.guest_timezone
+        )
+    };
     let reason_text = details
         .reason
         .as_ref()
@@ -1919,6 +2053,7 @@ async fn send_email(config: &SmtpConfig, email: Message) -> Result<()> {
 
 // --- Reschedule emails ---
 
+#[derive(Default)]
 pub struct RescheduleDetails {
     pub event_title: String,
     pub old_date: String,
@@ -1934,6 +2069,8 @@ pub struct RescheduleDetails {
     pub host_email: String,
     pub uid: String,
     pub location: Option<String>,
+    /// Host's IANA timezone (from `users.timezone`). See `BookingDetails::host_timezone`.
+    pub host_timezone: String,
 }
 
 /// Ask the guest to pick a new time (host-initiated reschedule).
@@ -2174,9 +2311,19 @@ pub async fn send_host_reschedule_request(
     confirm_token: Option<&str>,
     base_url: Option<&str>,
 ) -> Result<()> {
-    let new_time_display = format!(
-        "{} \u{2013} {}",
-        details.new_start_time, details.new_end_time
+    let (old_date_display, old_time_display) = host_time_display(
+        &details.old_date,
+        &details.old_start_time,
+        &details.old_end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
+    );
+    let (new_date_display, new_time_display) = host_time_display(
+        &details.new_date,
+        &details.new_start_time,
+        &details.new_end_time,
+        &details.guest_timezone,
+        &details.host_timezone,
     );
 
     let to = format!("{} <{}>", details.host_name, details.host_email).parse()?;
@@ -2205,7 +2352,7 @@ pub async fn send_host_reschedule_request(
     let plain = format!(
         "{} wants to reschedule their booking.\n\n\
          Event: {}\n\
-         Previous: {} at {} \u{2013} {}\n\
+         Previous: {} at {}\n\
          Requested: {} at {}\n\
          Guest: {} <{}>\n\
          {}\n\n\
@@ -2213,10 +2360,9 @@ pub async fn send_host_reschedule_request(
          \u{2014} calrs",
         details.guest_name,
         details.event_title,
-        details.old_date,
-        details.old_start_time,
-        details.old_end_time,
-        details.new_date,
+        old_date_display,
+        old_time_display,
+        new_date_display,
         new_time_display,
         details.guest_name,
         details.guest_email,
@@ -2235,14 +2381,11 @@ pub async fn send_host_reschedule_request(
         },
         EmailRow {
             label: "Previous".to_string(),
-            value: format!(
-                "{} at {} \u{2013} {}",
-                details.old_date, details.old_start_time, details.old_end_time
-            ),
+            value: format!("{} at {}", old_date_display, old_time_display),
         },
         EmailRow {
             label: "Requested".to_string(),
-            value: format!("{} at {}", details.new_date, new_time_display),
+            value: format!("{} at {}", new_date_display, new_time_display),
         },
         EmailRow {
             label: "Guest".to_string(),
@@ -3413,6 +3556,103 @@ mod tests {
         assert_eq!(end, "20260315T160000Z");
     }
 
+    // --- convert_time_between_tz / host_time_display tests ---
+
+    // Regression for issue #119: the host (Paris) was reading the time in the
+    // guest's wall-clock (LA), with no TZ label on cancellation emails. This
+    // verifies the LA→Paris conversion that makes the host email show 16:00
+    // Paris time when the guest booked 07:00 LA time.
+    #[test]
+    fn convert_time_between_tz_la_to_paris() {
+        let (date, start, end) = convert_time_between_tz(
+            "2026-05-26",
+            "07:00",
+            "07:30",
+            "America/Los_Angeles",
+            "Europe/Paris",
+        )
+        .expect("conversion should succeed for valid IANA names");
+        // May 26 is in PDT (UTC-7) and CEST (UTC+2), so LA 07:00 = Paris 16:00 same day.
+        assert_eq!(date, "2026-05-26");
+        assert_eq!(start, "16:00");
+        assert_eq!(end, "16:30");
+    }
+
+    // Late-evening LA booking crosses midnight into the next day in Paris.
+    #[test]
+    fn convert_time_between_tz_rolls_over_date() {
+        let (date, start, end) = convert_time_between_tz(
+            "2026-05-26",
+            "22:00",
+            "22:30",
+            "America/Los_Angeles",
+            "Europe/Paris",
+        )
+        .expect("conversion should succeed");
+        assert_eq!(date, "2026-05-27");
+        assert_eq!(start, "07:00");
+        assert_eq!(end, "07:30");
+    }
+
+    #[test]
+    fn convert_time_between_tz_invalid_zone_returns_none() {
+        assert!(convert_time_between_tz(
+            "2026-05-26",
+            "07:00",
+            "07:30",
+            "Not/A/Zone",
+            "Europe/Paris"
+        )
+        .is_none());
+        assert!(convert_time_between_tz(
+            "2026-05-26",
+            "07:00",
+            "07:30",
+            "America/Los_Angeles",
+            "Also/Bad"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn host_time_display_converts_to_host_tz() {
+        let (date, time_display) = host_time_display(
+            "2026-05-26",
+            "07:00",
+            "07:30",
+            "America/Los_Angeles",
+            "Europe/Paris",
+        );
+        assert_eq!(date, "2026-05-26");
+        assert_eq!(time_display, "16:00 \u{2013} 16:30 (Europe/Paris)");
+    }
+
+    // When host_timezone is empty (legacy callers / no users.timezone set),
+    // keep the original wall-clock and still surface *some* TZ label so the
+    // host can disambiguate. Fallback to guest_timezone.
+    #[test]
+    fn host_time_display_empty_host_tz_falls_back_to_guest_label() {
+        let (date, time_display) =
+            host_time_display("2026-05-26", "07:00", "07:30", "America/Los_Angeles", "");
+        assert_eq!(date, "2026-05-26");
+        assert_eq!(time_display, "07:00 \u{2013} 07:30 (America/Los_Angeles)");
+    }
+
+    // When both TZ values match, display the original time without conversion
+    // overhead, but still label it.
+    #[test]
+    fn host_time_display_same_tz_keeps_original_time() {
+        let (date, time_display) = host_time_display(
+            "2026-05-26",
+            "14:00",
+            "14:30",
+            "Europe/Paris",
+            "Europe/Paris",
+        );
+        assert_eq!(date, "2026-05-26");
+        assert_eq!(time_display, "14:00 \u{2013} 14:30 (Europe/Paris)");
+    }
+
     // --- ICS location field regression test ---
 
     #[test]
@@ -3620,6 +3860,7 @@ mod tests {
             host_email: "alice@example.com".to_string(),
             uid: "test-uid@calrs".to_string(),
             location: Some("https://meet.example.com/abc".to_string()),
+            ..Default::default()
         }
     }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -317,8 +317,11 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
         // - event type has reminder_minutes set (> 0)
         // - start_at minus reminder_minutes <= now
         // - start_at > now (don't remind for past bookings)
+        // `host_timezone` resolves like `get_host_tz`: prefer the explicit
+        // event-type tz, fall back to the host user's tz. NULL falls through
+        // to UTC at parse time.
         let due: Vec<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>, Option<String>, Option<String>)> = sqlx::query_as(
-            "SELECT b.id, b.guest_name, b.guest_email, b.guest_timezone, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), et.location_value, b.cancel_token, b.uid, b.language, u.language, u.timezone
+            "SELECT b.id, b.guest_name, b.guest_email, b.guest_timezone, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), et.location_value, b.cancel_token, b.uid, b.language, u.language, COALESCE(NULLIF(et.timezone, ''), u.timezone)
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -363,17 +366,24 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
             host_timezone,
         ) in &due
         {
-            let date = start_at.get(..10).unwrap_or(start_at).to_string();
-            let start_time = extract_time_24h(start_at);
-            let end_time = extract_time_24h(end_at);
+            // start_at/end_at are stored in the event-type tz (see #101). Convert
+            // to the guest's tz so `BookingDetails` carries guest-local wall-clock —
+            // matches the contract used by cancel/confirm handlers, and lets
+            // `host_time_display` convert back into the host's tz correctly for
+            // the host reminder.
+            let stored_tz_str = host_timezone.as_deref().unwrap_or("UTC");
+            let stored_tz = stored_tz_str.parse::<Tz>().unwrap_or(Tz::UTC);
+            let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+            let (date, start_time, end_time) =
+                booking_strings_in_guest_tz(start_at, end_at, stored_tz, guest_tz_parsed);
 
             let location = location_value.as_ref().filter(|v| !v.is_empty()).cloned();
 
             let details = crate::email::BookingDetails {
                 event_title: event_title.clone(),
-                date: date.clone(),
-                start_time: start_time.clone(),
-                end_time: end_time.clone(),
+                date,
+                start_time,
+                end_time,
                 guest_name: guest_name.clone(),
                 guest_email: guest_email.clone(),
                 guest_timezone: guest_timezone.clone(),
@@ -386,7 +396,7 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
                 additional_attendees: vec![],
                 guest_language: guest_language.clone(),
                 host_language: host_language.clone(),
-                host_timezone: host_timezone.clone().unwrap_or_default(),
+                host_timezone: stored_tz_str.to_string(),
             };
 
             let guest_cancel_url = cancel_token.as_ref().and_then(|t| {
@@ -14761,9 +14771,12 @@ async fn guest_reschedule_booking(
             .await
             .unwrap_or_default();
 
-    let old_date = old_start_at.get(..10).unwrap_or(&old_start_at).to_string();
-    let old_start_time = extract_time_24h(&old_start_at);
-    let old_end_time = extract_time_24h(&old_end_at);
+    // old_start_at/old_end_at are stored in the event-type tz. Convert into the
+    // guest's tz so `RescheduleDetails` carries guest-local wall-clock for
+    // both the OLD and NEW times — matches the contract used elsewhere and
+    // lets `host_time_display` correctly recover the host wall-clock.
+    let (old_date, old_start_time, old_end_time) =
+        booking_strings_in_guest_tz(&old_start_at, &old_end_at, host_tz, guest_tz);
 
     if needs_approval {
         // Guest-initiated reschedule on requires_confirmation event → pending.
@@ -15035,9 +15048,10 @@ async fn host_reschedule_booking(
         String,
         String,
         String,
+        String,
     )> = sqlx::query_as(
         "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at,
-                    et.title, COALESCE(b.guest_timezone, 'UTC')
+                    et.title, COALESCE(b.guest_timezone, 'UTC'), et.id
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -15049,7 +15063,7 @@ async fn host_reschedule_booking(
     .await
     .unwrap_or(None);
 
-    let (bid, _uid, guest_name, guest_email, start_at, end_at, event_title, guest_timezone) =
+    let (bid, _uid, guest_name, guest_email, start_at, end_at, event_title, guest_timezone, et_id) =
         match booking {
             Some(b) => b,
             None => return Redirect::to("/dashboard/bookings").into_response(),
@@ -15091,9 +15105,14 @@ async fn host_reschedule_booking(
                         .map(|base| format!("{}/booking/cancel/{}", base.trim_end_matches('/'), t))
                 });
 
-        let date = start_at.get(..10).unwrap_or(&start_at).to_string();
-        let start_time = extract_time_24h(&start_at);
-        let end_time = extract_time_24h(&end_at);
+        // start_at/end_at are stored in the event-type tz (see #101). Convert
+        // into the guest's tz before populating BookingDetails so the
+        // guest-facing "pick new time" email shows their wall-clock with their
+        // tz label.
+        let host_tz = get_host_tz(&state.pool, &et_id).await;
+        let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+        let (date, start_time, end_time) =
+            booking_strings_in_guest_tz(&start_at, &end_at, host_tz, guest_tz_parsed);
 
         let details = crate::email::BookingDetails {
             event_title,
@@ -15113,7 +15132,7 @@ async fn host_reschedule_booking(
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
-            host_timezone: user.timezone.clone(),
+            host_timezone: host_tz.name().to_string(),
             ..Default::default()
         };
 
@@ -22974,6 +22993,42 @@ mod tests {
             .and_hms_opt(10, 30, 0)
             .unwrap();
         assert_eq!(guest_to_host_local(dt, tz, tz), dt);
+    }
+
+    // End-to-end TZ pipeline used by background email paths (reminder loop,
+    // reschedule): `start_at` is stored in the event-type tz, must be converted
+    // to the guest tz to populate BookingDetails, and host_time_display must
+    // recover the host wall-clock for host-targeted emails. Regression for the
+    // reviewer-caught bug where the reminder loop short-circuited the first
+    // conversion and the host email displayed times in the wrong zone.
+    #[test]
+    fn stored_to_host_email_recovers_host_wall_clock() {
+        // Scenario from issue #119: Paris event type, LA guest, booked at
+        // what the guest saw as 07:00 LA = 16:00 Paris. start_at stored as
+        // Paris wall-clock.
+        let stored_start = "2026-05-26T16:00:00";
+        let stored_end = "2026-05-26T16:30:00";
+        let host_tz: Tz = "Europe/Paris".parse().unwrap();
+        let guest_tz: Tz = "America/Los_Angeles".parse().unwrap();
+
+        // Step 1: convert stored (host) -> guest wall-clock, as the reminder
+        // loop and reschedule handler now do before building BookingDetails.
+        let (date, start_time, end_time) =
+            booking_strings_in_guest_tz(stored_start, stored_end, host_tz, guest_tz);
+        assert_eq!(date, "2026-05-26");
+        assert_eq!(start_time, "07:00");
+        assert_eq!(end_time, "07:30");
+
+        // Step 2: host_time_display converts guest wall-clock back to host.
+        let (host_date, time_display) = crate::email::host_time_display(
+            &date,
+            &start_time,
+            &end_time,
+            guest_tz.name(),
+            host_tz.name(),
+        );
+        assert_eq!(host_date, "2026-05-26");
+        assert_eq!(time_display, "16:00 \u{2013} 16:30 (Europe/Paris)");
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -317,8 +317,8 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
         // - event type has reminder_minutes set (> 0)
         // - start_at minus reminder_minutes <= now
         // - start_at > now (don't remind for past bookings)
-        let due: Vec<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>, Option<String>)> = sqlx::query_as(
-            "SELECT b.id, b.guest_name, b.guest_email, b.guest_timezone, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), et.location_value, b.cancel_token, b.uid, b.language, u.language
+        let due: Vec<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>, Option<String>, Option<String>)> = sqlx::query_as(
+            "SELECT b.id, b.guest_name, b.guest_email, b.guest_timezone, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), et.location_value, b.cancel_token, b.uid, b.language, u.language, u.timezone
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -360,6 +360,7 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
             uid,
             guest_language,
             host_language,
+            host_timezone,
         ) in &due
         {
             let date = start_at.get(..10).unwrap_or(start_at).to_string();
@@ -385,6 +386,7 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
                 additional_attendees: vec![],
                 guest_language: guest_language.clone(),
                 host_language: host_language.clone(),
+                host_timezone: host_timezone.clone().unwrap_or_default(),
             };
 
             let guest_cancel_url = cancel_token.as_ref().and_then(|t| {
@@ -3741,6 +3743,7 @@ async fn cancel_booking(
             uid,
             reason,
             cancelled_by_host: true,
+            host_timezone: stored_tz.name().to_string(),
             ..Default::default()
         };
 
@@ -3848,6 +3851,7 @@ async fn confirm_booking(
         location: location_value,
         reminder_minutes: None,
         additional_attendees: vec![],
+        host_timezone: stored_tz.name().to_string(),
         ..Default::default()
     };
 
@@ -8554,6 +8558,7 @@ async fn handle_group_booking(
         reminder_minutes: reminder_min,
         additional_attendees: additional_attendees.clone(),
         guest_language: Some(lang.to_string()),
+        host_timezone: host_tz.name().to_string(),
         ..Default::default()
     };
 
@@ -9321,6 +9326,7 @@ async fn handle_dynamic_group_booking(
         reminder_minutes: reminder_min,
         additional_attendees: all_additional.clone(),
         guest_language: Some(lang.to_string()),
+        host_timezone: host_tz.name().to_string(),
         ..Default::default()
     };
 
@@ -10056,6 +10062,7 @@ async fn handle_booking_for_user(
             reminder_minutes: reminder_min,
             additional_attendees: additional_attendees.clone(),
             guest_language: Some(lang.to_string()),
+            host_timezone: host_tz.name().to_string(),
             ..Default::default()
         };
 
@@ -12038,6 +12045,7 @@ async fn handle_booking(
             reminder_minutes: reminder_min,
             additional_attendees: additional_attendees.clone(),
             guest_language: Some(lang.to_string()),
+            host_timezone: host_tz.name().to_string(),
             ..Default::default()
         };
 
@@ -13631,6 +13639,7 @@ async fn approve_booking_by_token(
         location: location_value,
         reminder_minutes: None,
         additional_attendees: vec![],
+        host_timezone: stored_tz.name().to_string(),
         ..Default::default()
     };
 
@@ -13854,6 +13863,7 @@ async fn decline_booking_by_token(
             uid: String::new(),
             reason: reason.clone(),
             cancelled_by_host: true,
+            host_timezone: stored_tz.name().to_string(),
             ..Default::default()
         };
         let _ = crate::email::send_guest_decline_notice(&smtp_config, &details).await;
@@ -14202,6 +14212,7 @@ async fn guest_cancel_booking(
             // Guest is the one cancelling; their browser language now is the
             // best signal we have (they chose this language to view the form).
             guest_language: Some(lang.to_string()),
+            host_timezone: stored_tz.name().to_string(),
             ..Default::default()
         };
 
@@ -14789,6 +14800,7 @@ async fn guest_reschedule_booking(
                 host_email,
                 uid: uid.clone(),
                 location: loc_value.clone(),
+                host_timezone: host_tz.name().to_string(),
             };
             let _ = crate::email::send_host_reschedule_request(
                 &smtp_config,
@@ -14828,6 +14840,7 @@ async fn guest_reschedule_booking(
                 location: loc_value,
                 reminder_minutes: None,
                 additional_attendees: vec![],
+                host_timezone: host_tz.name().to_string(),
                 ..Default::default()
             };
             let _ = crate::email::send_guest_pending_notice_ex(
@@ -14856,6 +14869,7 @@ async fn guest_reschedule_booking(
             location: loc_value.clone(),
             reminder_minutes: None,
             additional_attendees: vec![],
+            host_timezone: host_tz.name().to_string(),
             ..Default::default()
         };
         caldav_push_booking(
@@ -14904,6 +14918,7 @@ async fn guest_reschedule_booking(
                     host_email: host_email.clone(),
                     uid,
                     location: loc_value,
+                    host_timezone: host_tz.name().to_string(),
                 },
                 guest_cancel_url.as_deref(),
                 guest_reschedule_url.as_deref(),
@@ -15098,6 +15113,7 @@ async fn host_reschedule_booking(
             location: None,
             reminder_minutes: None,
             additional_attendees: vec![],
+            host_timezone: user.timezone.clone(),
             ..Default::default()
         };
 
@@ -15659,7 +15675,7 @@ async fn claim_booking(
         guest_tz,
         host_user_id,
         location,
-        _event_type_id,
+        event_type_id,
     ) = match booking {
         Some(b) => b,
         None => {
@@ -15704,6 +15720,8 @@ async fn claim_booking(
         .execute(&state.pool)
         .await;
 
+    let claim_host_tz = get_host_tz(&state.pool, &event_type_id).await;
+
     // Build details with claimant as additional attendee for CalDAV push
     let mut details = crate::email::BookingDetails {
         event_title: event_title.clone(),
@@ -15720,6 +15738,7 @@ async fn claim_booking(
         location,
         reminder_minutes: None,
         additional_attendees: vec![claimant_email.clone()],
+        host_timezone: claim_host_tz.name().to_string(),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary
- Fixes #119 — host emails were rendered in the guest's wall-clock time with no TZ label, so a Paris host reading a Los Angeles booking saw "07:00" and naturally assumed Paris time
- Host-targeted emails (notification, approval request, booking confirmed, reminder, cancellation, reschedule request) now convert times into the host's own timezone and show a `(TZ)` suffix, e.g. `16:00 – 16:30 (Europe/Paris)`
- Guest cancellation and decline emails gained the `(TZ)` label they were missing — confirmation/pending already had it

## Implementation
- `BookingDetails`, `CancellationDetails`, `RescheduleDetails` get a new `host_timezone: String` field (empty string preserves legacy behavior)
- Two helpers in `src/email.rs`: `convert_time_between_tz` (handles date rollover — e.g. LA 22:00 → Paris 07:00 next day) and `host_time_display` (returns `(date, formatted_time)`)
- 16 call sites in `src/web/mod.rs`, `src/commands/booking.rs`, `src/commands/sync.rs` populate `host_timezone` — mostly from the already-in-scope `host_tz` / `stored_tz` (event-type timezone via `get_host_tz`), with a couple of query extensions to fetch `users.timezone`
- 6 new unit tests, including a regression test mirroring the LA→Paris scenario from #119

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (676 passing, including 6 new tests)
- [ ] Manual: cancel a booking as a host whose timezone differs from the guest, confirm cancellation email shows host's local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)