### PR TITLE
feat(book): add captcha system for secure booking endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,104 @@ File: `src/web/mod.rs`, templates in `templates/`
 
 ---
 
+## Captcha (trycap / Cap)
+
+### What it does
+
+Protects booking endpoints against bots with a privacy-first proof-of-work CAPTCHA. The feature is **opt-in**: when no configuration is stored the booking flow works exactly as before — no widget, no server-side check. The captcha is only active on booking form pages (guest-facing), never on registration or dashboard routes.
+
+The chosen provider is [Cap](https://trycap.dev) — self-hosted, no GAFAM, no tracking, Docker-deployable. It is API-compatible with the reCAPTCHA/hCaptcha verification protocol, so switching providers in the future only requires updating `src/web/captcha.rs`.
+
+### Configuration (admin panel)
+
+Configured at `/dashboard/admin` → **Captcha** section. Four fields:
+
+| Field | Required | Description |
+|---|---|---|
+| Instance URL | Yes | Base URL of your Cap server, e.g. `https://captcha.example.com` |
+| Site key | Yes | Site key from the Cap dashboard |
+| Secret | Yes | Secret key for server-to-server verification (encrypted at rest with AES-256-GCM, same pattern as OIDC client secret) |
+| Widget script URL | No | Override the JS bundle URL. Defaults to `https://cdn.jsdelivr.net/npm/cap-widget`. Useful for air-gapped deployments. Changes take effect immediately after saving (CSP is rebuilt in memory). |
+
+Leaving all three main fields empty disables the captcha. The secret uses the keep-current pattern: leaving the password field empty on save preserves the stored value.
+
+### How it works end-to-end
+
+**GET (booking form):** The handler reads `state.captcha_config` (a `RwLock<Option<CaptchaConfig>>`). If `Some`, it passes `captcha_enabled = true`, `captcha_api_endpoint`, and `captcha_widget_url` to the template. The `<cap-widget>` element is rendered conditionally in `templates/book.html` with all i18n attributes pre-filled via the Fluent `t()` helper.
+
+**POST (booking submit):** The `BookForm` struct has a `captcha_token: Option<String>` field with `#[serde(rename = "cap-token")]` — the field name the Cap widget submits. After the CSRF check, `captcha::verify(&captcha_cfg, form.captcha_token.as_deref()).await` is called:
+- `config = None` → `Ok(())` immediately (pass-through)
+- `config = Some`, token missing/empty → `Err(())` → renders `booking_action_error.html`
+- `config = Some`, token present → POST to `<instance>/<site-key>/siteverify` with JSON `{"secret": "...", "response": "<token>"}` → parses `{"success": bool}`
+
+The verification is implemented in `src/web/captcha.rs` and applies to **3 handlers**: `handle_booking`, `handle_booking_for_user`, `handle_group_booking`. The dynamic group booking path (`username.contains('+')`) is also protected because the check happens before the branch.
+
+### Code structure
+
+| File | Role |
+|---|---|
+| `src/web/captcha.rs` | Self-contained module: `CaptchaConfig` struct, `load_captcha_config()`, `verify()`, `extract_origin()` helper, unit tests |
+| `src/web/mod.rs` | `AppState.captcha_config: RwLock<Option<CaptchaConfig>>`, `build_csp()`, `csp_middleware()`, `admin_update_captcha()` handler, wiring in the 4 GET form handlers and 3 POST booking handlers |
+| `migrations/053_captcha.sql` | Adds `captcha_instance_url`, `captcha_site_key`, `captcha_secret`, `captcha_widget_url` columns to `auth_config` |
+| `templates/admin.html` | Captcha configuration section (status badge, 4 inputs, save button) |
+| `templates/book.html` | Conditional `<cap-widget>` with all `data-cap-i18n-*` attributes |
+| `templates/base.html` | CSS custom property overrides for `cap-widget` theming |
+
+### Content-Security-Policy
+
+The CSP is **dynamic** — it is rebuilt whenever the admin saves captcha settings, without a server restart (except for the widget script URL, which controls the `script-src` domain). It is stored as a pre-built string in `AppState.csp: RwLock<String>` and applied by `csp_middleware` (an Axum `from_fn_with_state` layer).
+
+`build_csp(captcha: &Option<CaptchaConfig>) -> String` produces:
+
+**Without captcha configured:**
+```
+default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';
+script-src 'self' 'unsafe-inline';
+connect-src 'self';
+object-src 'none'; base-uri 'self'; frame-ancestors 'self'
+```
+
+**With captcha configured:**
+```
+default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';
+script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' <widget-origin>;
+worker-src blob:;
+connect-src 'self' <instance-origin> <widget-origin>;
+object-src 'none'; base-uri 'self'; frame-ancestors 'self'
+```
+
+The three extra directives and why they are needed:
+- **`'wasm-unsafe-eval'` in `script-src`** — Cap's proof-of-work solver runs as a WASM module. Without this, browsers block `WebAssembly.instantiate()` under a strict CSP. Falls back to a JS solver if blocked, but WASM is much faster.
+- **`worker-src blob:`** — The Cap widget spawns a Web Worker via a `blob:` URL to run the solver off the main thread. `worker-src` is not inherited from `script-src` in all browsers, so it must be explicit.
+- **`<widget-origin>` in `connect-src`** — The widget's JS fetches the WASM binary from the same CDN origin via `fetch()`. This is controlled by `connect-src`, not `script-src`. Both the Cap server origin (for token verification XHR) and the widget CDN origin (for WASM fetch) must be in `connect-src`.
+
+The `csp_middleware` skips setting the header if it is already present, so individual handlers can override it if needed in the future.
+
+### Translations
+
+All visible strings in the Cap widget are localised via the standard Fluent system. Keys use the `captcha-` prefix and live in each language file:
+
+Keys: `captcha-label`, `captcha-initial-state`, `captcha-verifying`, `captcha-solved`, `captcha-error`, `captcha-troubleshooting`, `captcha-wasm-disabled`, plus five `*-aria` keys for accessibility.
+
+### Styling
+
+The `<cap-widget>` custom element exposes CSS custom properties. They are overridden globally in `templates/base.html` to follow the app's existing theme variables:
+
+```css
+cap-widget {
+  --cap-background: var(--surface);
+  --cap-border-color: var(--border);
+  --cap-color: var(--text);
+  --cap-checkbox-background: var(--surface-hover);
+  --cap-spinner-color: var(--text);
+  --cap-spinner-background-color: var(--border);
+}
+```
+
+Because `--surface`, `--border`, etc. are already overridden by `html.dark { ... }` (in `base.html`) and by each preset/custom theme (via `theme_css` in `AppState`), the widget automatically adapts to dark mode and all custom themes (Nord, Dracula, Tokyo Night, etc.) with no additional CSS.
+
+---
+
 ## Known issues & TODOs
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Each team member's CalDAV calendars are checked for conflicts. The availability 
 
 - **Credential encryption** — CalDAV and SMTP passwords encrypted at rest with AES-256-GCM; secret key auto-generated or provided via `CALRS_SECRET_KEY`
 - **Hidden password input** — passwords never echoed to the terminal
+- **Privacy-first CAPTCHA** — optional [Cap](https://trycap.dev) integration (self-hosted, proof-of-work, no GAFAM). When configured, a `<cap-widget>` is shown on all booking pages and the token is verified server-to-server before any booking is processed. Disabled by default — no widget, no network call if unconfigured
 
 ### Localization
 
@@ -367,6 +368,64 @@ calrs serve --port 3000
 ```
 
 The login page will show a "Sign in with SSO" button. With `--auto-register true`, users are created automatically on first OIDC login. Existing local users are linked by email.
+
+## Captcha setup (Cap / trycap.dev)
+
+calrs integrates [Cap](https://trycap.dev), a self-hosted proof-of-work CAPTCHA that requires no third-party service and collects no user data. The widget appears only on booking pages — never on the dashboard or registration form.
+
+**The feature is opt-in.** If you do not configure it, the booking flow works exactly as before: no widget, no network call.
+
+### 1. Deploy a Cap instance
+
+Cap is distributed as a Docker image. Minimal compose example:
+
+```yaml
+services:
+  cap:
+    image: ghcr.io/trycap/cap:latest
+    ports:
+      - "3001:3001"
+    environment:
+      CAP_SECRET: your-secret-key
+```
+
+Create a site in the Cap dashboard and note the **site key** and **secret**.
+
+### 2. Configure calrs
+
+Go to **Admin panel → Captcha** and fill in:
+
+| Field | Example | Notes |
+|---|---|---|
+| Instance URL | `https://captcha.example.com` | Base URL of your Cap server |
+| Site key | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | From the Cap dashboard |
+| Secret | `your-secret-key` | Encrypted at rest with AES-256-GCM |
+| Widget script URL | *(leave empty)* | Defaults to `https://cdn.jsdelivr.net/npm/cap-widget`. Override for air-gapped deployments. |
+
+Click **Save captcha settings**. All changes — including the widget script URL — take effect immediately, no restart required.
+
+To disable, clear the Instance URL, Site key, and Secret fields and save.
+
+### How verification works
+
+1. The guest completes the proof-of-work challenge in the browser (the Cap widget handles this automatically, with a WASM solver for speed)
+2. The widget writes the resulting token into a hidden `cap-token` form field
+3. On submit, calrs calls `POST <instance>/<site-key>/siteverify` with the token and the secret (server-to-server, never exposed to the browser)
+4. If verification fails, the guest sees the standard error page — no booking is created
+
+### Content-Security-Policy
+
+calrs sets a strict CSP on all responses. When Cap is configured, the following directives are added and updated automatically on every save:
+
+| Directive | Added value | Why |
+|---|---|---|
+| `script-src` | `'wasm-unsafe-eval' <widget-origin>` | The widget JS loads from an external origin; `wasm-unsafe-eval` allows the WASM proof-of-work solver |
+| `worker-src` | `blob:` | The widget spawns a Web Worker via a blob URL to run the solver off the main thread |
+| `connect-src` | `<instance-origin> <widget-origin>` | The browser fetches the WASM binary from the widget CDN and sends the solved token to the Cap server |
+
+When captcha is disabled, none of these directives are present — the CSP reverts to its strict baseline immediately after saving.
+
+---
 
 ## Reverse proxy
 

--- a/i18n/de/main.ftl
+++ b/i18n/de/main.ftl
@@ -74,6 +74,18 @@ book-additional-guests-label = Weitere Teilnehmer
 book-additional-guests-hint = (optional, bis zu { $max })
 book-add-guest-btn = + Teilnehmer hinzufügen
 book-guest-email-placeholder = kollege@example.com
+captcha-label = Sicherheitsüberprüfung
+captcha-initial-state = Bestätigen Sie, dass Sie ein Mensch sind
+captcha-verifying = Überprüfung läuft...
+captcha-solved = Sie sind ein Mensch
+captcha-error = Fehler
+captcha-troubleshooting = Fehlerbehebung
+captcha-wasm-disabled = WASM aktivieren für deutlich schnellere Lösung
+captcha-verify-aria = Klicken Sie, um zu bestätigen, dass Sie ein Mensch sind
+captcha-verifying-aria = Überprüfung läuft, bitte warten
+captcha-verified-aria = Bestätigt
+captcha-required = Bitte bestätigen Sie, dass Sie ein Mensch sind
+captcha-error-aria = Ein Fehler ist aufgetreten, bitte versuchen Sie es erneut
 book-confirm-button = Buchung bestätigen
 
 # Shared labels used across the cancel / decline / approve / reschedule / claim flows

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -74,6 +74,18 @@ book-additional-guests-label = Additional guests
 book-additional-guests-hint = (optional, up to { $max })
 book-add-guest-btn = + Add guest email
 book-guest-email-placeholder = colleague@example.com
+captcha-label = Security verification
+captcha-initial-state = Verify you're human
+captcha-verifying = Verifying...
+captcha-solved = You're human
+captcha-error = Error
+captcha-troubleshooting = Troubleshooting
+captcha-wasm-disabled = Enable WASM for significantly faster solving
+captcha-verify-aria = Click to verify you're a human
+captcha-verifying-aria = Verifying, please wait
+captcha-verified-aria = Verified
+captcha-required = Please verify you're human
+captcha-error-aria = An error occurred, please try again
 book-confirm-button = Confirm booking
 
 # Shared labels used across the cancel / decline / approve / reschedule / claim flows

--- a/i18n/es/main.ftl
+++ b/i18n/es/main.ftl
@@ -74,6 +74,18 @@ book-additional-guests-label = Invitados adicionales
 book-additional-guests-hint = (opcional, hasta { $max })
 book-add-guest-btn = + Añadir invitado
 book-guest-email-placeholder = colega@example.com
+captcha-label = Verificación de seguridad
+captcha-initial-state = Verifique que es humano
+captcha-verifying = Verificando...
+captcha-solved = Eres humano
+captcha-error = Error
+captcha-troubleshooting = Solución de problemas
+captcha-wasm-disabled = Active WASM para una resolución significativamente más rápida
+captcha-verify-aria = Haga clic para verificar que es humano
+captcha-verifying-aria = Verificando, por favor espere
+captcha-verified-aria = Verificado
+captcha-required = Por favor, verifique que es humano
+captcha-error-aria = Se ha producido un error, por favor inténtelo de nuevo
 book-confirm-button = Confirmar reserva
 
 # Shared labels used across the cancel / decline / approve / reschedule / claim flows

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -74,6 +74,18 @@ book-additional-guests-label = Invités supplémentaires
 book-additional-guests-hint = (facultatif, jusqu'à { $max })
 book-add-guest-btn = + Ajouter un invité
 book-guest-email-placeholder = collegue@example.com
+captcha-label = Vérification de sécurité
+captcha-initial-state = Vérifiez que vous êtes humain
+captcha-verifying = Vérification en cours...
+captcha-solved = Vous êtes humain
+captcha-error = Erreur
+captcha-troubleshooting = Dépannage
+captcha-wasm-disabled = Activez WASM pour une résolution plus rapide
+captcha-verify-aria = Cliquez pour vérifier que vous êtes humain
+captcha-verifying-aria = Vérification en cours, veuillez patienter
+captcha-verified-aria = Vérifié
+captcha-required = Veuillez vérifier que vous êtes humain
+captcha-error-aria = Une erreur est survenue, veuillez réessayer
 book-confirm-button = Confirmer la réservation
 
 # Shared labels used across the cancel / decline / approve / reschedule / claim flows

--- a/i18n/it/main.ftl
+++ b/i18n/it/main.ftl
@@ -74,6 +74,18 @@ book-additional-guests-label = Ospiti aggiuntivi
 book-additional-guests-hint = (opzionale, fino a { $max })
 book-add-guest-btn = + Aggiungi ospite
 book-guest-email-placeholder = collega@example.com
+captcha-label = Verifica di sicurezza
+captcha-initial-state = Verifica di essere umano
+captcha-verifying = Verifica in corso...
+captcha-solved = Sei umano
+captcha-error = Errore
+captcha-troubleshooting = Risoluzione dei problemi
+captcha-wasm-disabled = Abilita WASM per una risoluzione significativamente più rapida
+captcha-verify-aria = Clicca per verificare di essere umano
+captcha-verifying-aria = Verifica in corso, attendere prego
+captcha-verified-aria = Verificato
+captcha-required = Verifica di essere umano
+captcha-error-aria = Si è verificato un errore, riprova
 book-confirm-button = Conferma prenotazione
 
 # Shared labels used across the cancel / decline / approve / reschedule / claim flows

--- a/i18n/pl/main.ftl
+++ b/i18n/pl/main.ftl
@@ -74,6 +74,18 @@ book-additional-guests-label = Dodatkowi goście
 book-additional-guests-hint = (opcjonalne, do { $max })
 book-add-guest-btn = + Dodaj gościa
 book-guest-email-placeholder = wspolpracownik@example.com
+captcha-label = Weryfikacja bezpieczeństwa
+captcha-initial-state = Potwierdź, że jesteś człowiekiem
+captcha-verifying = Weryfikacja...
+captcha-solved = Jesteś człowiekiem
+captcha-error = Błąd
+captcha-troubleshooting = Rozwiązywanie problemów
+captcha-wasm-disabled = Włącz WASM dla znacznie szybszego rozwiązywania
+captcha-verify-aria = Kliknij, aby potwierdzić, że jesteś człowiekiem
+captcha-verifying-aria = Weryfikacja, proszę czekać
+captcha-verified-aria = Zweryfikowano
+captcha-required = Proszę potwierdzić, że jesteś człowiekiem
+captcha-error-aria = Wystąpił błąd, spróbuj ponownie
 book-confirm-button = Potwierdź rezerwację
 
 # Shared labels used across the cancel / decline / approve / reschedule / claim flows

--- a/migrations/054_captcha.sql
+++ b/migrations/054_captcha.sql
@@ -1,0 +1,4 @@
+ALTER TABLE auth_config ADD COLUMN captcha_instance_url TEXT;
+ALTER TABLE auth_config ADD COLUMN captcha_site_key TEXT;
+ALTER TABLE auth_config ADD COLUMN captcha_secret TEXT;
+ALTER TABLE auth_config ADD COLUMN captcha_widget_url TEXT;

--- a/src/db.rs
+++ b/src/db.rs
@@ -231,6 +231,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "053_oauth2_caldav",
             include_str!("../migrations/053_oauth2_caldav.sql"),
         ),
+        (
+            "054_captcha",
+            include_str!("../migrations/054_captcha.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -838,7 +842,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 53, "All 53 migrations should be tracked");
+        assert_eq!(count.0, 54, "All 54 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -852,7 +856,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 53, "Still 53 migrations after second run");
+        assert_eq!(count.0, 54, "Still 54 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -231,10 +231,7 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "053_oauth2_caldav",
             include_str!("../migrations/053_oauth2_caldav.sql"),
         ),
-        (
-            "054_captcha",
-            include_str!("../migrations/054_captcha.sql"),
-        ),
+        ("054_captcha", include_str!("../migrations/054_captcha.sql")),
     ];
 
     let mut applied_count = 0u32;

--- a/src/web/captcha.rs
+++ b/src/web/captcha.rs
@@ -1,0 +1,245 @@
+use sqlx::SqlitePool;
+
+pub const DEFAULT_WIDGET_URL: &str = "https://cdn.jsdelivr.net/npm/cap-widget";
+
+pub struct CaptchaConfig {
+    pub instance_url: String,
+    pub site_key: String,
+    pub secret: String,
+    pub widget_url: String,
+}
+
+pub struct CaptchaVars {
+    pub enabled: bool,
+    pub api_endpoint: String,
+    pub widget_url: String,
+}
+
+impl CaptchaVars {
+    pub fn from_config(config: &Option<CaptchaConfig>) -> Self {
+        Self {
+            enabled: config.is_some(),
+            api_endpoint: config
+                .as_ref()
+                .map(|c| c.api_endpoint())
+                .unwrap_or_default(),
+            widget_url: config
+                .as_ref()
+                .map(|c| c.widget_url.clone())
+                .unwrap_or_else(|| DEFAULT_WIDGET_URL.to_string()),
+        }
+    }
+}
+
+impl CaptchaConfig {
+    /// API endpoint URL passed to the <cap-widget> data-cap-api-endpoint attribute.
+    pub fn api_endpoint(&self) -> String {
+        format!(
+            "{}/{}/",
+            self.instance_url.trim_end_matches('/'),
+            self.site_key
+        )
+    }
+
+    /// Extract scheme+host from widget_url for use in Content-Security-Policy script-src.
+    /// e.g. "https://cdn.jsdelivr.net/npm/cap-widget" → "https://cdn.jsdelivr.net"
+    pub fn widget_script_origin(&self) -> String {
+        extract_origin(&self.widget_url)
+    }
+
+    /// Extract scheme+host from instance_url for use in Content-Security-Policy connect-src.
+    /// e.g. "https://captcha.example.com" → "https://captcha.example.com"
+    pub fn instance_origin(&self) -> String {
+        extract_origin(&self.instance_url)
+    }
+}
+
+fn extract_origin(url: &str) -> String {
+    let parts: Vec<&str> = url.splitn(4, '/').collect();
+    if parts.len() >= 3 && (parts[0] == "https:" || parts[0] == "http:") {
+        format!("{}//{}", parts[0], parts[2])
+    } else {
+        String::new()
+    }
+}
+
+pub async fn load_captcha_config(pool: &SqlitePool, key: &[u8; 32]) -> Option<CaptchaConfig> {
+    let row: Option<(Option<String>, Option<String>, Option<String>, Option<String>)> =
+        sqlx::query_as(
+            "SELECT captcha_instance_url, captcha_site_key, captcha_secret, captcha_widget_url \
+             FROM auth_config WHERE id = 'singleton'",
+        )
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+
+    let (instance_url, site_key, secret_enc, widget_url) = row?;
+    let instance_url = instance_url.filter(|s| !s.trim().is_empty())?;
+    let site_key = site_key.filter(|s| !s.trim().is_empty())?;
+    let secret_enc = secret_enc.filter(|s| !s.trim().is_empty())?;
+    let secret = crate::crypto::decrypt_value(key, &secret_enc).ok()?;
+    let widget_url = widget_url
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_WIDGET_URL.to_string());
+
+    Some(CaptchaConfig {
+        instance_url,
+        site_key,
+        secret,
+        widget_url,
+    })
+}
+
+#[derive(serde::Serialize)]
+struct VerifyRequest<'a> {
+    secret: &'a str,
+    response: &'a str,
+}
+
+#[derive(serde::Deserialize)]
+struct VerifyResponse {
+    success: bool,
+}
+
+/// Returns `Ok(())` if captcha is not configured (pass-through) or if the token
+/// is valid. Returns `Err(())` if captcha is configured but the token is missing
+/// or fails server-side verification.
+pub async fn verify(config: &Option<CaptchaConfig>, token: Option<&str>) -> Result<(), ()> {
+    let cfg = match config {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    let token = match token.filter(|t| !t.trim().is_empty()) {
+        Some(t) => t,
+        None => {
+            tracing::warn!("captcha token missing on booking attempt");
+            return Err(());
+        }
+    };
+
+    let verify_url = format!("{}/siteverify", cfg.api_endpoint().trim_end_matches('/'));
+
+    let client = reqwest::Client::new();
+    let resp = match client
+        .post(&verify_url)
+        .json(&VerifyRequest {
+            secret: &cfg.secret,
+            response: token,
+        })
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "captcha verification request failed");
+            return Err(());
+        }
+    };
+
+    match resp.json::<VerifyResponse>().await {
+        Ok(r) if r.success => Ok(()),
+        Ok(_) => {
+            tracing::warn!("captcha token rejected by verification server");
+            Err(())
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "captcha verification response parse failed");
+            Err(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- extract_origin tests ---
+
+    #[test]
+    fn extract_origin_returns_scheme_and_host() {
+        assert_eq!(
+            extract_origin("https://cdn.jsdelivr.net/npm/cap-widget"),
+            "https://cdn.jsdelivr.net"
+        );
+    }
+
+    #[test]
+    fn extract_origin_handles_root_url() {
+        assert_eq!(
+            extract_origin("https://cap.example.com"),
+            "https://cap.example.com"
+        );
+    }
+
+    #[test]
+    fn extract_origin_handles_trailing_slash() {
+        assert_eq!(
+            extract_origin("https://cap.example.com/"),
+            "https://cap.example.com"
+        );
+    }
+
+    #[test]
+    fn extract_origin_rejects_invalid_url() {
+        assert_eq!(extract_origin("not-a-url"), "");
+        assert_eq!(extract_origin(""), "");
+    }
+
+    // --- api_endpoint tests ---
+
+    #[test]
+    fn api_endpoint_strips_trailing_slash_on_instance() {
+        let cfg = CaptchaConfig {
+            instance_url: "https://cap.example.com/".to_string(),
+            site_key: "mykey".to_string(),
+            secret: "s".to_string(),
+            widget_url: DEFAULT_WIDGET_URL.to_string(),
+        };
+        assert_eq!(cfg.api_endpoint(), "https://cap.example.com/mykey/");
+    }
+
+    #[test]
+    fn api_endpoint_no_trailing_slash_on_instance() {
+        let cfg = CaptchaConfig {
+            instance_url: "https://cap.example.com".to_string(),
+            site_key: "mykey".to_string(),
+            secret: "s".to_string(),
+            widget_url: DEFAULT_WIDGET_URL.to_string(),
+        };
+        assert_eq!(cfg.api_endpoint(), "https://cap.example.com/mykey/");
+    }
+
+    // --- verify passthrough tests (no network) ---
+
+    #[tokio::test]
+    async fn verify_passes_through_when_no_config() {
+        assert!(verify(&None, None).await.is_ok());
+        assert!(verify(&None, Some("any-token")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn verify_fails_when_config_set_and_token_missing() {
+        let cfg = Some(CaptchaConfig {
+            instance_url: "https://cap.example.com".to_string(),
+            site_key: "key".to_string(),
+            secret: "secret".to_string(),
+            widget_url: DEFAULT_WIDGET_URL.to_string(),
+        });
+        assert!(verify(&cfg, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn verify_fails_when_config_set_and_token_empty() {
+        let cfg = Some(CaptchaConfig {
+            instance_url: "https://cap.example.com".to_string(),
+            site_key: "key".to_string(),
+            secret: "secret".to_string(),
+            widget_url: DEFAULT_WIDGET_URL.to_string(),
+        });
+        assert!(verify(&cfg, Some("")).await.is_err());
+        assert!(verify(&cfg, Some("   ")).await.is_err());
+    }
+}

--- a/src/web/captcha.rs
+++ b/src/web/captcha.rs
@@ -55,11 +55,16 @@ impl CaptchaConfig {
 }
 
 fn extract_origin(url: &str) -> String {
-    let parts: Vec<&str> = url.splitn(4, '/').collect();
-    if parts.len() >= 3 && (parts[0] == "https:" || parts[0] == "http:") {
-        format!("{}//{}", parts[0], parts[2])
-    } else {
-        String::new()
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return String::new();
+    };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return String::new();
+    }
+    let host = parsed.host_str().unwrap_or("");
+    match parsed.port() {
+        Some(port) => format!("{}://{}:{}", parsed.scheme(), host, port),
+        None => format!("{}://{}", parsed.scheme(), host),
     }
 }
 

--- a/src/web/captcha.rs
+++ b/src/web/captcha.rs
@@ -64,15 +64,19 @@ fn extract_origin(url: &str) -> String {
 }
 
 pub async fn load_captcha_config(pool: &SqlitePool, key: &[u8; 32]) -> Option<CaptchaConfig> {
-    let row: Option<(Option<String>, Option<String>, Option<String>, Option<String>)> =
-        sqlx::query_as(
-            "SELECT captcha_instance_url, captcha_site_key, captcha_secret, captcha_widget_url \
+    let row: Option<(
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )> = sqlx::query_as(
+        "SELECT captcha_instance_url, captcha_site_key, captcha_secret, captcha_widget_url \
              FROM auth_config WHERE id = 'singleton'",
-        )
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten();
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten();
 
     let (instance_url, site_key, secret_enc, widget_url) = row?;
     let instance_url = instance_url.filter(|s| !s.trim().is_empty())?;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -13764,9 +13764,7 @@ async fn admin_update_captcha(
         return resp;
     }
 
-    let instance_url = form
-        .captcha_instance_url
-        .filter(|s| !s.trim().is_empty());
+    let instance_url = form.captcha_instance_url.filter(|s| !s.trim().is_empty());
     let site_key = form.captcha_site_key.filter(|s| !s.trim().is_empty());
     let widget_url = form.captcha_widget_url.filter(|s| !s.trim().is_empty());
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,3 +1,5 @@
+pub mod captcha;
+
 use crate::utils::convert_event_to_tz;
 use axum::extract::{Form, Multipart, Path, Query, State};
 use axum::http::HeaderMap;
@@ -89,6 +91,8 @@ pub struct AppState {
     pub secret_key: [u8; 32],
     pub theme_css: tokio::sync::RwLock<String>,
     pub company_link: tokio::sync::RwLock<Option<String>>,
+    pub captcha_config: tokio::sync::RwLock<Option<captcha::CaptchaConfig>>,
+    pub csp: tokio::sync::RwLock<String>,
 }
 
 // --- CSRF protection (double-submit cookie pattern) ---
@@ -831,6 +835,50 @@ async fn csrf_cookie_middleware(
     response
 }
 
+fn build_csp(captcha: &Option<captcha::CaptchaConfig>) -> String {
+    let (wasm_eval, worker_src, script_extra, connect_extra) = match captcha.as_ref() {
+        Some(c) => {
+            let widget_origin = c.widget_script_origin();
+            let instance_origin = c.instance_origin();
+            (
+                " 'wasm-unsafe-eval'",
+                "worker-src blob:; ",
+                format!(" {}", widget_origin),
+                format!(" {} {}", instance_origin, widget_origin),
+            )
+        }
+        None => ("", "", String::new(), String::new()),
+    };
+    format!(
+        "default-src 'self'; img-src 'self' data:; \
+         style-src 'self' 'unsafe-inline'; \
+         script-src 'self' 'unsafe-inline'{}{}; \
+         {}connect-src 'self'{}; \
+         object-src 'none'; base-uri 'self'; frame-ancestors 'self'",
+        wasm_eval, script_extra, worker_src, connect_extra
+    )
+}
+
+async fn csp_middleware(
+    State(state): State<Arc<AppState>>,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let mut response = next.run(request).await;
+    if !response
+        .headers()
+        .contains_key(axum::http::header::CONTENT_SECURITY_POLICY)
+    {
+        let csp = state.csp.read().await.clone();
+        if let Ok(val) = axum::http::HeaderValue::from_str(&csp) {
+            response
+                .headers_mut()
+                .insert(axum::http::header::CONTENT_SECURITY_POLICY, val);
+        }
+    }
+    response
+}
+
 pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8; 32]) -> Router {
     let mut env = Environment::new();
     env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
@@ -839,6 +887,8 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
 
     let initial_theme_css = build_theme_css(&pool).await;
     let initial_company_link = get_company_link(&pool).await;
+    let initial_captcha = captcha::load_captcha_config(&pool, &secret_key).await;
+    let initial_csp = build_csp(&initial_captcha);
 
     let state = Arc::new(AppState {
         pool,
@@ -850,6 +900,8 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         data_dir,
         theme_css: tokio::sync::RwLock::new(initial_theme_css),
         company_link: tokio::sync::RwLock::new(initial_company_link),
+        captcha_config: tokio::sync::RwLock::new(initial_captcha),
+        csp: tokio::sync::RwLock::new(initial_csp),
     });
 
     Router::new()
@@ -991,6 +1043,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
             "/dashboard/admin/google-oauth2",
             post(admin_update_google_oauth2),
         )
+        .route("/dashboard/admin/captcha", post(admin_update_captcha))
         .route("/dashboard/admin/logo", post(admin_upload_logo))
         .route("/dashboard/admin/logo/delete", post(admin_delete_logo))
         .route(
@@ -1118,14 +1171,9 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
                 "geolocation=(), microphone=(), camera=(), payment=(), usb=()",
             ),
         ))
-        .layer(SetResponseHeaderLayer::if_not_present(
-            axum::http::header::CONTENT_SECURITY_POLICY,
-            axum::http::HeaderValue::from_static(
-                "default-src 'self'; img-src 'self' data:; \
-                 style-src 'self' 'unsafe-inline'; \
-                 script-src 'self' 'unsafe-inline'; \
-                 object-src 'none'; base-uri 'self'; frame-ancestors 'self'",
-            ),
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            csp_middleware,
         ))
         .with_state(state)
 }
@@ -8314,6 +8362,7 @@ async fn show_group_book_form(
         Ok(t) => t,
         Err(e) => return internal_error_html("internal", &e),
     };
+    let captcha = captcha::CaptchaVars::from_config(&*state.captcha_config.read().await);
     let rendered = tmpl
         .render(context! {
             event_type => context! {
@@ -8338,6 +8387,9 @@ async fn show_group_book_form(
             invite_token => query.invite.as_deref().unwrap_or(""),
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            captcha_enabled => captcha.enabled,
+            captcha_api_endpoint => captcha.api_endpoint,
+            captcha_widget_url => captcha.widget_url,
             lang => lang,
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
@@ -8356,6 +8408,20 @@ async fn handle_group_booking(
         return resp;
     }
     let lang = crate::i18n::detect_from_headers(&headers);
+    let captcha_cfg = state.captcha_config.read().await;
+    if captcha::verify(&captcha_cfg, form.captcha_token.as_deref())
+        .await
+        .is_err()
+    {
+        tracing::warn!("captcha failed on group booking");
+        return render_booking_action_error(
+            &state,
+            &headers,
+            "Captcha verification failed",
+            "Please go back and try again.",
+        );
+    }
+    drop(captcha_cfg);
     // Rate limit by IP
     let client_ip = client_ip_for_rate_limit(&headers);
     if state.booking_limiter.check_limited(&client_ip).await {
@@ -9116,6 +9182,7 @@ async fn show_dynamic_group_book_form(
         Ok(t) => t,
         Err(e) => return internal_error_html("internal", &e),
     };
+    let captcha = captcha::CaptchaVars::from_config(&*state.captcha_config.read().await);
     Html(
         tmpl.render(context! {
             event_type => context! {
@@ -9140,6 +9207,9 @@ async fn show_dynamic_group_book_form(
             invite_token => "",
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            captcha_enabled => captcha.enabled,
+            captcha_api_endpoint => captcha.api_endpoint,
+            captcha_widget_url => captcha.widget_url,
             lang => lang,
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e)),
@@ -9828,6 +9898,7 @@ async fn show_book_form_for_user(
         Ok(t) => t,
         Err(e) => return internal_error_html("internal", &e),
     };
+    let captcha = captcha::CaptchaVars::from_config(&*state.captcha_config.read().await);
     let rendered = tmpl
         .render(context! {
             event_type => context! {
@@ -9852,6 +9923,9 @@ async fn show_book_form_for_user(
             invite_token => query.invite.as_deref().unwrap_or(""),
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            captcha_enabled => captcha.enabled,
+            captcha_api_endpoint => captcha.api_endpoint,
+            captcha_widget_url => captcha.widget_url,
             lang => lang,
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
@@ -9868,6 +9942,20 @@ async fn handle_booking_for_user(
     if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
         return resp;
     }
+    let captcha_cfg = state.captcha_config.read().await;
+    if captcha::verify(&captcha_cfg, form.captcha_token.as_deref())
+        .await
+        .is_err()
+    {
+        tracing::warn!("captcha failed on user booking");
+        return render_booking_action_error(
+            &state,
+            &headers,
+            "Captcha verification failed",
+            "Please go back and try again.",
+        );
+    }
+    drop(captcha_cfg);
     if username.contains('+') {
         return handle_dynamic_group_booking(&state, &headers, &username, &slug, &form).await;
     }
@@ -11764,6 +11852,7 @@ async fn show_book_form(
         Ok(t) => t,
         Err(e) => return internal_error_html("internal", &e),
     };
+    let captcha = captcha::CaptchaVars::from_config(&*state.captcha_config.read().await);
     let rendered = tmpl
         .render(context! {
             event_type => context! {
@@ -11784,6 +11873,9 @@ async fn show_book_form(
             form_notes => "",
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
+            captcha_enabled => captcha.enabled,
+            captcha_api_endpoint => captcha.api_endpoint,
+            captcha_widget_url => captcha.widget_url,
             lang => lang,
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
@@ -11882,6 +11974,8 @@ struct BookForm {
     invite_token: Option<String>,
     #[serde(default)]
     additional_guests: Option<String>,
+    #[serde(rename = "cap-token", default)]
+    captcha_token: Option<String>,
 }
 
 async fn handle_booking(
@@ -11894,6 +11988,20 @@ async fn handle_booking(
         return resp;
     }
     let lang = crate::i18n::detect_from_headers(&headers);
+    let captcha_cfg = state.captcha_config.read().await;
+    if captcha::verify(&captcha_cfg, form.captcha_token.as_deref())
+        .await
+        .is_err()
+    {
+        tracing::warn!("captcha failed on booking");
+        return render_booking_action_error(
+            &state,
+            &headers,
+            "Captcha verification failed",
+            "Please go back and try again.",
+        );
+    }
+    drop(captcha_cfg);
     // Rate limit by IP
     let client_ip = client_ip_for_rate_limit(&headers);
     if state.booking_limiter.check_limited(&client_ip).await {
@@ -13007,6 +13115,22 @@ async fn admin_dashboard(
         version => env!("CARGO_PKG_VERSION"),
     };
 
+    let captcha_cfg = state.captcha_config.read().await;
+    let captcha_configured = captcha_cfg.is_some();
+    let captcha_instance_url = captcha_cfg
+        .as_ref()
+        .map(|c| c.instance_url.clone())
+        .unwrap_or_default();
+    let captcha_site_key = captcha_cfg
+        .as_ref()
+        .map(|c| c.site_key.clone())
+        .unwrap_or_default();
+    let captcha_widget_url = captcha_cfg
+        .as_ref()
+        .map(|c| c.widget_url.clone())
+        .unwrap_or_else(|| captcha::DEFAULT_WIDGET_URL.to_string());
+    drop(captcha_cfg);
+
     Html(
         tmpl.render(context! {
             current_user_id => current_user.id,
@@ -13030,6 +13154,10 @@ async fn admin_dashboard(
             smtp_enabled => smtp_enabled,
             smtp_from_env => smtp_from_env,
             smtp_error => smtp_error,
+            captcha_configured => captcha_configured,
+            captcha_instance_url => captcha_instance_url,
+            captcha_site_key => captcha_site_key,
+            captcha_widget_url => captcha_widget_url,
             has_logo => state.data_dir.join("logo.png").exists(),
             company_link => get_company_link(&state.pool).await.unwrap_or_default(),
             current_theme => get_theme_name(&state.pool).await,
@@ -13613,6 +13741,75 @@ async fn google_callback(
         Redirect::to("/dashboard/sources")
     };
     (headers, redirect).into_response()
+}
+
+// --- Captcha settings ---
+
+#[derive(Deserialize)]
+struct AdminCaptchaForm {
+    _csrf: Option<String>,
+    captcha_instance_url: Option<String>,
+    captcha_site_key: Option<String>,
+    captcha_secret: Option<String>,
+    captcha_widget_url: Option<String>,
+}
+
+async fn admin_update_captcha(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminCaptchaForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    let instance_url = form
+        .captcha_instance_url
+        .filter(|s| !s.trim().is_empty());
+    let site_key = form.captcha_site_key.filter(|s| !s.trim().is_empty());
+    let widget_url = form.captcha_widget_url.filter(|s| !s.trim().is_empty());
+
+    let secret_provided = form
+        .captcha_secret
+        .as_ref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+
+    if secret_provided {
+        let secret = form.captcha_secret.unwrap_or_default();
+        let encrypted = match crate::crypto::encrypt_value(&state.secret_key, &secret) {
+            Ok(s) => s,
+            Err(e) => return internal_error_response("encrypt captcha secret", &e),
+        };
+        let _ = sqlx::query(
+            "UPDATE auth_config SET captcha_instance_url = ?, captcha_site_key = ?, captcha_secret = ?, captcha_widget_url = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(&instance_url)
+        .bind(&site_key)
+        .bind(&encrypted)
+        .bind(&widget_url)
+        .execute(&state.pool)
+        .await;
+    } else {
+        let _ = sqlx::query(
+            "UPDATE auth_config SET captcha_instance_url = ?, captcha_site_key = ?, captcha_widget_url = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(&instance_url)
+        .bind(&site_key)
+        .bind(&widget_url)
+        .execute(&state.pool)
+        .await;
+    }
+
+    let new_config = captcha::load_captcha_config(&state.pool, &state.secret_key).await;
+    let new_csp = build_csp(&new_config);
+    *state.captcha_config.write().await = new_config;
+    *state.csp.write().await = new_csp;
+
+    tracing::info!(admin = %_admin.0.email, "admin: captcha config updated");
+
+    Redirect::to("/dashboard/admin").into_response()
 }
 
 // --- Logo management ---
@@ -23977,5 +24174,59 @@ mod tests {
             "Mary Smith"
         );
         assert_eq!(derive_name_from_email("alice@example.com"), "Alice");
+    }
+
+    // --- build_csp tests ---
+
+    fn make_captcha_config(instance_url: &str, widget_url: &str) -> captcha::CaptchaConfig {
+        captcha::CaptchaConfig {
+            instance_url: instance_url.to_string(),
+            site_key: "testkey".to_string(),
+            secret: "secret".to_string(),
+            widget_url: widget_url.to_string(),
+        }
+    }
+
+    #[test]
+    fn build_csp_without_captcha_has_no_extra_directives() {
+        let csp = build_csp(&None);
+        assert!(!csp.contains("wasm-unsafe-eval"));
+        assert!(!csp.contains("worker-src"));
+        assert!(!csp.contains("cdn.jsdelivr.net"));
+        assert!(csp.contains("script-src 'self' 'unsafe-inline'"));
+        assert!(csp.contains("connect-src 'self'"));
+    }
+
+    #[test]
+    fn build_csp_with_captcha_includes_wasm_and_worker_src() {
+        let cfg = Some(make_captcha_config(
+            "https://cap.example.com",
+            captcha::DEFAULT_WIDGET_URL,
+        ));
+        let csp = build_csp(&cfg);
+        assert!(csp.contains("'wasm-unsafe-eval'"));
+        assert!(csp.contains("worker-src blob:"));
+    }
+
+    #[test]
+    fn build_csp_with_captcha_includes_script_origin() {
+        let cfg = Some(make_captcha_config(
+            "https://cap.example.com",
+            captcha::DEFAULT_WIDGET_URL,
+        ));
+        let csp = build_csp(&cfg);
+        assert!(csp.contains("https://cdn.jsdelivr.net"), "{}", csp);
+    }
+
+    #[test]
+    fn build_csp_with_captcha_includes_connect_origins() {
+        let cfg = Some(make_captcha_config(
+            "https://cap.example.com",
+            captcha::DEFAULT_WIDGET_URL,
+        ));
+        let csp = build_csp(&cfg);
+        assert!(csp.contains("connect-src 'self'"), "{}", csp);
+        assert!(csp.contains("https://cap.example.com"), "{}", csp);
+        assert!(csp.contains("https://cdn.jsdelivr.net"), "{}", csp);
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -92,7 +92,12 @@ pub struct AppState {
     pub theme_css: tokio::sync::RwLock<String>,
     pub company_link: tokio::sync::RwLock<Option<String>>,
     pub captcha_config: tokio::sync::RwLock<Option<captcha::CaptchaConfig>>,
+    /// CSP for booking form pages: relaxed with captcha origins when captcha
+    /// is enabled, identical to `csp_baseline` otherwise. Rebuilt on admin save.
     pub csp: tokio::sync::RwLock<String>,
+    /// Strict baseline CSP served on every non-booking page regardless of
+    /// captcha configuration.
+    pub csp_baseline: String,
 }
 
 // --- CSRF protection (double-submit cookie pattern) ---
@@ -859,17 +864,29 @@ fn build_csp(captcha: &Option<captcha::CaptchaConfig>) -> String {
     )
 }
 
+/// Booking form pages (`…/book`) are the only pages that embed the captcha
+/// widget, so they are the only ones that get the relaxed CSP when captcha is
+/// enabled. Every other page keeps the strict baseline policy.
+fn is_booking_form_path(path: &str) -> bool {
+    path.ends_with("/book")
+}
+
 async fn csp_middleware(
     State(state): State<Arc<AppState>>,
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
+    let booking_page = is_booking_form_path(request.uri().path());
     let mut response = next.run(request).await;
     if !response
         .headers()
         .contains_key(axum::http::header::CONTENT_SECURITY_POLICY)
     {
-        let csp = state.csp.read().await.clone();
+        let csp = if booking_page {
+            state.csp.read().await.clone()
+        } else {
+            state.csp_baseline.clone()
+        };
         if let Ok(val) = axum::http::HeaderValue::from_str(&csp) {
             response
                 .headers_mut()
@@ -902,6 +919,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         company_link: tokio::sync::RwLock::new(initial_company_link),
         captcha_config: tokio::sync::RwLock::new(initial_captcha),
         csp: tokio::sync::RwLock::new(initial_csp),
+        csp_baseline: build_csp(&None),
     });
 
     Router::new()
@@ -1153,6 +1171,10 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         // theme toggle, time-zone banner) and inline `style="..."` attributes.
         // Tightening this would require nonces wired through every render
         // site or a sweep across templates to externalize inline blocks.
+        //
+        // The CSP itself is set by `csp_middleware`: booking form pages
+        // (`…/book`) get the captcha-relaxed policy when captcha is enabled,
+        // everything else always gets the strict baseline.
         .layer(SetResponseHeaderLayer::if_not_present(
             axum::http::header::X_FRAME_OPTIONS,
             axum::http::HeaderValue::from_static("SAMEORIGIN"),
@@ -24220,6 +24242,23 @@ mod tests {
         ));
         let csp = build_csp(&cfg);
         assert!(csp.contains("https://cdn.jsdelivr.net"), "{}", csp);
+    }
+
+    #[test]
+    fn booking_form_paths_get_relaxed_csp() {
+        assert!(is_booking_form_path("/u/alice/intro/book"));
+        assert!(is_booking_form_path("/team/sales/demo/book"));
+        assert!(is_booking_form_path("/intro/book"));
+    }
+
+    #[test]
+    fn non_booking_paths_keep_baseline_csp() {
+        assert!(!is_booking_form_path("/"));
+        assert!(!is_booking_form_path("/dashboard"));
+        assert!(!is_booking_form_path("/dashboard/admin"));
+        assert!(!is_booking_form_path("/u/alice/intro"));
+        assert!(!is_booking_form_path("/booking/cancel/sometoken"));
+        assert!(!is_booking_form_path("/u/alice/bookkeeping"));
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -13780,7 +13780,7 @@ async fn admin_update_captcha(
             Ok(s) => s,
             Err(e) => return internal_error_response("encrypt captcha secret", &e),
         };
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "UPDATE auth_config SET captcha_instance_url = ?, captcha_site_key = ?, captcha_secret = ?, captcha_widget_url = ?, updated_at = datetime('now') WHERE id = 'singleton'",
         )
         .bind(&instance_url)
@@ -13788,16 +13788,22 @@ async fn admin_update_captcha(
         .bind(&encrypted)
         .bind(&widget_url)
         .execute(&state.pool)
-        .await;
+        .await
+        {
+            tracing::error!(error = %e, "failed to save captcha config");
+        }
     } else {
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "UPDATE auth_config SET captcha_instance_url = ?, captcha_site_key = ?, captcha_widget_url = ?, updated_at = datetime('now') WHERE id = 'singleton'",
         )
         .bind(&instance_url)
         .bind(&site_key)
         .bind(&widget_url)
         .execute(&state.pool)
-        .await;
+        .await
+        {
+            tracing::error!(error = %e, "failed to save captcha config");
+        }
     }
 
     let new_config = captcha::load_captcha_config(&state.pool, &state.secret_key).await;

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -342,6 +342,36 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
   </form>
 </div>
 
+<!-- Captcha settings -->
+<div class="card">
+  <h2>Captcha</h2>
+  <div style="margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
+    Status: {% if captcha_configured %}<strong style="color: var(--success);">enabled</strong>{% else %}<span style="color: var(--text-muted);">disabled</span>{% endif %}
+    {% if captcha_instance_url %}&middot; Instance: <span style="color: var(--text-muted);">{{ captcha_instance_url }}</span>{% endif %}
+  </div>
+  <form method="post" action="/dashboard/admin/captcha">
+    <div class="form-group">
+      <label>Instance URL</label>
+      <input type="url" name="captcha_instance_url" value="{{ captcha_instance_url }}" placeholder="https://captcha.example.com">
+    </div>
+    <div class="form-group">
+      <label>Site key</label>
+      <input type="text" name="captcha_site_key" value="{{ captcha_site_key }}" placeholder="your-site-key">
+    </div>
+    <div class="form-group">
+      <label>Secret <span class="hint">(leave empty to keep current)</span></label>
+      <input type="password" name="captcha_secret" value="" placeholder="Leave empty to keep unchanged">
+    </div>
+    <div class="form-group">
+      <label>Widget script URL <span class="hint">(optional)</span></label>
+      <input type="url" name="captcha_widget_url" value="{{ captcha_widget_url }}" placeholder="https://cdn.jsdelivr.net/npm/cap-widget">
+      <span style="font-size: 0.8rem; color: var(--text-muted);">Override if the CDN is blocked. Changes take effect immediately after saving.</span>
+    </div>
+    <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.75rem;">Leave instance URL, site key and secret empty to disable captcha on booking pages.</p>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save captcha settings</button>
+  </form>
+</div>
+
 <!-- SMTP settings -->
 <div class="card">
   <h2>SMTP settings</h2>

--- a/templates/base.html
+++ b/templates/base.html
@@ -253,6 +253,15 @@
       color: var(--text-muted);
     }
     textarea { resize: vertical; min-height: 80px; }
+    cap-widget {
+      --cap-background: var(--surface);
+      --cap-border-color: var(--border);
+      --cap-color: var(--text);
+      --cap-checkbox-background: var(--surface-hover);
+      --cap-spinner-color: var(--text);
+      --cap-spinner-background-color: var(--border);
+      --cap-widget-width: 480px;
+    }
 
     .btn {
       display: inline-block;

--- a/templates/book.html
+++ b/templates/book.html
@@ -119,6 +119,27 @@
     </script>
     {% endif %}
 
+    {% if captcha_enabled %}
+    <div class="form-group">
+      <label>{{ t("captcha-label") }}</label>
+      <script src="{{ captcha_widget_url }}"></script>
+      <cap-widget
+        data-cap-api-endpoint="{{ captcha_api_endpoint }}"
+        data-cap-i18n-initial-state="{{ t('captcha-initial-state') }}"
+        data-cap-i18n-verifying-label="{{ t('captcha-verifying') }}"
+        data-cap-i18n-solved-label="{{ t('captcha-solved') }}"
+        data-cap-i18n-error-label="{{ t('captcha-error') }}"
+        data-cap-i18n-troubleshooting-label="{{ t('captcha-troubleshooting') }}"
+        data-cap-i18n-wasm-disabled="{{ t('captcha-wasm-disabled') }}"
+        data-cap-i18n-verify-aria-label="{{ t('captcha-verify-aria') }}"
+        data-cap-i18n-verifying-aria-label="{{ t('captcha-verifying-aria') }}"
+        data-cap-i18n-verified-aria-label="{{ t('captcha-verified-aria') }}"
+        data-cap-i18n-required-label="{{ t('captcha-required') }}"
+        data-cap-i18n-error-aria-label="{{ t('captcha-error-aria') }}"
+      ></cap-widget>
+    </div>
+    {% endif %}
+
     <button type="submit" class="btn">{{ t("book-confirm-button") }}</button>
   </form>
 </div>


### PR DESCRIPTION
Hello l'équipe,

J'ai récemment découvert le projet, et je compte mettre en production le projet ! 
Mais il me manquait une petite chose pour combler tout mes besoins : un système de CAPTCHA pour éviter les robots.
Le Rate Limiter empêchant uniquement les requêtes massives. 

Résumé : 

  - Ajoute une intégration Cap (captcha proof-of-work, self-hébergé, sans tracking tiers) sur toutes
  les pages de réservation
  - Fonctionnalité opt-in : sans configuration, le flow de réservation est inchangé. Aucun widget,
  aucun appel réseau
  - Le secret Cap est chiffré au repos avec AES-256-GCM (même pattern que les secrets OIDC et Google
  OAuth2)
  - CSP dynamique : reconstruite en mémoire à chaque sauvegarde admin, sans redémarrage du serveur

  Implémentation : 

  - `src/web/captcha.rs` — module autonome : CaptchaConfig, CaptchaVars (variables template),
  load_captcha_config(), verify(), tests unitaires
  - `src/web/mod.rs` — AppState étendu avec captcha_config: RwLock<Option<CaptchaConfig>> et csp:
  RwLock<String> ; build_csp() et csp_middleware() pour la CSP dynamique ; vérification captcha
  ajoutée dans les 3 handlers POST booking ; handler admin_update_captcha
  - `migrations/054_captcha.sql `— 4 colonnes sur auth_config : captcha_instance_url, captcha_site_key,
  captcha_secret, captcha_widget_url
  -` templates/` : section Captcha dans admin.html, widget conditionnel dans book.html, overrides CSS
  dans base.html (s'adapte automatiquement au dark mode et aux thèmes custom)
  - `i18n` : 12 clés captcha-* dans EN, FR, DE, ES, IT, PL

  Test plan :

  - [x] cargo build
  - [x] cargo test (695 tests, dont 4 nouveaux sur build_csp et 8 sur captcha.rs)
  - [x] Sans captcha configuré : flow de réservation intact, pas de widget, Content-Security-Policy
  en mode strict baseline
  - [x] Configurer une instance Cap dans Admin → Captcha : widget visible sur toutes les pages de
  réservation (/u/, /team/, legacy /{slug})
  - [x] Soumettre une réservation sans compléter le widget → bloqué sur la page d'erreur
  - [x] Soumettre après validation du widget → réservation créée normalement
  - [x] Vider les champs et sauvegarder → captcha désactivé, Content-Security-Policy revient au
  baseline immédiatement
