### PR TITLE
feat(caldav): allow private/reserved CalDAV hosts via CALRS_ALLOW_PRIVATE_HOSTS

### DIFF
--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -117,6 +117,16 @@ CalDAV source URLs are user-supplied. `validate_caldav_url()` blocks URLs whose 
 
 This check resolves the hostname once at validation time, so a DNS-rebinding attacker who answers the initial lookup with a public IP and a subsequent lookup (during the actual HTTP fetch) with a private IP can bypass the guard. Mitigating this purely at the application layer would require inspecting the connected socket's peer address after every TCP handshake, which is outside the scope of the current implementation. The recommended deployment posture is therefore an **egress firewall** that prevents calrs from reaching RFC1918 / link-local ranges regardless of what DNS returns.
 
+#### Allowing private CalDAV hosts (self-hosting)
+
+Self-hosted deployments often run calrs and the CalDAV server on the same private network (e.g. a docker-compose stack where `http://radicale:5232` resolves to an RFC1918 address). To permit specific hostnames to resolve to private/reserved IPs, set the `CALRS_ALLOW_PRIVATE_HOSTS` environment variable to a comma-separated list of hostnames (or literal IPs):
+
+```
+CALRS_ALLOW_PRIVATE_HOSTS=radicale,nextcloud.local,127.0.0.1
+```
+
+Matching is case-insensitive and exact (no wildcards or subdomain matching). Only the listed hosts bypass the private-IP check; every other host is still validated. Keep this list as small as possible, scheme validation (http/https only) still applies.
+
 In a trusted multi-user deployment (e.g., behind OIDC) this is low risk. For public-registration instances, configure egress filtering at the network level.
 
 ## Recommendations for production

--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -42,7 +42,30 @@ fn is_private_ip(ip: &IpAddr) -> bool {
     }
 }
 
+/// Parse the `CALRS_ALLOW_PRIVATE_HOSTS` env var into a list of hostnames that
+/// are permitted to resolve to private/reserved IPs. Comma-separated,
+/// whitespace-trimmed, case-insensitive. Empty entries are ignored.
+fn private_host_allowlist() -> Vec<String> {
+    std::env::var("CALRS_ALLOW_PRIVATE_HOSTS")
+        .unwrap_or_default()
+        .split(',')
+        .map(|h| h.trim().to_ascii_lowercase())
+        .filter(|h| !h.is_empty())
+        .collect()
+}
+
+/// Whether `host` is in the configured private-host allowlist (case-insensitive).
+fn is_host_allowlisted(host: &str, allowlist: &[String]) -> bool {
+    let host = host.to_ascii_lowercase();
+    allowlist.contains(&host)
+}
+
 /// Validate a CalDAV URL: must be http(s), must not resolve to a private IP.
+///
+/// Self-hosted deployments (e.g. calrs and Radicale on the same docker network)
+/// can opt specific hostnames out of the private-IP check via the
+/// `CALRS_ALLOW_PRIVATE_HOSTS` env var (comma-separated hostnames). The check
+/// stays active for every other host.
 ///
 /// Limitation: this resolves the hostname once at validation time. A DNS
 /// rebinding attacker who returns a public IP for the initial lookup and a
@@ -64,6 +87,12 @@ pub fn validate_caldav_url(url: &str) -> Result<()> {
     let host = parsed
         .host_str()
         .ok_or_else(|| anyhow::anyhow!("URL has no host"))?;
+
+    // Hosts the operator has explicitly opted out of the private-IP check.
+    let allowlist = private_host_allowlist();
+    if is_host_allowlisted(host, &allowlist) {
+        return Ok(());
+    }
 
     // Try parsing as IP directly
     if let Ok(ip) = host.parse::<IpAddr>() {
@@ -1498,5 +1527,45 @@ END:VCALENDAR</c:calendar-data>
 
         let principal = client.discover_principal().await.unwrap();
         assert_eq!(principal, url);
+    }
+
+    // --- private-host allowlist (SSRF opt-out) ---
+
+    #[test]
+    fn allowlist_matches_case_insensitively() {
+        let list = vec!["radicale".to_string(), "nextcloud.local".to_string()];
+        assert!(is_host_allowlisted("radicale", &list));
+        assert!(is_host_allowlisted("RADICALE", &list));
+        assert!(is_host_allowlisted("Nextcloud.Local", &list));
+        assert!(!is_host_allowlisted("evil.example.com", &list));
+        assert!(!is_host_allowlisted("radicale.example.com", &list));
+    }
+
+    #[test]
+    fn empty_allowlist_matches_nothing() {
+        assert!(!is_host_allowlisted("radicale", &[]));
+    }
+
+    /// All env-var assertions live in one test: Rust runs tests in parallel
+    /// within a process, so a second test touching the same env var would race.
+    #[test]
+    fn allowlist_env_var_opts_host_out_of_private_ip_check() {
+        // Loopback literal is rejected by default.
+        std::env::remove_var("CALRS_ALLOW_PRIVATE_HOSTS");
+        assert!(private_host_allowlist().is_empty());
+        assert!(validate_caldav_url("http://127.0.0.1:5232").is_err());
+
+        // ...but allowed once its host is on the allowlist.
+        std::env::set_var("CALRS_ALLOW_PRIVATE_HOSTS", " 127.0.0.1 , radicale ");
+        assert_eq!(private_host_allowlist(), vec!["127.0.0.1", "radicale"]);
+        assert!(validate_caldav_url("http://127.0.0.1:5232").is_ok());
+
+        // Non-http schemes are still rejected even when host is allowlisted.
+        assert!(validate_caldav_url("ftp://127.0.0.1:5232").is_err());
+
+        // A host not on the allowlist still gets the private-IP check.
+        assert!(validate_caldav_url("http://10.0.0.1").is_err());
+
+        std::env::remove_var("CALRS_ALLOW_PRIVATE_HOSTS");
     }
 }


### PR DESCRIPTION
Closes #123.

Adds an opt-in allowlist for CalDAV hostnames permitted to resolve to private/reserved IPs, via the `CALRS_ALLOW_PRIVATE_HOSTS` env var (comma-separated, case-insensitive, exact match). This unblocks self-hosted docker-compose stacks where calrs and the CalDAV server (e.g. Radicale) share a private network.

- Default behavior unchanged: every non-listed host is still validated by `validate_caldav_url()`.
- Scheme check (http/https only) still applies even for allowlisted hosts.
- Exact matching only, no wildcards/subdomains.
- Docs updated in `security.md`; unit tests cover matching, env parsing, and the SSRF guard staying active for non-listed hosts.

Reported and locally verified by @aburg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)