### PR TITLE
Embed code generator (Inline, Float button, element Click)

### DIFF
--- a/assets/embed.js
+++ b/assets/embed.js
@@ -1,0 +1,184 @@
+/* calrs embed runtime — pasted into a host site and exposes window.Calrs.
+ *
+ * API:
+ *   Calrs.inline({ selector, link, config })
+ *   Calrs.floatingButton({ link, buttonText, buttonPosition, buttonColor, textColor, showIcon, config })
+ *   Calrs.elementClick()
+ *
+ * Where `link` is a full URL to a calrs booking page (e.g.
+ * "https://cal.example.com/u/alice/intro") and `config` is an object with
+ * optional `layout` ("month" | "week" | "column"), `theme` ("auto" | "light"
+ * | "dark"), and `brand` (hex color, with or without leading "#"). These end
+ * up as query parameters on the iframe src and feed into the embed-mode
+ * rendering on the calrs side.
+ */
+(function () {
+  if (window.Calrs) return;
+
+  function buildSrc(link, config) {
+    if (!link) return 'about:blank';
+    var url = link + (link.indexOf('?') >= 0 ? '&' : '?') + 'embed=1';
+    if (config) {
+      if (config.layout) url += '&layout=' + encodeURIComponent(config.layout);
+      if (config.theme) url += '&theme=' + encodeURIComponent(config.theme);
+      if (config.brand) {
+        var b = String(config.brand).replace(/^#/, '');
+        url += '&brand=' + encodeURIComponent(b);
+      }
+    }
+    return url;
+  }
+
+  function originOf(url) {
+    try { return new URL(url, location.href).origin; } catch (e) { return null; }
+  }
+
+  // Auto-size: parent listens for {type:'calrs:resize', height} from the
+  // booking page inside the iframe. The booking page emits this on load and
+  // whenever its content height changes. We accept messages only from the
+  // iframe's own origin and contentWindow to avoid trusting unrelated frames.
+  function attachResize(iframe) {
+    var iframeOrigin = originOf(iframe.src);
+    window.addEventListener('message', function (ev) {
+      if (!ev.data || ev.data.type !== 'calrs:resize') return;
+      if (iframeOrigin && ev.origin !== iframeOrigin) return;
+      if (ev.source !== iframe.contentWindow) return;
+      var h = Math.max(60, Math.floor(ev.data.height || 0)) + 8;
+      iframe.style.height = h + 'px';
+    });
+  }
+
+  // Single shared modal — reused by floatingButton and elementClick.
+  var modal = null;
+  function ensureModal() {
+    if (modal) return modal;
+    var overlay = document.createElement('div');
+    overlay.style.cssText =
+      'position:fixed;inset:0;z-index:2147483647;background:rgba(0,0,0,0.55);' +
+      'display:none;align-items:center;justify-content:center;padding:1rem;';
+    var box = document.createElement('div');
+    box.style.cssText =
+      'background:#fff;border-radius:12px;width:min(960px,100%);height:min(90vh,720px);' +
+      'overflow:hidden;position:relative;display:flex;flex-direction:column;' +
+      'box-shadow:0 20px 60px rgba(0,0,0,0.4);';
+    var close = document.createElement('button');
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Close');
+    close.innerHTML = '&times;';
+    close.style.cssText =
+      'position:absolute;top:0.5rem;right:0.5rem;width:34px;height:34px;border-radius:50%;' +
+      'border:0;background:rgba(0,0,0,0.06);color:#000;font-size:22px;line-height:1;' +
+      'cursor:pointer;z-index:2;';
+    close.addEventListener('click', closeModal);
+    var iframe = document.createElement('iframe');
+    iframe.style.cssText = 'flex:1;width:100%;border:0;display:block;';
+    iframe.setAttribute('allow', 'clipboard-write');
+    iframe.setAttribute('title', 'Booking');
+    box.appendChild(close);
+    box.appendChild(iframe);
+    overlay.appendChild(box);
+    overlay.addEventListener('click', function (ev) {
+      if (ev.target === overlay) closeModal();
+    });
+    document.addEventListener('keydown', function (ev) {
+      if (ev.key === 'Escape' && modal && modal.overlay.style.display !== 'none') closeModal();
+    });
+    document.body.appendChild(overlay);
+    modal = { overlay: overlay, iframe: iframe };
+    return modal;
+  }
+  function openModal(link, config) {
+    var m = ensureModal();
+    m.iframe.src = buildSrc(link, config);
+    m.overlay.style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+  }
+  function closeModal() {
+    if (!modal) return;
+    modal.overlay.style.display = 'none';
+    modal.iframe.src = 'about:blank';
+    document.body.style.overflow = '';
+  }
+
+  function calendarIcon() {
+    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '18');
+    svg.setAttribute('height', '18');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '2');
+    svg.setAttribute('stroke-linecap', 'round');
+    svg.setAttribute('stroke-linejoin', 'round');
+    svg.innerHTML =
+      '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>' +
+      '<line x1="16" y1="2" x2="16" y2="6"></line>' +
+      '<line x1="8" y1="2" x2="8" y2="6"></line>' +
+      '<line x1="3" y1="10" x2="21" y2="10"></line>';
+    return svg;
+  }
+
+  var Calrs = {
+    inline: function (opts) {
+      opts = opts || {};
+      var target = typeof opts.selector === 'string' ? document.querySelector(opts.selector) : opts.selector;
+      if (!target) return;
+      var iframe = document.createElement('iframe');
+      iframe.src = buildSrc(opts.link, opts.config);
+      iframe.style.cssText = 'width:100%;min-height:560px;border:0;display:block;';
+      iframe.setAttribute('loading', 'lazy');
+      iframe.setAttribute('title', 'Booking');
+      target.innerHTML = '';
+      target.appendChild(iframe);
+      attachResize(iframe);
+    },
+
+    floatingButton: function (opts) {
+      opts = opts || {};
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      var pos = opts.buttonPosition || 'bottom-right';
+      var bg = opts.buttonColor || '#2563eb';
+      var fg = opts.textColor || '#ffffff';
+      var positions = {
+        'bottom-right': 'bottom:1rem;right:1rem;',
+        'bottom-left':  'bottom:1rem;left:1rem;',
+        'top-right':    'top:1rem;right:1rem;',
+        'top-left':     'top:1rem;left:1rem;'
+      };
+      btn.style.cssText =
+        'position:fixed;' + (positions[pos] || positions['bottom-right']) +
+        'z-index:2147483646;padding:0.75rem 1.25rem;border:0;border-radius:999px;' +
+        'font-family:inherit;font-size:0.95rem;font-weight:600;cursor:pointer;' +
+        'display:inline-flex;align-items:center;gap:0.5rem;' +
+        'box-shadow:0 4px 14px rgba(0,0,0,0.15);' +
+        'background:' + bg + ';color:' + fg + ';';
+      if (opts.showIcon !== false) btn.appendChild(calendarIcon());
+      var label = document.createElement('span');
+      label.textContent = opts.buttonText || 'Book a meeting';
+      btn.appendChild(label);
+      btn.addEventListener('click', function () { openModal(opts.link, opts.config); });
+      document.body.appendChild(btn);
+    },
+
+    elementClick: function () {
+      document.addEventListener('click', function (ev) {
+        var el = ev.target.closest('[data-calrs-link]');
+        if (!el) return;
+        ev.preventDefault();
+        var raw = el.getAttribute('data-calrs-config');
+        var cfg = {};
+        if (raw) { try { cfg = JSON.parse(raw); } catch (e) {} }
+        openModal(el.getAttribute('data-calrs-link'), cfg);
+      });
+    }
+  };
+
+  window.Calrs = Calrs;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { Calrs.elementClick(); });
+  } else {
+    Calrs.elementClick();
+  }
+})();

--- a/assets/embed.js
+++ b/assets/embed.js
@@ -17,6 +17,10 @@
 
   function buildSrc(link, config) {
     if (!link) return 'about:blank';
+    // Drop any #fragment first: appending our query after it would fold the
+    // params into the fragment, so embed=1/layout/theme/brand would be lost.
+    var hashIdx = link.indexOf('#');
+    if (hashIdx >= 0) link = link.slice(0, hashIdx);
     var url = link + (link.indexOf('?') >= 0 ? '&' : '?') + 'embed=1';
     if (config) {
       if (config.layout) url += '&layout=' + encodeURIComponent(config.layout);
@@ -50,6 +54,8 @@
 
   // Single shared modal — reused by floatingButton and elementClick.
   var modal = null;
+  // Guards elementClick() against binding its document listener more than once.
+  var elementClickBound = false;
   function ensureModal() {
     if (modal) return modal;
     var overlay = document.createElement('div');
@@ -162,6 +168,10 @@
     },
 
     elementClick: function () {
+      // Idempotent: we auto-invoke on load AND expose this publicly, so a host
+      // page calling it manually must not bind the document listener twice.
+      if (elementClickBound) return;
+      elementClickBound = true;
       document.addEventListener('click', function (ev) {
         var el = ev.target.closest('[data-calrs-link]');
         if (!el) return;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -7389,8 +7389,8 @@ async fn group_embed_page(
         return Html("You are not a team admin of this team.".to_string()).into_response();
     }
 
-    let et: Option<(String, String, String, String, String)> = sqlx::query_as(
-        "SELECT et.slug, et.title, et.default_calendar_view, et.visibility, t.slug \
+    let et: Option<(String, String, String, String, String, String)> = sqlx::query_as(
+        "SELECT et.slug, et.title, et.default_calendar_view, et.visibility, t.slug, t.visibility \
          FROM event_types et \
          JOIN teams t ON t.id = et.team_id \
          WHERE et.team_id = ? AND et.slug = ?",
@@ -7401,10 +7401,11 @@ async fn group_embed_page(
     .await
     .unwrap_or(None);
 
-    let (et_slug, et_title, default_calendar_view, visibility, team_slug) = match et {
-        Some(e) => e,
-        None => return Redirect::to("/dashboard/event-types").into_response(),
-    };
+    let (et_slug, et_title, default_calendar_view, visibility, team_slug, team_visibility) =
+        match et {
+            Some(e) => e,
+            None => return Redirect::to("/dashboard/event-types").into_response(),
+        };
 
     let cal_path = format!("/team/{}/{}", team_slug, et_slug);
     let base_url = embed_base_url();
@@ -7430,6 +7431,7 @@ async fn group_embed_page(
             default_layout => default_calendar_view,
             accent_color => accent,
             visibility => visibility,
+            team_visibility => team_visibility,
             impersonating => impersonating,
             impersonating_name => impersonating_name,
         })

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -118,10 +118,22 @@ pub const CSRF_COOKIE_NAME: &str = "__Host-calrs_csrf";
 /// client JS in `base.html` to read the cookie and inject it into the form.
 /// `Secure` is set so the token never leaks over plaintext HTTP; modern
 /// browsers still honour `Secure` cookies on localhost for dev over HTTP.
+///
+/// `cross_site=true` switches the cookie to `SameSite=None` so the booking
+/// page can read it from inside a third-party iframe (the embed flow). The
+/// double-submit token-vs-cookie comparison still defends against CSRF — we
+/// never relied on SameSite for that. Browsers blocking all third-party
+/// cookies (Safari ITP, Chrome with 3P cookies disabled) still won't deliver
+/// it; that's an upstream-platform limitation outside our control.
 pub fn csrf_cookie_value(token: &str) -> String {
+    csrf_cookie_value_for(token, false)
+}
+
+pub fn csrf_cookie_value_for(token: &str, cross_site: bool) -> String {
+    let same_site = if cross_site { "None" } else { "Lax" };
     format!(
-        "{}={}; Path=/; Secure; SameSite=Lax; Max-Age=86400",
-        CSRF_COOKIE_NAME, token
+        "{}={}; Path=/; Secure; SameSite={}; Max-Age=86400",
+        CSRF_COOKIE_NAME, token, same_site
     )
 }
 
@@ -819,18 +831,120 @@ fn build_avail_schedule(all_rules: &[(i32, String, String)]) -> String {
         .join(";")
 }
 
+/// Query parameters that the embed-code generator threads into the booking
+/// flow. When `embed=1`, the booking pages drop their chrome (logo, footer,
+/// theme toggle) and emit a postMessage on load so the parent iframe can
+/// auto-size. The other fields are passed straight through to the templates
+/// as visual hints. None of them are persisted server-side — the embed code
+/// embeds them as URL params on every iframe load.
+#[derive(Deserialize, Default, Clone, Debug)]
+struct EmbedParams {
+    #[serde(default)]
+    embed: Option<String>,
+    #[serde(default)]
+    layout: Option<String>,
+    #[serde(default)]
+    theme: Option<String>,
+    #[serde(default)]
+    brand: Option<String>,
+}
+
+impl EmbedParams {
+    fn is_embedded(&self) -> bool {
+        matches!(self.embed.as_deref(), Some("1") | Some("true"))
+    }
+
+    /// Validated hex color suitable for inlining into a CSS variable. Returns
+    /// None if `brand` is missing, empty, or not 3/6 hex digits — we never
+    /// pass raw user input into CSS to avoid breaking out of the rule. The
+    /// leading "#" is added here; the wire format omits it (URLs use "#" as
+    /// the fragment delimiter).
+    fn brand_css(&self) -> Option<String> {
+        let raw = self.brand.as_deref()?.trim_start_matches('#');
+        let len = raw.len();
+        if (len == 3 || len == 6) && raw.chars().all(|c| c.is_ascii_hexdigit()) {
+            Some(format!("#{}", raw))
+        } else {
+            None
+        }
+    }
+
+    /// "?embed=1&layout=month&theme=dark&brand=ff0000" — used to keep params
+    /// alive across page transitions inside the iframe. Returns empty string
+    /// when not embedded so callers can unconditionally append it.
+    fn query_suffix(&self, leading_amp: bool) -> String {
+        if !self.is_embedded() {
+            return String::new();
+        }
+        let mut parts: Vec<String> = vec!["embed=1".to_string()];
+        if let Some(v) = self.layout.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("layout={}", urlencode_simple(v)));
+        }
+        if let Some(v) = self.theme.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("theme={}", urlencode_simple(v)));
+        }
+        if let Some(v) = self.brand.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("brand={}", urlencode_simple(v)));
+        }
+        let sep = if leading_amp { "&" } else { "?" };
+        format!("{}{}", sep, parts.join("&"))
+    }
+}
+
+/// Minimal URL-encoder for the small whitelist of values EmbedParams carries
+/// (slug-like layout names, theme tokens, hex colors). Keeps the helper
+/// dependency-free; if we ever accept richer values we can swap in `urlencoding`.
+fn urlencode_simple(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+/// Wrap an HTML render in a response. When `embed=1`, override the global
+/// `X-Frame-Options: SAMEORIGIN` so legacy browsers don't refuse the iframe.
+/// The matching `frame-ancestors *` CSP override is added by `csp_middleware`
+/// — that keeps the CSP composition (captcha allowances + embed framing) in
+/// one place. Modern browsers honour CSP's frame-ancestors over the legacy
+/// header per CSP Level 2.
+fn html_response(body: String, embed: &EmbedParams) -> Response {
+    let mut resp = Html(body).into_response();
+    if embed.is_embedded() {
+        // `ALLOWALL` is non-standard; modern browsers ignore it once CSP
+        // frame-ancestors is set, but it prevents the global SAMEORIGIN
+        // layer from re-asserting itself for browsers that don't speak CSP.
+        resp.headers_mut().insert(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("ALLOWALL"),
+        );
+    }
+    resp
+}
+
 /// Middleware that ensures a CSRF cookie is set on every response.
+///
+/// When the request URL carries `embed=1`, the cookie is issued with
+/// `SameSite=None; Secure` so the booking flow inside a third-party iframe
+/// can read its own cookie. Outside the embed flow, the strict `SameSite=Lax`
+/// default applies.
 async fn csrf_cookie_middleware(
     headers: HeaderMap,
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
+    let cross_site_cookie = is_embed_request(request.uri().query());
     let mut response = next.run(request).await;
 
     // Only set cookie if not already present in the request
     if csrf_token_from_headers(&headers).is_none() {
         let token = generate_csrf_token();
-        if let Ok(cookie_val) = csrf_cookie_value(&token).parse() {
+        if let Ok(cookie_val) = csrf_cookie_value_for(&token, cross_site_cookie).parse() {
             response
                 .headers_mut()
                 .append(axum::http::header::SET_COOKIE, cookie_val);
@@ -838,6 +952,16 @@ async fn csrf_cookie_middleware(
     }
 
     response
+}
+
+/// Detects the `embed=1` (or `embed=true`) query param without pulling in a
+/// full URL parser. Tolerates extra params and arbitrary parameter order.
+fn is_embed_request(query: Option<&str>) -> bool {
+    let Some(q) = query else { return false };
+    q.split('&').any(|pair| {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        k == "embed" && (v == "1" || v == "true")
+    })
 }
 
 fn build_csp(captcha: &Option<captcha::CaptchaConfig>) -> String {
@@ -877,15 +1001,25 @@ async fn csp_middleware(
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     let booking_page = is_booking_form_path(request.uri().path());
+    let embed_mode = is_embed_request(request.uri().query());
     let mut response = next.run(request).await;
     if !response
         .headers()
         .contains_key(axum::http::header::CONTENT_SECURITY_POLICY)
     {
-        let csp = if booking_page {
+        let strict = if booking_page {
             state.csp.read().await.clone()
         } else {
             state.csp_baseline.clone()
+        };
+        // In embed mode, swap the default `frame-ancestors 'self'` for `*` so
+        // the page can be loaded inside a third-party iframe. The replacement
+        // is safe because `build_csp` is the sole producer of the strict CSP
+        // string and always uses that exact directive.
+        let csp = if embed_mode {
+            strict.replace("frame-ancestors 'self'", "frame-ancestors *")
+        } else {
+            strict
         };
         if let Ok(val) = axum::http::HeaderValue::from_str(&csp) {
             response
@@ -988,6 +1122,8 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
             "/dashboard/event-types/{slug}/overrides/{override_id}/delete",
             post(delete_override),
         )
+        // Embed code generator
+        .route("/dashboard/event-types/{slug}/embed", get(embed_page))
         // Calendar source management
         .route(
             "/dashboard/sources/new",
@@ -1106,6 +1242,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/logo", get(serve_logo))
         .route("/accent.css", get(serve_accent_css))
         .route("/brand-logo", get(serve_brand_logo))
+        .route("/embed.js", get(serve_embed_js))
         .route("/fonts/inter-latin.woff2", get(serve_font_inter_latin))
         .route(
             "/fonts/inter-latin-ext.woff2",
@@ -1516,6 +1653,7 @@ async fn dashboard_event_types(
             toggle_url => format!("/dashboard/event-types/{}/toggle", slug),
             delete_url => format!("/dashboard/event-types/{}/delete", slug),
             overrides_url => format!("/dashboard/event-types/{}/overrides", slug),
+            embed_url => format!("/dashboard/event-types/{}/embed", slug),
             view_url => if vis != "private" { user.username.as_ref().map(|u| format!("/u/{}/{}", u, slug)) } else { None::<String> },
         });
     }
@@ -7042,6 +7180,77 @@ async fn delete_override(
     Redirect::to(&format!("/dashboard/event-types/{}/overrides", slug)).into_response()
 }
 
+/// Renders the embed code generator for a personal event type. The page is
+/// all client-side once rendered: changing form fields rebuilds the snippet
+/// and reloads the preview iframe — nothing is persisted server-side.
+async fn embed_page(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::auth::AuthUser,
+    Path(slug): Path<String>,
+) -> Response {
+    let user = &auth_user.user;
+
+    let et: Option<(String, String, String, String, String)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.default_calendar_view, et.visibility \
+         FROM event_types et \
+         JOIN accounts a ON a.id = et.account_id \
+         WHERE a.user_id = ? AND et.slug = ? AND et.team_id IS NULL",
+    )
+    .bind(&user.id)
+    .bind(&slug)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
+
+    let (_et_id, et_slug, et_title, default_calendar_view, visibility) = match et {
+        Some(e) => e,
+        None => return Redirect::to("/dashboard/event-types").into_response(),
+    };
+
+    // Username for the cal link path: /u/{username}/{slug}.
+    let username: String = user.username.clone().unwrap_or_else(|| user.id.clone());
+    let cal_path = format!("/u/{}/{}", username, et_slug);
+
+    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    let base_url = base_url.trim_end_matches('/').to_string();
+
+    // Pre-fill brand color from the org theme so the default snippet matches
+    // the rest of the site.
+    let accent: Option<String> =
+        sqlx::query_scalar("SELECT custom_accent FROM auth_config WHERE id = 'singleton'")
+            .fetch_optional(&state.pool)
+            .await
+            .ok()
+            .flatten();
+    let accent = accent
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "#2563eb".to_string());
+
+    let tmpl = match state.templates.get_template("embed.html") {
+        Ok(t) => t,
+        Err(e) => return internal_error_response("template render", &e),
+    };
+
+    let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
+
+    Html(
+        tmpl.render(context! {
+            sidebar => sidebar_context(&auth_user, "event-types"),
+            event_type_title => et_title,
+            event_type_slug => et_slug,
+            cal_path => cal_path,
+            base_url => base_url,
+            default_layout => default_calendar_view,
+            accent_color => accent,
+            visibility => visibility,
+            impersonating => impersonating,
+            impersonating_name => impersonating_name,
+        })
+        .unwrap_or_default(),
+    )
+    .into_response()
+}
+
 // --- Group event type handlers ---
 
 async fn new_group_event_type_form(
@@ -8178,7 +8387,8 @@ async fn show_group_slots(
     headers: HeaderMap,
     Path((team_slug, slug)): Path<(String, String)>,
     Query(query): Query<SlotsQuery>,
-) -> impl IntoResponse {
+) -> Response {
+    let embed = query.embed_params();
     let lang = crate::i18n::detect_from_headers(&headers);
     let et: Option<(String, String, String, Option<String>, i32, i32, i32, i32, String, Option<String>, String, String, String, String, Option<String>, String)> = sqlx::query_as(
         "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.location_type, et.location_value, t.name, et.visibility, et.scheduling_mode, t.visibility, t.invite_token, et.default_calendar_view
@@ -8211,7 +8421,7 @@ async fn show_group_slots(
         default_calendar_view,
     ) = match et {
         Some(e) => e,
-        None => return Html("Event type not found.".to_string()),
+        None => return Html("Event type not found.".to_string()).into_response(),
     };
 
     // Resolve the team id once and reuse for membership checks and downstream
@@ -8226,7 +8436,7 @@ async fn show_group_slots(
     .unwrap_or(None)
     {
         Some(tid) => tid,
-        None => return Html("Event type not found.".to_string()),
+        None => return Html("Event type not found.".to_string()).into_response(),
     };
 
     // Global admins can view any team event type (matches their management
@@ -8294,7 +8504,7 @@ async fn show_group_slots(
             // "Event type not found" response so we don't leak existence.
             "Event type not found."
         };
-        return Html(msg.to_string());
+        return Html(msg.to_string()).into_response();
     }
 
     // can_book: only with a valid booking invite for private/internal events.
@@ -8447,7 +8657,7 @@ async fn show_group_slots(
 
     let tmpl = match state.templates.get_template("slots.html") {
         Ok(t) => t,
-        Err(e) => return internal_error_html("internal", &e),
+        Err(e) => return internal_error_html("internal", &e).into_response(),
     };
     let rendered = tmpl
         .render(context! {
@@ -8477,14 +8687,19 @@ async fn show_group_slots(
             guest_tz => guest_tz_name,
             tz_options => tz_options,
             invite_token => query.invite.as_deref().unwrap_or(""),
-            default_calendar_view => default_calendar_view,
+            default_calendar_view => embed.layout.as_deref().filter(|s| !s.is_empty()).unwrap_or(default_calendar_view.as_str()),
             company_link => state.company_link.read().await.clone(),
             lang => lang,
             can_book => can_book,
+            embed => embed.is_embedded(),
+            embed_brand => embed.brand_css().unwrap_or_default(),
+            embed_theme => embed.theme.as_deref().unwrap_or(""),
+            embed_qs_amp => embed.query_suffix(true),
+            embed_qs_q => embed.query_suffix(false),
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
 
-    Html(rendered)
+    html_response(rendered, &embed)
 }
 
 async fn show_group_book_form(
@@ -8493,7 +8708,8 @@ async fn show_group_book_form(
     headers: HeaderMap,
     Path((team_slug, slug)): Path<(String, String)>,
     Query(query): Query<BookQuery>,
-) -> impl IntoResponse {
+) -> Response {
+    let embed = query.embed_params();
     let lang = crate::i18n::detect_from_headers(&headers);
     let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, String, i32, String, Option<String>, String)> = sqlx::query_as(
         "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, t.name, et.visibility, et.max_additional_guests, t.visibility, t.invite_token, t.id
@@ -8523,7 +8739,7 @@ async fn show_group_book_form(
         team_id,
     ) = match et {
         Some(e) => e,
-        None => return Html("Event type not found.".to_string()),
+        None => return Html("Event type not found.".to_string()).into_response(),
     };
 
     // Logged-in team members (and global admins) substitute for the team
@@ -8540,7 +8756,9 @@ async fn show_group_book_form(
     if visibility == "private" || visibility == "internal" {
         let token = match &query.invite {
             Some(t) => t,
-            None => return Html("This event type requires an invite link.".to_string()),
+            None => {
+                return Html("This event type requires an invite link.".to_string()).into_response()
+            }
         };
         let invite: Option<(String, String, Option<String>, i32, i32)> = sqlx::query_as(
             "SELECT guest_name, guest_email, expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
@@ -8552,15 +8770,16 @@ async fn show_group_book_form(
         .unwrap_or(None);
 
         match invite {
-            None => return Html("Invalid invite link.".to_string()),
+            None => return Html("Invalid invite link.".to_string()).into_response(),
             Some((name, email, expires_at, max_uses, used_count)) => {
                 if let Some(exp) = &expires_at {
                     if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
-                        return Html("This invite link has expired.".to_string());
+                        return Html("This invite link has expired.".to_string()).into_response();
                     }
                 }
                 if used_count >= max_uses {
-                    return Html("This invite link has already been used.".to_string());
+                    return Html("This invite link has already been used.".to_string())
+                        .into_response();
                 }
                 invite_guest_name = Some(name);
                 invite_guest_email = Some(email);
@@ -8571,7 +8790,7 @@ async fn show_group_book_form(
         // unless the viewer is a logged-in team member or global admin.
         let valid = matches!((&team_invite_token, &query.invite), (Some(expected), Some(provided)) if !provided.is_empty() && provided == expected);
         if !valid {
-            return Html("Event type not found.".to_string());
+            return Html("Event type not found.".to_string()).into_response();
         }
         invite_guest_name = None;
         invite_guest_email = None;
@@ -8585,11 +8804,11 @@ async fn show_group_book_form(
 
     let date = match NaiveDate::parse_from_str(&query.date, "%Y-%m-%d") {
         Ok(d) => d,
-        Err(_) => return Html("Invalid date format.".to_string()),
+        Err(_) => return Html("Invalid date format.".to_string()).into_response(),
     };
     let time = match NaiveTime::parse_from_str(&query.time, "%H:%M") {
         Ok(t) => t,
-        Err(_) => return Html("Invalid time format.".to_string()),
+        Err(_) => return Html("Invalid time format.".to_string()).into_response(),
     };
     let end_time = (date.and_time(time) + Duration::minutes(duration as i64))
         .time()
@@ -8599,7 +8818,7 @@ async fn show_group_book_form(
 
     let tmpl = match state.templates.get_template("book.html") {
         Ok(t) => t,
-        Err(e) => return internal_error_html("internal", &e),
+        Err(e) => return internal_error_html("internal", &e).into_response(),
     };
     let captcha = captcha::CaptchaVars::from_config(&*state.captcha_config.read().await);
     let rendered = tmpl
@@ -8630,10 +8849,15 @@ async fn show_group_book_form(
             captcha_api_endpoint => captcha.api_endpoint,
             captcha_widget_url => captcha.widget_url,
             lang => lang,
+            embed => embed.is_embedded(),
+            embed_brand => embed.brand_css().unwrap_or_default(),
+            embed_theme => embed.theme.as_deref().unwrap_or(""),
+            embed_qs_amp => embed.query_suffix(true),
+            embed_qs_q => embed.query_suffix(false),
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
 
-    Html(rendered)
+    html_response(rendered, &embed)
 }
 
 async fn handle_group_booking(
@@ -8641,8 +8865,9 @@ async fn handle_group_booking(
     optional_auth: crate::auth::OptionalAuthUser,
     headers: axum::http::HeaderMap,
     Path((team_slug, slug)): Path<(String, String)>,
+    Query(embed): Query<EmbedParams>,
     Form(form): Form<BookForm>,
-) -> impl IntoResponse {
+) -> Response {
     if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
         return resp;
     }
@@ -9046,10 +9271,15 @@ async fn handle_group_booking(
             reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
+            embed => embed.is_embedded(),
+            embed_brand => embed.brand_css().unwrap_or_default(),
+            embed_theme => embed.theme.as_deref().unwrap_or(""),
+            embed_qs_amp => embed.query_suffix(true),
+            embed_qs_q => embed.query_suffix(false),
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
 
-    Html(rendered).into_response()
+    html_response(rendered, &embed)
 }
 
 // --- Group slot computation ---
@@ -9827,9 +10057,12 @@ async fn show_slots_for_user(
     headers: HeaderMap,
     Path((username, slug)): Path<(String, String)>,
     Query(query): Query<SlotsQuery>,
-) -> impl IntoResponse {
+) -> Response {
+    let embed = query.embed_params();
     if username.contains('+') {
-        return show_dynamic_group_slots(&state, &headers, &username, &slug, &query).await;
+        return show_dynamic_group_slots(&state, &headers, &username, &slug, &query)
+            .await
+            .into_response();
     }
 
     let user: Option<(
@@ -9848,7 +10081,7 @@ async fn show_slots_for_user(
 
     let (host_user_id, host_name, host_title, host_avatar_path, user_lang) = match user {
         Some(user) => user,
-        None => return Html("User not found.".to_string()),
+        None => return Html("User not found.".to_string()).into_response(),
     };
 
     let lang = crate::i18n::resolve(user_lang.as_deref(), &headers);
@@ -9880,7 +10113,7 @@ async fn show_slots_for_user(
         default_calendar_view,
     ) = match et {
         Some(e) => e,
-        None => return Html("Event type not found.".to_string()),
+        None => return Html("Event type not found.".to_string()).into_response(),
     };
 
     // Validate invite token for private event types
@@ -9889,7 +10122,9 @@ async fn show_slots_for_user(
     if visibility == "private" || visibility == "internal" {
         let token = match &query.invite {
             Some(t) => t,
-            None => return Html("This event type requires an invite link.".to_string()),
+            None => {
+                return Html("This event type requires an invite link.".to_string()).into_response()
+            }
         };
         let invite: Option<(String, String, Option<String>, i32, i32)> = sqlx::query_as(
             "SELECT guest_name, guest_email, expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
@@ -9901,15 +10136,16 @@ async fn show_slots_for_user(
         .unwrap_or(None);
 
         match invite {
-            None => return Html("Invalid invite link.".to_string()),
+            None => return Html("Invalid invite link.".to_string()).into_response(),
             Some((name, email, expires_at, max_uses, used_count)) => {
                 if let Some(exp) = &expires_at {
                     if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
-                        return Html("This invite link has expired.".to_string());
+                        return Html("This invite link has expired.".to_string()).into_response();
                     }
                 }
                 if used_count >= max_uses {
-                    return Html("This invite link has already been used.".to_string());
+                    return Html("This invite link has already been used.".to_string())
+                        .into_response();
                 }
                 invite_guest_name = Some(name);
                 invite_guest_email = Some(email);
@@ -9990,7 +10226,7 @@ async fn show_slots_for_user(
 
     let tmpl = match state.templates.get_template("slots.html") {
         Ok(t) => t,
-        Err(e) => return internal_error_html("internal", &e),
+        Err(e) => return internal_error_html("internal", &e).into_response(),
     };
     let rendered = tmpl
         .render(context! {
@@ -10022,13 +10258,18 @@ async fn show_slots_for_user(
             invite_token => query.invite.as_deref().unwrap_or(""),
             invite_guest_name => invite_guest_name.as_deref().unwrap_or(""),
             invite_guest_email => invite_guest_email.as_deref().unwrap_or(""),
-            default_calendar_view => default_calendar_view,
+            default_calendar_view => embed.layout.as_deref().filter(|s| !s.is_empty()).unwrap_or(default_calendar_view.as_str()),
             company_link => state.company_link.read().await.clone(),
             lang => lang,
+            embed => embed.is_embedded(),
+            embed_brand => embed.brand_css().unwrap_or_default(),
+            embed_theme => embed.theme.as_deref().unwrap_or(""),
+            embed_qs_amp => embed.query_suffix(true),
+            embed_qs_q => embed.query_suffix(false),
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
 
-    Html(rendered)
+    html_response(rendered, &embed)
 }
 
 async fn show_book_form_for_user(
@@ -10036,9 +10277,12 @@ async fn show_book_form_for_user(
     headers: HeaderMap,
     Path((username, slug)): Path<(String, String)>,
     Query(query): Query<BookQuery>,
-) -> impl IntoResponse {
+) -> Response {
+    let embed = query.embed_params();
     if username.contains('+') {
-        return show_dynamic_group_book_form(&state, &headers, &username, &slug, &query).await;
+        return show_dynamic_group_book_form(&state, &headers, &username, &slug, &query)
+            .await
+            .into_response();
     }
 
     let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32, Option<String>)> = sqlx::query_as(
@@ -10067,7 +10311,7 @@ async fn show_book_form_for_user(
         user_lang,
     ) = match et {
         Some(e) => e,
-        None => return Html("Event type not found.".to_string()),
+        None => return Html("Event type not found.".to_string()).into_response(),
     };
 
     let lang = crate::i18n::resolve(user_lang.as_deref(), &headers);
@@ -10078,7 +10322,9 @@ async fn show_book_form_for_user(
     if visibility == "private" || visibility == "internal" {
         let token = match &query.invite {
             Some(t) => t,
-            None => return Html("This event type requires an invite link.".to_string()),
+            None => {
+                return Html("This event type requires an invite link.".to_string()).into_response()
+            }
         };
         let invite: Option<(String, String, Option<String>, i32, i32)> = sqlx::query_as(
             "SELECT guest_name, guest_email, expires_at, max_uses, used_count FROM booking_invites WHERE token = ? AND event_type_id = ?",
@@ -10090,15 +10336,16 @@ async fn show_book_form_for_user(
         .unwrap_or(None);
 
         match invite {
-            None => return Html("Invalid invite link.".to_string()),
+            None => return Html("Invalid invite link.".to_string()).into_response(),
             Some((name, email, expires_at, max_uses, used_count)) => {
                 if let Some(exp) = &expires_at {
                     if exp < &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string() {
-                        return Html("This invite link has expired.".to_string());
+                        return Html("This invite link has expired.".to_string()).into_response();
                     }
                 }
                 if used_count >= max_uses {
-                    return Html("This invite link has already been used.".to_string());
+                    return Html("This invite link has already been used.".to_string())
+                        .into_response();
                 }
                 invite_guest_name = Some(name);
                 invite_guest_email = Some(email);
@@ -10121,11 +10368,11 @@ async fn show_book_form_for_user(
 
     let date = match NaiveDate::parse_from_str(&query.date, "%Y-%m-%d") {
         Ok(d) => d,
-        Err(_) => return Html("Invalid date format.".to_string()),
+        Err(_) => return Html("Invalid date format.".to_string()).into_response(),
     };
     let time = match NaiveTime::parse_from_str(&query.time, "%H:%M") {
         Ok(t) => t,
-        Err(_) => return Html("Invalid time format.".to_string()),
+        Err(_) => return Html("Invalid time format.".to_string()).into_response(),
     };
     let end_time = (date.and_time(time) + Duration::minutes(duration as i64))
         .time()
@@ -10135,7 +10382,7 @@ async fn show_book_form_for_user(
 
     let tmpl = match state.templates.get_template("book.html") {
         Ok(t) => t,
-        Err(e) => return internal_error_html("internal", &e),
+        Err(e) => return internal_error_html("internal", &e).into_response(),
     };
     let captcha = captcha::CaptchaVars::from_config(&*state.captcha_config.read().await);
     let rendered = tmpl
@@ -10166,18 +10413,24 @@ async fn show_book_form_for_user(
             captcha_api_endpoint => captcha.api_endpoint,
             captcha_widget_url => captcha.widget_url,
             lang => lang,
+            embed => embed.is_embedded(),
+            embed_brand => embed.brand_css().unwrap_or_default(),
+            embed_theme => embed.theme.as_deref().unwrap_or(""),
+            embed_qs_amp => embed.query_suffix(true),
+            embed_qs_q => embed.query_suffix(false),
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
 
-    Html(rendered)
+    html_response(rendered, &embed)
 }
 
 async fn handle_booking_for_user(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     Path((username, slug)): Path<(String, String)>,
+    Query(embed): Query<EmbedParams>,
     Form(form): Form<BookForm>,
-) -> impl IntoResponse {
+) -> Response {
     if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
         return resp;
     }
@@ -10196,7 +10449,9 @@ async fn handle_booking_for_user(
     }
     drop(captcha_cfg);
     if username.contains('+') {
-        return handle_dynamic_group_booking(&state, &headers, &username, &slug, &form).await;
+        return handle_dynamic_group_booking(&state, &headers, &username, &slug, &form)
+            .await
+            .into_response();
     }
     // Rate limit by IP
     let client_ip = client_ip_for_rate_limit(&headers);
@@ -10574,10 +10829,15 @@ async fn handle_booking_for_user(
             reschedule_notice_min => reschedule_notice_min,
             company_link => state.company_link.read().await.clone(),
             lang => lang,
+            embed => embed.is_embedded(),
+            embed_brand => embed.brand_css().unwrap_or_default(),
+            embed_theme => embed.theme.as_deref().unwrap_or(""),
+            embed_qs_amp => embed.query_suffix(true),
+            embed_qs_q => embed.query_suffix(false),
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e));
 
-    Html(rendered).into_response()
+    html_response(rendered, &embed)
 }
 
 // --- Slot computation (shared with CLI) ---
@@ -11462,6 +11722,25 @@ struct SlotsQuery {
     /// When "1", perform full sync + computation (AJAX callback for deferred loading)
     #[serde(default)]
     deferred: Option<String>,
+    #[serde(default)]
+    embed: Option<String>,
+    #[serde(default)]
+    layout: Option<String>,
+    #[serde(default)]
+    theme: Option<String>,
+    #[serde(default)]
+    brand: Option<String>,
+}
+
+impl SlotsQuery {
+    fn embed_params(&self) -> EmbedParams {
+        EmbedParams {
+            embed: self.embed.clone(),
+            layout: self.layout.clone(),
+            theme: self.theme.clone(),
+            brand: self.brand.clone(),
+        }
+    }
 }
 
 /// Parse a "YYYY-MM" month param, returning (year, month_1indexed). Defaults to current month in guest TZ.
@@ -12032,6 +12311,25 @@ struct BookQuery {
     tz: Option<String>,
     #[serde(default)]
     invite: Option<String>,
+    #[serde(default)]
+    embed: Option<String>,
+    #[serde(default)]
+    layout: Option<String>,
+    #[serde(default)]
+    theme: Option<String>,
+    #[serde(default)]
+    brand: Option<String>,
+}
+
+impl BookQuery {
+    fn embed_params(&self) -> EmbedParams {
+        EmbedParams {
+            embed: self.embed.clone(),
+            layout: self.layout.clone(),
+            theme: self.theme.clone(),
+            brand: self.brand.clone(),
+        }
+    }
 }
 
 async fn show_book_form(
@@ -14106,6 +14404,22 @@ async fn serve_brand_logo() -> impl IntoResponse {
         .header("Content-Type", "image/png")
         .header("Cache-Control", "public, max-age=86400")
         .body(axum::body::Body::from(BRAND_LOGO))
+        .unwrap_or_else(|_| axum::response::Response::new(axum::body::Body::empty()))
+        .into_response()
+}
+
+/// Serves the embed runtime that consumers paste into their own sites. It's
+/// loaded cross-origin, so we set permissive CORS — there's no auth state to
+/// leak. The contents are checked into `assets/embed.js` and baked into the
+/// binary via `include_str!`.
+async fn serve_embed_js() -> impl IntoResponse {
+    static EMBED_JS: &str = include_str!("../../assets/embed.js");
+    axum::response::Response::builder()
+        .status(200)
+        .header("Content-Type", "application/javascript; charset=utf-8")
+        .header("Cache-Control", "public, max-age=3600")
+        .header("Access-Control-Allow-Origin", "*")
+        .body(axum::body::Body::from(EMBED_JS))
         .unwrap_or_else(|_| axum::response::Response::new(axum::body::Body::empty()))
         .into_response()
 }
@@ -19258,6 +19572,32 @@ mod tests {
     }
 
     #[test]
+    fn csrf_cookie_embed_uses_samesite_none() {
+        let cookie = csrf_cookie_value_for("tok", true);
+        assert!(
+            cookie.contains("SameSite=None"),
+            "embed CSRF cookie must use SameSite=None for third-party iframes: {}",
+            cookie
+        );
+        assert!(
+            cookie.contains("; Secure"),
+            "embed CSRF cookie must still carry Secure: {}",
+            cookie
+        );
+    }
+
+    #[test]
+    fn is_embed_request_detects_flag() {
+        assert!(is_embed_request(Some("embed=1")));
+        assert!(is_embed_request(Some("embed=true")));
+        assert!(is_embed_request(Some("foo=bar&embed=1&baz=qux")));
+        assert!(!is_embed_request(Some("embed=0")));
+        assert!(!is_embed_request(Some("notembed=1")));
+        assert!(!is_embed_request(None));
+        assert!(!is_embed_request(Some("")));
+    }
+
+    #[test]
     fn csrf_token_from_headers_extracts_token() {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -24361,6 +24701,7 @@ mod tests {
                     edit_url => "/e/edit",
                     toggle_url => "/e/toggle",
                     overrides_url => "/e/overrides",
+                    embed_url => "/e/embed",
                     delete_url => "/e/delete",
                     view_url => "/e/view",
                 }],
@@ -24595,5 +24936,41 @@ mod tests {
         assert!(csp.contains("connect-src 'self'"), "{}", csp);
         assert!(csp.contains("https://cap.example.com"), "{}", csp);
         assert!(csp.contains("https://cdn.jsdelivr.net"), "{}", csp);
+    }
+
+    // Embed mode must preserve captcha allowances (so captcha-enabled
+    // deployments can still serve a working booking form inside iframes).
+    // `csp_middleware` does the swap via string replace on the strict CSP,
+    // so we verify the contract: the produced CSP keeps frame-ancestors
+    // exactly once and contains the expected substring for swapping.
+    #[test]
+    fn build_csp_contains_frame_ancestors_self_for_swap() {
+        assert_eq!(
+            build_csp(&None).matches("frame-ancestors 'self'").count(),
+            1
+        );
+        let cfg = Some(make_captcha_config(
+            "https://cap.example.com",
+            captcha::DEFAULT_WIDGET_URL,
+        ));
+        assert_eq!(build_csp(&cfg).matches("frame-ancestors 'self'").count(), 1);
+    }
+
+    #[test]
+    fn build_csp_embed_swap_preserves_captcha_allowances() {
+        let cfg = Some(make_captcha_config(
+            "https://cap.example.com",
+            captcha::DEFAULT_WIDGET_URL,
+        ));
+        let strict = build_csp(&cfg);
+        let embed_csp = strict.replace("frame-ancestors 'self'", "frame-ancestors *");
+        assert!(embed_csp.contains("frame-ancestors *"));
+        assert!(!embed_csp.contains("frame-ancestors 'self'"));
+        // Captcha allowances must survive the swap so the widget loads in an
+        // embedded booking form.
+        assert!(embed_csp.contains("'wasm-unsafe-eval'"));
+        assert!(embed_csp.contains("worker-src blob:"));
+        assert!(embed_csp.contains("https://cap.example.com"));
+        assert!(embed_csp.contains("https://cdn.jsdelivr.net"));
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -131,9 +131,16 @@ pub fn csrf_cookie_value(token: &str) -> String {
 
 pub fn csrf_cookie_value_for(token: &str, cross_site: bool) -> String {
     let same_site = if cross_site { "None" } else { "Lax" };
+    // In the cross-site (embed) case also mark the cookie `Partitioned` (CHIPS).
+    // Browsers that block unpartitioned third-party cookies (Safari 18.4+,
+    // Firefox 131+, Chrome with 3P cookies disabled) will then still deliver it
+    // inside the embed iframe, so the double-submit CSRF check keeps working.
+    // `Partitioned` requires `Secure` + `Path=/`, both already set, and is
+    // compatible with the `__Host-` prefix.
+    let partitioned = if cross_site { "; Partitioned" } else { "" };
     format!(
-        "{}={}; Path=/; Secure; SameSite={}; Max-Age=86400",
-        CSRF_COOKIE_NAME, token, same_site
+        "{}={}; Path=/; Secure; SameSite={}; Max-Age=86400{}",
+        CSRF_COOKIE_NAME, token, same_site, partitioned
     )
 }
 
@@ -854,19 +861,25 @@ impl EmbedParams {
         matches!(self.embed.as_deref(), Some("1") | Some("true"))
     }
 
-    /// Validated hex color suitable for inlining into a CSS variable. Returns
-    /// None if `brand` is missing, empty, or not 3/6 hex digits — we never
-    /// pass raw user input into CSS to avoid breaking out of the rule. The
-    /// leading "#" is added here; the wire format omits it (URLs use "#" as
-    /// the fragment delimiter).
+    /// Full set of accent CSS variable declarations derived from `brand`,
+    /// suitable for inlining inside a `:root, html.dark { … }` rule. Returns
+    /// None if `brand` is missing, empty, or not 3/6 hex digits — we never pass
+    /// raw user input into CSS to avoid breaking out of the rule.
+    ///
+    /// Besides `--accent`/`--accent-hover` (the brand hex), we derive the rgba
+    /// variants `--accent-subtle`/`--accent-border`/`--accent-muted` from the
+    /// same color so slot pills, borders and muted states pick up the brand
+    /// too — otherwise those would keep the org accent and render half-themed.
     fn brand_css(&self) -> Option<String> {
         let raw = self.brand.as_deref()?.trim_start_matches('#');
-        let len = raw.len();
-        if (len == 3 || len == 6) && raw.chars().all(|c| c.is_ascii_hexdigit()) {
-            Some(format!("#{}", raw))
-        } else {
-            None
-        }
+        let (r, g, b) = hex_to_rgb(raw)?;
+        Some(format!(
+            "--accent: #{hex}; --accent-hover: #{hex}; \
+             --accent-subtle: rgba({r},{g},{b},0.12); \
+             --accent-border: rgba({r},{g},{b},0.3); \
+             --accent-muted: rgba({r},{g},{b},0.5);",
+            hex = raw
+        ))
     }
 
     /// "?embed=1&layout=month&theme=dark&brand=ff0000" — used to keep params
@@ -889,6 +902,23 @@ impl EmbedParams {
         let sep = if leading_amp { "&" } else { "?" };
         format!("{}{}", sep, parts.join("&"))
     }
+}
+
+/// Parse a 3- or 6-digit hex color (no leading '#') into (r, g, b) decimal
+/// components. Returns None for any other length or non-hex input. A 3-digit
+/// value is expanded by doubling each nibble (e.g. "f30" → ff3300).
+fn hex_to_rgb(raw: &str) -> Option<(u8, u8, u8)> {
+    let full = match raw.len() {
+        3 if raw.chars().all(|c| c.is_ascii_hexdigit()) => {
+            raw.chars().flat_map(|c| [c, c]).collect::<String>()
+        }
+        6 if raw.chars().all(|c| c.is_ascii_hexdigit()) => raw.to_string(),
+        _ => return None,
+    };
+    let r = u8::from_str_radix(&full[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&full[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&full[4..6], 16).ok()?;
+    Some((r, g, b))
 }
 
 /// Minimal URL-encoder for the small whitelist of values EmbedParams carries
@@ -938,7 +968,8 @@ async fn csrf_cookie_middleware(
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    let cross_site_cookie = is_embed_request(request.uri().query());
+    let cross_site_cookie =
+        is_embedded_booking_request(request.uri().path(), request.uri().query());
     let mut response = next.run(request).await;
 
     // Only set cookie if not already present in the request
@@ -962,6 +993,67 @@ fn is_embed_request(query: Option<&str>) -> bool {
         let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
         k == "embed" && (v == "1" || v == "true")
     })
+}
+
+/// Public booking surfaces that may legitimately be loaded inside a
+/// third-party iframe.
+///
+/// SECURITY: this gates BOTH the relaxed `frame-ancestors *` CSP swap and the
+/// `SameSite=None` CSRF cookie. It must never match authenticated or sensitive
+/// surfaces (`/auth/...`, `/dashboard/...`, asset routes), otherwise those
+/// pages become frameable by any site — e.g. `/auth/login?embed=1` would be a
+/// fully functional login form inside an attacker's iframe (clickjacking /
+/// login CSRF). The embed=1 flag alone is NOT sufficient; the path must also
+/// be a booking surface.
+fn is_embeddable_path(path: &str) -> bool {
+    // Modern user/team booking routes (allowlist).
+    if path == "/u"
+        || path.starts_with("/u/")
+        || path == "/team"
+        || path.starts_with("/team/")
+        || path == "/g"
+        || path.starts_with("/g/")
+    {
+        return true;
+    }
+    // Legacy single-user booking pages: only `/{slug}` and `/{slug}/book`.
+    // Everything is a single top-level segment, so reject any path whose first
+    // segment is a reserved (non-booking) route. New reserved top-level routes
+    // must be added to RESERVED below to stay out of the embed surface.
+    let trimmed = path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return false;
+    }
+    let mut segs = trimmed.split('/');
+    let first = segs.next().unwrap_or("");
+    let rest: Vec<&str> = segs.collect();
+    let shape_ok = rest.is_empty() || (rest.len() == 1 && rest[0] == "book");
+    if !shape_ok {
+        return false;
+    }
+    const RESERVED: &[&str] = &[
+        "auth",
+        "dashboard",
+        "avatar",
+        "team-avatar",
+        "logo",
+        "accent.css",
+        "brand-logo",
+        "embed.js",
+        "fonts",
+        "t",
+        "booking",
+        "u",
+        "team",
+        "g",
+    ];
+    !RESERVED.contains(&first)
+}
+
+/// True when the request is both flagged `embed=1` and targets an embeddable
+/// booking surface. This is the single gate for embed-mode behavior changes.
+fn is_embedded_booking_request(path: &str, query: Option<&str>) -> bool {
+    is_embed_request(query) && is_embeddable_path(path)
 }
 
 fn build_csp(captcha: &Option<captcha::CaptchaConfig>) -> String {
@@ -1001,7 +1093,7 @@ async fn csp_middleware(
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     let booking_page = is_booking_form_path(request.uri().path());
-    let embed_mode = is_embed_request(request.uri().query());
+    let embed_mode = is_embedded_booking_request(request.uri().path(), request.uri().query());
     let mut response = next.run(request).await;
     if !response
         .headers()
@@ -7207,24 +7299,39 @@ async fn embed_page(
         None => return Redirect::to("/dashboard/event-types").into_response(),
     };
 
-    // Username for the cal link path: /u/{username}/{slug}.
-    let username: String = user.username.clone().unwrap_or_else(|| user.id.clone());
-    let cal_path = format!("/u/{}/{}", username, et_slug);
+    // Username for the cal link path: /u/{username}/{slug}. `users.username` is
+    // nullable (migration 003) and all /u/{username} lookups match on it, so a
+    // user without a username can't produce a working embed link. Rather than
+    // emit a snippet pointing at a 404, render the page with a notice and no
+    // snippet (has_username = false).
+    let username = user.username.clone().filter(|u| !u.is_empty());
+    let has_username = username.is_some();
+    let cal_path = match &username {
+        Some(u) => format!("/u/{}/{}", u, et_slug),
+        None => String::new(),
+    };
 
     let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
     let base_url = base_url.trim_end_matches('/').to_string();
 
-    // Pre-fill brand color from the org theme so the default snippet matches
-    // the rest of the site.
-    let accent: Option<String> =
-        sqlx::query_scalar("SELECT custom_accent FROM auth_config WHERE id = 'singleton'")
+    // Pre-fill brand color from the org theme so the default snippet matches the
+    // rest of the site. `custom_accent` is only meaningful when theme='custom';
+    // for a preset theme we resolve the preset's accent (same precedence as
+    // build_theme_css), otherwise the prefill would be stale or fall back to
+    // the default blue and not match the real org accent.
+    let theme_row: Option<(String, Option<String>)> =
+        sqlx::query_as("SELECT theme, custom_accent FROM auth_config WHERE id = 'singleton'")
             .fetch_optional(&state.pool)
             .await
-            .ok()
-            .flatten();
-    let accent = accent
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "#2563eb".to_string());
+            .unwrap_or(None);
+    let accent = match theme_row {
+        Some((ref theme, ref custom)) if theme == "custom" => custom
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "#2563eb".to_string()),
+        Some((ref theme, _)) => preset_accent(theme).to_string(),
+        None => "#2563eb".to_string(),
+    };
 
     let tmpl = match state.templates.get_template("embed.html") {
         Ok(t) => t,
@@ -7239,6 +7346,7 @@ async fn embed_page(
             event_type_title => et_title,
             event_type_slug => et_slug,
             cal_path => cal_path,
+            has_username => has_username,
             base_url => base_url,
             default_layout => default_calendar_view,
             accent_color => accent,
@@ -10059,6 +10167,10 @@ async fn show_slots_for_user(
     Query(query): Query<SlotsQuery>,
 ) -> Response {
     let embed = query.embed_params();
+    // Dynamic group pages (`alice+bob`) intentionally return before embed
+    // threading: embedding ad-hoc combined links is out of scope, so these
+    // render with full chrome and don't autosize. The embed generator only
+    // produces single-user/team links.
     if username.contains('+') {
         return show_dynamic_group_slots(&state, &headers, &username, &slug, &query)
             .await
@@ -12059,6 +12171,22 @@ fn preset_theme_css(theme: &str) -> &'static str {
         ),
         // "default" (blue) — no overrides needed, base.html defines it
         _ => "",
+    }
+}
+
+/// Light-mode accent hex for a preset theme, mirroring the `--accent` values in
+/// `preset_theme_css`. Used to prefill the embed brand color so it matches the
+/// org theme even when a preset (not a custom theme) is active.
+fn preset_accent(theme: &str) -> &'static str {
+    match theme {
+        "nord" => "#5e81ac",
+        "dracula" => "#bd93f9",
+        "gruvbox" => "#d65d0e",
+        "solarized" => "#268bd2",
+        "tokyo-night" => "#7a5af5",
+        "vates" => "#be1621",
+        // "default" (blue) and anything unknown
+        _ => "#2563eb",
     }
 }
 
@@ -19584,6 +19712,61 @@ mod tests {
             "embed CSRF cookie must still carry Secure: {}",
             cookie
         );
+        assert!(
+            cookie.contains("; Partitioned"),
+            "embed CSRF cookie must be Partitioned (CHIPS) for browsers blocking unpartitioned 3P cookies: {}",
+            cookie
+        );
+    }
+
+    #[test]
+    fn csrf_cookie_non_embed_is_samesite_lax_unpartitioned() {
+        let cookie = csrf_cookie_value_for("tok", false);
+        assert!(cookie.contains("SameSite=Lax"), "{}", cookie);
+        assert!(
+            !cookie.contains("Partitioned"),
+            "non-embed cookie must not be Partitioned: {}",
+            cookie
+        );
+    }
+
+    #[test]
+    fn hex_to_rgb_parses_3_and_6_digit() {
+        assert_eq!(hex_to_rgb("ff0000"), Some((255, 0, 0)));
+        assert_eq!(hex_to_rgb("2563eb"), Some((37, 99, 235)));
+        assert_eq!(hex_to_rgb("f30"), Some((255, 51, 0)));
+        assert_eq!(hex_to_rgb("fff"), Some((255, 255, 255)));
+        assert_eq!(hex_to_rgb(""), None);
+        assert_eq!(hex_to_rgb("12345"), None);
+        assert_eq!(hex_to_rgb("gggggg"), None);
+    }
+
+    #[test]
+    fn brand_css_derives_rgba_variants() {
+        let p = EmbedParams {
+            brand: Some("ff0000".to_string()),
+            ..Default::default()
+        };
+        let css = p.brand_css().expect("valid hex yields css");
+        assert!(css.contains("--accent: #ff0000"), "{}", css);
+        assert!(
+            css.contains("--accent-subtle: rgba(255,0,0,0.12)"),
+            "{}",
+            css
+        );
+        assert!(
+            css.contains("--accent-border: rgba(255,0,0,0.3)"),
+            "{}",
+            css
+        );
+        assert!(css.contains("--accent-muted: rgba(255,0,0,0.5)"), "{}", css);
+
+        // Invalid input yields no CSS (never inject raw user input).
+        let bad = EmbedParams {
+            brand: Some("red; } body{display:none".to_string()),
+            ..Default::default()
+        };
+        assert!(bad.brand_css().is_none());
     }
 
     #[test]
@@ -19595,6 +19778,46 @@ mod tests {
         assert!(!is_embed_request(Some("notembed=1")));
         assert!(!is_embed_request(None));
         assert!(!is_embed_request(Some("")));
+    }
+
+    #[test]
+    fn is_embeddable_path_allows_booking_surfaces_only() {
+        // Public booking surfaces — embeddable.
+        assert!(is_embeddable_path("/u/alice"));
+        assert!(is_embeddable_path("/u/alice/intro"));
+        assert!(is_embeddable_path("/u/alice/intro/book"));
+        assert!(is_embeddable_path("/team/sales"));
+        assert!(is_embeddable_path("/team/sales/intro"));
+        assert!(is_embeddable_path("/g/sales"));
+        // Legacy single-user booking pages.
+        assert!(is_embeddable_path("/intro"));
+        assert!(is_embeddable_path("/intro/book"));
+
+        // Sensitive / non-booking surfaces — never embeddable.
+        assert!(!is_embeddable_path("/auth/login"));
+        assert!(!is_embeddable_path("/auth/register"));
+        assert!(!is_embeddable_path("/dashboard"));
+        assert!(!is_embeddable_path("/dashboard/event-types"));
+        assert!(!is_embeddable_path("/dashboard/admin"));
+        assert!(!is_embeddable_path("/"));
+        assert!(!is_embeddable_path("/embed.js"));
+        assert!(!is_embeddable_path("/accent.css"));
+        assert!(!is_embeddable_path("/avatar/123"));
+        assert!(!is_embeddable_path("/booking/approve/tok"));
+    }
+
+    #[test]
+    fn embedded_booking_request_requires_both_flag_and_path() {
+        // The blocking issue: embed=1 on a sensitive path must NOT enable embed.
+        assert!(!is_embedded_booking_request("/auth/login", Some("embed=1")));
+        assert!(!is_embedded_booking_request("/dashboard", Some("embed=1")));
+        // Booking surface with the flag — enabled.
+        assert!(is_embedded_booking_request(
+            "/u/alice/intro",
+            Some("embed=1")
+        ));
+        // Booking surface without the flag — not embed mode.
+        assert!(!is_embedded_booking_request("/u/alice/intro", None));
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1330,6 +1330,10 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
             "/dashboard/group-event-types/{team_id}/{slug}/delete",
             post(delete_group_event_type),
         )
+        .route(
+            "/dashboard/group-event-types/{team_id}/{slug}/embed",
+            get(group_embed_page),
+        )
         // Serve logo and fonts
         .route("/logo", get(serve_logo))
         .route("/accent.css", get(serve_accent_css))
@@ -1773,6 +1777,7 @@ async fn dashboard_event_types(
             edit_url => format!("/dashboard/group-event-types/{}/{}/edit", team_id, slug),
             toggle_url => format!("/dashboard/group-event-types/{}/{}/toggle", team_id, slug),
             delete_url => format!("/dashboard/group-event-types/{}/{}/delete", team_id, slug),
+            embed_url => format!("/dashboard/group-event-types/{}/{}/embed", team_id, slug),
             overrides_url => format!("/dashboard/event-types/{}/overrides", slug),
             // Team event types always get a view link — logged-in team members
             // can view private/internal slots without an invite token.
@@ -7311,27 +7316,8 @@ async fn embed_page(
         None => String::new(),
     };
 
-    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
-    let base_url = base_url.trim_end_matches('/').to_string();
-
-    // Pre-fill brand color from the org theme so the default snippet matches the
-    // rest of the site. `custom_accent` is only meaningful when theme='custom';
-    // for a preset theme we resolve the preset's accent (same precedence as
-    // build_theme_css), otherwise the prefill would be stale or fall back to
-    // the default blue and not match the real org accent.
-    let theme_row: Option<(String, Option<String>)> =
-        sqlx::query_as("SELECT theme, custom_accent FROM auth_config WHERE id = 'singleton'")
-            .fetch_optional(&state.pool)
-            .await
-            .unwrap_or(None);
-    let accent = match theme_row {
-        Some((ref theme, ref custom)) if theme == "custom" => custom
-            .clone()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "#2563eb".to_string()),
-        Some((ref theme, _)) => preset_accent(theme).to_string(),
-        None => "#2563eb".to_string(),
-    };
+    let base_url = embed_base_url();
+    let accent = org_accent_hex(&state.pool).await;
 
     let tmpl = match state.templates.get_template("embed.html") {
         Ok(t) => t,
@@ -7347,6 +7333,99 @@ async fn embed_page(
             event_type_slug => et_slug,
             cal_path => cal_path,
             has_username => has_username,
+            base_url => base_url,
+            default_layout => default_calendar_view,
+            accent_color => accent,
+            visibility => visibility,
+            impersonating => impersonating,
+            impersonating_name => impersonating_name,
+        })
+        .unwrap_or_default(),
+    )
+    .into_response()
+}
+
+/// Absolute base URL for embed snippets: `CALRS_BASE_URL` without a trailing
+/// slash, or empty (the page then falls back to the dashboard's own origin).
+fn embed_base_url() -> String {
+    std::env::var("CALRS_BASE_URL")
+        .unwrap_or_default()
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Resolve the org accent hex for prefilling the embed brand color. Mirrors
+/// build_theme_css precedence: the preset's accent for a preset theme,
+/// `custom_accent` only when theme='custom', default blue otherwise.
+async fn org_accent_hex(pool: &SqlitePool) -> String {
+    let theme_row: Option<(String, Option<String>)> =
+        sqlx::query_as("SELECT theme, custom_accent FROM auth_config WHERE id = 'singleton'")
+            .fetch_optional(pool)
+            .await
+            .unwrap_or(None);
+    match theme_row {
+        Some((ref theme, ref custom)) if theme == "custom" => custom
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "#2563eb".to_string()),
+        Some((ref theme, _)) => preset_accent(theme).to_string(),
+        None => "#2563eb".to_string(),
+    }
+}
+
+/// Embed code generator for a team event type. Mirrors `embed_page` but the
+/// booking link is the team path `/team/{team_slug}/{event_slug}`, which is
+/// always well-formed (teams always have a slug), so there is no missing-link
+/// case. Access is restricted to team admins and global admins.
+async fn group_embed_page(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::auth::AuthUser,
+    Path((team_id, slug)): Path<(String, String)>,
+) -> Response {
+    let user = &auth_user.user;
+    let is_admin = user.role == "admin";
+
+    if !is_admin && !is_team_admin(&state.pool, &user.id, &team_id).await {
+        return Html("You are not a team admin of this team.".to_string()).into_response();
+    }
+
+    let et: Option<(String, String, String, String, String)> = sqlx::query_as(
+        "SELECT et.slug, et.title, et.default_calendar_view, et.visibility, t.slug \
+         FROM event_types et \
+         JOIN teams t ON t.id = et.team_id \
+         WHERE et.team_id = ? AND et.slug = ?",
+    )
+    .bind(&team_id)
+    .bind(&slug)
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
+
+    let (et_slug, et_title, default_calendar_view, visibility, team_slug) = match et {
+        Some(e) => e,
+        None => return Redirect::to("/dashboard/event-types").into_response(),
+    };
+
+    let cal_path = format!("/team/{}/{}", team_slug, et_slug);
+    let base_url = embed_base_url();
+    let accent = org_accent_hex(&state.pool).await;
+
+    let tmpl = match state.templates.get_template("embed.html") {
+        Ok(t) => t,
+        Err(e) => return internal_error_response("template render", &e),
+    };
+
+    let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
+
+    // Team event types always sit on a real team slug, so the embed link is
+    // never dead — has_username is always true here.
+    Html(
+        tmpl.render(context! {
+            sidebar => sidebar_context(&auth_user, "event-types"),
+            event_type_title => et_title,
+            event_type_slug => et_slug,
+            cal_path => cal_path,
+            has_username => true,
             base_url => base_url,
             default_layout => default_calendar_view,
             accent_color => accent,

--- a/templates/base.html
+++ b/templates/base.html
@@ -625,12 +625,12 @@ window.calrsFormat12h = function(time24) {
   if (window.parent === window) return;
   var lastH = 0;
   function send() {
-    var h = Math.max(
-      document.body.scrollHeight,
-      document.documentElement.scrollHeight,
-      document.body.offsetHeight,
-      document.documentElement.offsetHeight
-    );
+    // Measure body only — never documentElement. The root element's
+    // scrollHeight is coupled to the iframe viewport height set by the parent,
+    // which creates a runaway feedback loop (parent grows iframe → viewport
+    // grows → documentElement.scrollHeight grows → report larger → repeat).
+    // body uses min-height:0 in embed mode, so it tracks real content height.
+    var h = Math.max(document.body.scrollHeight, document.body.offsetHeight);
     if (Math.abs(h - lastH) < 4) return;
     lastH = h;
     try {

--- a/templates/base.html
+++ b/templates/base.html
@@ -446,11 +446,9 @@
     {% if embed_brand %}
     /* Apply the brand accent in both light and dark mode. The `html.dark`
        selector is needed to out-specify base.html's `html.dark` accent rule;
-       `:root` alone (lower specificity) would lose to it in dark mode. */
-    :root, html.dark {
-      --accent: {{ embed_brand }};
-      --accent-hover: {{ embed_brand }};
-    }
+       `:root` alone (lower specificity) would lose to it in dark mode. The
+       declarations (incl. derived rgba variants) come from EmbedParams. */
+    :root, html.dark { {{ embed_brand }} }
     {% endif %}
   </style>
   {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,8 +7,16 @@
   <title>{% block title %}calrs{% endblock %}</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦀</text></svg>">
   <script>
-  // Apply theme ASAP to avoid flash
-  (function(){var t=localStorage.getItem('calrs_theme');if(t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('dark');})();
+  // Apply theme ASAP to avoid flash. In embed mode the parent controls theme
+  // via ?theme= so we skip localStorage and respect the URL param only.
+  (function(){
+    var embed = {{ embed | default(false) | tojson }};
+    var embedTheme = {{ embed_theme | default("") | tojson }};
+    var t = embed ? embedTheme : (localStorage.getItem('calrs_theme') || '');
+    var prefersDark = matchMedia('(prefers-color-scheme:dark)').matches;
+    var dark = t === 'dark' || ((t === '' || t === 'auto' || t === 'system') && prefersDark);
+    if (dark) document.documentElement.classList.add('dark');
+  })();
   </script>
   <style>
     @font-face {
@@ -427,6 +435,25 @@
     }
   </style>
   <link rel="stylesheet" href="/accent.css">
+  {% if embed %}
+  <style>
+    /* Embed mode: drop the centered card frame so the host page controls the
+       canvas. The parent iframe sets its own width; we just need to fit the
+       content. */
+    body { padding: 1rem 0.75rem; background: transparent; display: block; min-height: 0; }
+    .container { max-width: none; }
+    .logo, .powered, .theme-pill, #theme-toggle { display: none !important; }
+    {% if embed_brand %}
+    /* Apply the brand accent in both light and dark mode. The `html.dark`
+       selector is needed to out-specify base.html's `html.dark` accent rule;
+       `:root` alone (lower specificity) would lose to it in dark mode. */
+    :root, html.dark {
+      --accent: {{ embed_brand }};
+      --accent-hover: {{ embed_brand }};
+    }
+    {% endif %}
+  </style>
+  {% endif %}
   {% block head %}{% endblock %}
 </head>
 <body>
@@ -526,11 +553,19 @@
 // Theme toggle (light / dark / system)
 (function() {
   var btn = document.getElementById('theme-toggle');
-  if (!btn) return;
-  function getTheme() { return localStorage.getItem('calrs_theme') || 'system'; }
+  // In embed mode the parent controls the theme via ?theme=, so we must read
+  // that instead of localStorage — otherwise this script would clobber the
+  // dark/light class the early head script already set from the URL param.
+  var embed = {{ embed | default(false) | tojson }};
+  var embedTheme = {{ embed_theme | default("") | tojson }};
+  function getTheme() {
+    if (embed) return embedTheme || 'system';
+    return localStorage.getItem('calrs_theme') || 'system';
+  }
+  function followsSystem(t) { return t === 'system' || t === 'auto' || t === ''; }
   function isDark() {
     var t = getTheme();
-    return t === 'dark' || (t === 'system' && matchMedia('(prefers-color-scheme:dark)').matches);
+    return t === 'dark' || (followsSystem(t) && matchMedia('(prefers-color-scheme:dark)').matches);
   }
   function apply() {
     if (isDark()) {
@@ -539,14 +574,18 @@
       document.documentElement.classList.remove('dark');
     }
   }
-  btn.addEventListener('click', function() {
-    var next = isDark() ? 'light' : 'dark';
-    localStorage.setItem('calrs_theme', next);
-    apply();
-  });
+  // The toggle button is hidden in embed mode; only wire it when present and
+  // when the visitor (not the parent) owns the theme.
+  if (btn && !embed) {
+    btn.addEventListener('click', function() {
+      var next = isDark() ? 'light' : 'dark';
+      localStorage.setItem('calrs_theme', next);
+      apply();
+    });
+  }
   apply();
   matchMedia('(prefers-color-scheme:dark)').addEventListener('change', function() {
-    if (getTheme() === 'system') apply();
+    if (followsSystem(getTheme())) apply();
   });
 })();
 </script>
@@ -579,5 +618,38 @@ window.calrsFormat12h = function(time24) {
   return h + ':' + m + ' ' + suffix;
 };
 </script>
+{% if embed %}
+<script>
+// Embed mode: report content height to the parent iframe so it can autosize.
+(function() {
+  if (window.parent === window) return;
+  var lastH = 0;
+  function send() {
+    var h = Math.max(
+      document.body.scrollHeight,
+      document.documentElement.scrollHeight,
+      document.body.offsetHeight,
+      document.documentElement.offsetHeight
+    );
+    if (Math.abs(h - lastH) < 4) return;
+    lastH = h;
+    try {
+      window.parent.postMessage({ type: 'calrs:resize', height: h }, '*');
+    } catch (e) {}
+  }
+  send();
+  window.addEventListener('load', send);
+  if (window.ResizeObserver) {
+    new ResizeObserver(send).observe(document.body);
+  } else {
+    setInterval(send, 500);
+  }
+  // Re-measure on common interaction events that change page height.
+  ['click', 'change', 'input', 'transitionend', 'animationend'].forEach(function(evt) {
+    document.addEventListener(evt, function() { setTimeout(send, 50); }, true);
+  });
+})();
+</script>
+{% endif %}
 </body>
 </html>

--- a/templates/book.html
+++ b/templates/book.html
@@ -16,7 +16,7 @@
 
 <div class="logo">{% if company_link %}<a href="{{ company_link }}" target="_blank" rel="noopener noreferrer">{% endif %}<img src="/logo" alt="" onerror="this.closest('.logo').style.display='none'">{% if company_link %}</a>{% endif %}</div>
 
-<a href="{{ base }}" class="back-link">&larr; {{ t("book-back-to-times") }}</a>
+<a href="{{ base }}{{ embed_qs_q | default('') }}" class="back-link">&larr; {{ t("book-back-to-times") }}</a>
 
 <div class="card">
   <h1>{{ event_type.title }}</h1>
@@ -40,7 +40,7 @@
     <div class="error">{{ error }}</div>
   {% endif %}
 
-  <form method="POST" action="{{ base }}/book">
+  <form method="POST" action="{{ base }}/book{{ embed_qs_q | default('') }}">
     <input type="hidden" name="date" value="{{ date }}">
     <input type="hidden" name="time" value="{{ time_start }}">
     {% if guest_tz is defined and guest_tz %}<input type="hidden" name="tz" value="{{ guest_tz }}">{% endif %}

--- a/templates/confirmed.html
+++ b/templates/confirmed.html
@@ -47,8 +47,8 @@
   {% endif %}
 </div>
 <div style="text-align: center; margin-top: 1.5rem;">
-  {% if team_slug %}<a href="/team/{{ team_slug }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>
-  {% elif username %}<a href="/u/{{ username }}/{{ event_type.slug }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>{% endif %}
+  {% if team_slug %}<a href="/team/{{ team_slug }}/{{ event_type.slug }}{{ embed_qs_q | default('') }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>
+  {% elif username %}<a href="/u/{{ username }}/{{ event_type.slug }}{{ embed_qs_q | default('') }}" style="color: var(--accent); font-size: 0.9rem;">&larr; {{ t("confirmed-book-another") }}</a>{% endif %}
 </div>
 <script>
 (function() {

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -41,9 +41,7 @@
         <form method="post" action="{{ et.toggle_url }}" style="margin: 0;">
           <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">{% if et.enabled %}Disable{% else %}Enable{% endif %}</button>
         </form>
-        {% if not et.is_team %}
         <a href="{{ et.embed_url }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Embed</a>
-        {% endif %}
         {% endif %}
         <div class="action-menu">
           <button type="button" class="slot-btn action-menu-toggle" style="font-size: 0.8rem; cursor: pointer; padding: 0.375rem 0.5rem;">&ctdot;</button>

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -41,15 +41,15 @@
         <form method="post" action="{{ et.toggle_url }}" style="margin: 0;">
           <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">{% if et.enabled %}Disable{% else %}Enable{% endif %}</button>
         </form>
+        {% if not et.is_team %}
+        <a href="{{ et.embed_url }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Embed</a>
+        {% endif %}
         {% endif %}
         <div class="action-menu">
           <button type="button" class="slot-btn action-menu-toggle" style="font-size: 0.8rem; cursor: pointer; padding: 0.375rem 0.5rem;">&ctdot;</button>
           <div class="action-menu-dropdown">
             {% if et.can_manage %}
             <a href="{{ et.overrides_url }}">Overrides</a>
-            {% endif %}
-            {% if et.can_manage and not et.is_team %}
-            <a href="{{ et.embed_url }}">Embed</a>
             {% endif %}
             {% if et.is_team and et.can_manage %}
             <a href="/dashboard/teams/{{ et.team_id }}/settings">Team settings</a>

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -48,6 +48,9 @@
             {% if et.can_manage %}
             <a href="{{ et.overrides_url }}">Overrides</a>
             {% endif %}
+            {% if et.can_manage and not et.is_team %}
+            <a href="{{ et.embed_url }}">Embed</a>
+            {% endif %}
             {% if et.is_team and et.can_manage %}
             <a href="/dashboard/teams/{{ et.team_id }}/settings">Team settings</a>
             {% endif %}

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -2,6 +2,10 @@
 {% block title %}Embed — {{ event_type_title }} — calrs{% endblock %}
 {% block dashboard_content %}
 <style>
+  /* The embed page is preview-heavy, so let it use more horizontal space than
+     the default dashboard 900px cap to give the live preview room to breathe. */
+  .dashboard-main .container { max-width: 1400px; }
+
   .embed-wrap { display: grid; grid-template-columns: 320px 1fr; gap: 1.25rem; align-items: start; }
   @media (max-width: 900px) { .embed-wrap { grid-template-columns: 1fr; } }
 

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -169,12 +169,7 @@
       </div>
 
       <h2 class="embed-section-label">Live preview</h2>
-      <div class="embed-preview-frame" id="preview-frame">
-        <div class="embed-preview-faux" id="preview-empty" style="display:none;">
-          <strong>Element click</strong>
-          <span>The embed code attaches to existing elements on your site. There's nothing visual to preview — try the floating or inline variant.</span>
-        </div>
-      </div>
+      <div class="embed-preview-frame" id="preview-frame"></div>
     </div>
   </div>
 </div>
@@ -276,12 +271,7 @@
   var previewIframe = null;
   var previewBtn = null;
   function clearPreview() {
-    var frame = $('preview-frame');
-    var empty = $('preview-empty');
-    Array.prototype.slice.call(frame.children).forEach(function (c) {
-      if (c !== empty) c.remove();
-    });
-    empty.style.display = 'none';
+    $('preview-frame').innerHTML = '';
     previewIframe = null;
     previewBtn = null;
   }
@@ -292,6 +282,23 @@
       '&theme='  + encodeURIComponent(state.theme) +
       '&brand='  + encodeURIComponent(state.brand.replace(/^#/, ''));
     return url;
+  }
+
+  // Shared by floating-button and element-click previews: swap the preview
+  // panel for the booking iframe with a "back" control, simulating the modal.
+  function openModalSim() {
+    var frame = $('preview-frame');
+    clearPreview();
+    var iframe = document.createElement('iframe');
+    iframe.src = buildIframeSrc();
+    iframe.style.cssText = 'width:100%;min-height:560px;border:0;display:block;';
+    frame.appendChild(iframe);
+    var back = document.createElement('button');
+    back.type = 'button';
+    back.textContent = '← back to preview';
+    back.style.cssText = 'position:absolute;top:0.5rem;left:0.5rem;padding:0.25rem 0.625rem;border:1px solid var(--border);border-radius:6px;background:var(--surface);font:inherit;font-size:0.75rem;cursor:pointer;z-index:5;';
+    back.addEventListener('click', renderPreview);
+    frame.appendChild(back);
   }
 
   function renderPreview() {
@@ -337,20 +344,7 @@
           '<line x1="8" y1="2" x2="8" y2="6"></line>' +
           '<line x1="3" y1="10" x2="21" y2="10"></line></svg>');
       }
-      btn.addEventListener('click', function () {
-        // Replace preview with iframe to simulate the modal experience.
-        clearPreview();
-        var iframe = document.createElement('iframe');
-        iframe.src = buildIframeSrc();
-        iframe.style.cssText = 'width:100%;min-height:560px;border:0;display:block;';
-        frame.appendChild(iframe);
-        var back = document.createElement('button');
-        back.type = 'button';
-        back.textContent = '← back to preview';
-        back.style.cssText = 'position:absolute;top:0.5rem;left:0.5rem;padding:0.25rem 0.625rem;border:1px solid var(--border);border-radius:6px;background:var(--surface);font:inherit;font-size:0.75rem;cursor:pointer;z-index:5;';
-        back.addEventListener('click', renderPreview);
-        frame.appendChild(back);
-      });
+      btn.addEventListener('click', openModalSim);
       var hint = document.createElement('div');
       hint.style.cssText = 'position:absolute;top:0.5rem;left:0.5rem;font-size:0.75rem;color:var(--text-muted);';
       hint.textContent = 'Click the button to simulate the modal';
@@ -358,8 +352,34 @@
       frame.appendChild(btn);
       previewBtn = btn;
     } else {
-      // element click — nothing to preview
-      $('preview-empty').style.display = 'flex';
+      // element-click — render demo trigger elements so the user can try the
+      // modal. On a real site they'd add data-calrs-link to their own markup;
+      // here we just wire the click directly to the same modal simulation.
+      var wrap = document.createElement('div');
+      wrap.style.cssText = 'position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1rem;padding:1rem;text-align:center;';
+
+      var hint = document.createElement('div');
+      hint.style.cssText = 'font-size:0.8rem;color:var(--text-muted);max-width:360px;';
+      hint.textContent = 'Demo triggers — on your site, add the data attributes from the snippet to any element. Click either one to try the modal:';
+      wrap.appendChild(hint);
+
+      var demoBtn = document.createElement('button');
+      demoBtn.type = 'button';
+      demoBtn.textContent = 'Book a meeting';
+      demoBtn.style.cssText =
+        'padding:0.75rem 1.5rem;border:0;border-radius:8px;font:inherit;font-size:0.95rem;' +
+        'font-weight:600;cursor:pointer;background:' + state.brand + ';color:#fff;';
+      demoBtn.addEventListener('click', openModalSim);
+      wrap.appendChild(demoBtn);
+
+      var demoLink = document.createElement('a');
+      demoLink.href = '#';
+      demoLink.textContent = 'or click this text link';
+      demoLink.style.cssText = 'font-size:0.9rem;color:' + state.brand + ';text-decoration:underline;cursor:pointer;';
+      demoLink.addEventListener('click', function (e) { e.preventDefault(); openModalSim(); });
+      wrap.appendChild(demoLink);
+
+      $('preview-frame').appendChild(wrap);
     }
   }
 

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -82,6 +82,11 @@
   </div>
   {% endif %}
 
+  {% if not has_username %}
+  <div class="error" style="margin-bottom: 1rem;">
+    You need to set a <strong>username</strong> before you can embed this event type — the embed link is <code>/u/&lt;username&gt;/{{ event_type_slug }}</code>. <a href="/dashboard/settings" style="color: var(--accent);">Set a username in settings</a> and come back.
+  </div>
+  {% else %}
   <div class="embed-tabs" role="tablist">
     <button type="button" class="embed-tab active" data-variant="inline">Inline</button>
     <button type="button" class="embed-tab" data-variant="floating">Floating button</button>
@@ -176,8 +181,10 @@
       <div class="embed-preview-frame" id="preview-frame"></div>
     </div>
   </div>
+  {% endif %}
 </div>
 
+{% if has_username %}
 <script>
 (function () {
   var calPath  = {{ cal_path | tojson }};
@@ -492,4 +499,5 @@
   refresh();
 })();
 </script>
+{% endif %}
 {% endblock %}

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -1,0 +1,471 @@
+{% extends "dashboard_base.html" %}
+{% block title %}Embed — {{ event_type_title }} — calrs{% endblock %}
+{% block dashboard_content %}
+<style>
+  .embed-wrap { display: grid; grid-template-columns: 320px 1fr; gap: 1.25rem; align-items: start; }
+  @media (max-width: 900px) { .embed-wrap { grid-template-columns: 1fr; } }
+
+  .embed-tabs { display: flex; gap: 0.25rem; margin-bottom: 1rem; border-bottom: 1px solid var(--border); }
+  .embed-tab {
+    appearance: none; background: none; border: 0; padding: 0.625rem 0.875rem;
+    font: inherit; font-size: 0.85rem; font-weight: 500; cursor: pointer;
+    color: var(--text-secondary); border-bottom: 2px solid transparent;
+    margin-bottom: -1px; transition: all 0.15s ease;
+  }
+  .embed-tab:hover { color: var(--text); }
+  .embed-tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+
+  .embed-config .form-row { margin-bottom: 0.875rem; }
+  .embed-config label { display: block; font-size: 0.8rem; font-weight: 600; margin-bottom: 0.25rem; color: var(--text-secondary); }
+  .embed-config input[type="text"], .embed-config select {
+    width: 100%; padding: 0.5rem 0.625rem; border: 1px solid var(--border);
+    border-radius: var(--radius); background: var(--surface); color: var(--text);
+    font: inherit; font-size: 0.9rem;
+  }
+  .embed-config .color-row { display: flex; gap: 0.5rem; align-items: center; }
+  .embed-config input[type="color"] {
+    width: 2.25rem; height: 2.25rem; padding: 0; border: 1px solid var(--border);
+    border-radius: var(--radius); background: none; cursor: pointer;
+  }
+  .embed-config input[type="color"]:disabled { opacity: 0.4; cursor: not-allowed; }
+  .embed-config .check-row { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; }
+  .embed-config .check-row input { margin: 0; }
+  .embed-config .field-hint { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.25rem; }
+
+  .embed-code-block {
+    position: relative; background: var(--bg); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 0.875rem 1rem; padding-right: 5rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.78rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+    color: var(--text); max-height: 280px; overflow: auto;
+  }
+  .embed-copy-btn {
+    position: absolute; top: 0.5rem; right: 0.5rem;
+    padding: 0.375rem 0.625rem; font-size: 0.75rem; font-weight: 600;
+    border: 1px solid var(--border); border-radius: var(--radius);
+    background: var(--surface); color: var(--accent); cursor: pointer;
+  }
+  .embed-copy-btn:hover { border-color: var(--accent); }
+  .embed-copy-btn.copied { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+  .embed-preview-frame {
+    background:
+      linear-gradient(45deg, rgba(127,127,127,0.06) 25%, transparent 25%, transparent 75%, rgba(127,127,127,0.06) 75%),
+      linear-gradient(45deg, rgba(127,127,127,0.06) 25%, transparent 25%, transparent 75%, rgba(127,127,127,0.06) 75%);
+    background-size: 16px 16px; background-position: 0 0, 8px 8px;
+    border: 1px solid var(--border); border-radius: var(--radius);
+    min-height: 400px; position: relative; overflow: hidden;
+  }
+  .embed-preview-frame iframe { width: 100%; min-height: 560px; border: 0; display: block; background: var(--surface); }
+  .embed-preview-faux {
+    position: absolute; inset: 0; padding: 1rem;
+    display: flex; align-items: center; justify-content: center; flex-direction: column; gap: 0.75rem;
+    color: var(--text-muted); font-size: 0.85rem; text-align: center;
+  }
+  .embed-section-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); margin: 0 0 0.4rem; }
+</style>
+
+<div class="card">
+  <div style="display:flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
+    <h1 style="margin-bottom: 0;">Embed: {{ event_type_title }}</h1>
+    <a href="/dashboard/event-types" style="color: var(--text-secondary); font-size: 0.85rem; text-decoration: none;">&larr; Back to event types</a>
+  </div>
+  <p class="subtitle" style="margin-bottom: 1rem;">Generate a snippet to embed this event type on your own website.</p>
+
+  {% if visibility != "public" %}
+  <div class="error" style="margin-bottom: 1rem;">
+    Heads up: this event type is <strong>{{ visibility }}</strong>. Embedded visitors will need a valid invite link to book — the generated snippet won't carry one. Consider switching visibility to public for direct embedding.
+  </div>
+  {% endif %}
+
+  <div class="embed-tabs" role="tablist">
+    <button type="button" class="embed-tab active" data-variant="inline">Inline</button>
+    <button type="button" class="embed-tab" data-variant="floating">Floating button</button>
+    <button type="button" class="embed-tab" data-variant="element">Element click</button>
+  </div>
+
+  <div class="embed-wrap">
+    <!-- LEFT: config -->
+    <div class="embed-config">
+      <div class="form-row">
+        <label for="cfg-layout">Layout</label>
+        <select id="cfg-layout">
+          <option value="month">Month view</option>
+          <option value="week">Week view</option>
+          <option value="column">Column view</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="cfg-theme">Theme</label>
+        <select id="cfg-theme">
+          <option value="auto">Auto (follow visitor)</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label>Brand color</label>
+        <div class="color-row">
+          <input type="color" id="cfg-brand">
+          <input type="text" id="cfg-brand-hex" maxlength="7" style="flex:1;" placeholder="#2563eb">
+        </div>
+        <div class="check-row" style="margin-top: 0.4rem;">
+          <input type="checkbox" id="cfg-use-org" checked>
+          <label for="cfg-use-org" style="font-size: 0.8rem; font-weight: 500; margin: 0;">Use organization color</label>
+        </div>
+      </div>
+
+      <!-- Floating-button-only -->
+      <div class="form-row variant-floating">
+        <label for="cfg-button-text">Button text</label>
+        <input type="text" id="cfg-button-text" value="Book a meeting" maxlength="60">
+      </div>
+
+      <div class="form-row variant-floating">
+        <label for="cfg-button-position">Button position</label>
+        <select id="cfg-button-position">
+          <option value="bottom-right">Bottom right</option>
+          <option value="bottom-left">Bottom left</option>
+          <option value="top-right">Top right</option>
+          <option value="top-left">Top left</option>
+        </select>
+      </div>
+
+      <div class="form-row variant-floating">
+        <label>Button colors</label>
+        <div class="color-row">
+          <input type="color" id="cfg-button-bg" value="#2563eb">
+          <input type="text" id="cfg-button-fg-hex" maxlength="7" placeholder="text" style="flex:1;">
+        </div>
+        <div class="color-row" style="margin-top: 0.375rem;">
+          <input type="color" id="cfg-button-fg" value="#ffffff">
+          <span class="field-hint" style="margin:0;">Background / text</span>
+        </div>
+      </div>
+
+      <div class="form-row variant-floating">
+        <div class="check-row">
+          <input type="checkbox" id="cfg-show-icon" checked>
+          <label for="cfg-show-icon" style="font-size: 0.85rem; font-weight: 500; margin: 0;">Show calendar icon</label>
+        </div>
+      </div>
+
+      <!-- Element-click instructions -->
+      <div class="form-row variant-element">
+        <div class="field-hint">
+          Drop the snippet into your site once, then add the data attributes shown to any clickable element (button, link, div) you want to trigger the modal.
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT: code + preview -->
+    <div>
+      <h2 class="embed-section-label">Snippet</h2>
+      <div style="position: relative; margin-bottom: 1rem;">
+        <pre class="embed-code-block" id="snippet-output">Loading…</pre>
+        <button type="button" class="embed-copy-btn" id="copy-btn">Copy</button>
+      </div>
+
+      <h2 class="embed-section-label">Live preview</h2>
+      <div class="embed-preview-frame" id="preview-frame">
+        <div class="embed-preview-faux" id="preview-empty" style="display:none;">
+          <strong>Element click</strong>
+          <span>The embed code attaches to existing elements on your site. There's nothing visual to preview — try the floating or inline variant.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var calPath  = {{ cal_path | tojson }};
+  var baseUrl  = {{ base_url | tojson }};
+  var defaultLayout = {{ default_layout | tojson }};
+  var orgAccent = {{ accent_color | tojson }};
+
+  // Resolve absolute base for the snippet: prefer CALRS_BASE_URL, else fall
+  // back to the dashboard's own origin. Without CALRS_BASE_URL, embed code
+  // copied during development still works against localhost.
+  var snippetBase = baseUrl || (location.origin);
+
+  var state = {
+    variant: 'inline',
+    layout: defaultLayout || 'month',
+    theme: 'auto',
+    useOrgColor: true,
+    brand: orgAccent || '#2563eb',
+    buttonText: 'Book a meeting',
+    buttonPosition: 'bottom-right',
+    buttonBg: orgAccent || '#2563eb',
+    buttonFg: '#ffffff',
+    showIcon: true
+  };
+
+  function $(id) { return document.getElementById(id); }
+  function setVal(id, v) { var el = $(id); if (el) el.value = v; }
+  function hexNorm(v) {
+    if (!v) return '#2563eb';
+    v = String(v).trim();
+    if (v.charAt(0) !== '#') v = '#' + v;
+    if (!/^#[0-9a-fA-F]{6}$/.test(v)) return null;
+    return v;
+  }
+
+  function buildConfigJs() {
+    var parts = ['"layout":"' + state.layout + '"'];
+    parts.push('"theme":"' + state.theme + '"');
+    parts.push('"brand":"' + state.brand + '"');
+    return '{' + parts.join(', ') + '}';
+  }
+
+  function indent(n) { return new Array(n + 1).join(' '); }
+
+  function snippetInline() {
+    var divId = 'calrs-inline-' + encodeURIComponent(calPath.replace(/^\//, '').replace(/\//g, '-'));
+    return [
+      '<!-- calrs inline embed -->',
+      '<div id="' + divId + '" style="width:100%;min-height:600px"></div>',
+      '<script src="' + snippetBase + '/embed.js" defer><' + '/script>',
+      '<script>',
+      indent(2) + 'window.addEventListener("DOMContentLoaded", function () {',
+      indent(4) + 'Calrs.inline({',
+      indent(6) + 'selector: "#' + divId + '",',
+      indent(6) + 'link: "' + snippetBase + calPath + '",',
+      indent(6) + 'config: ' + buildConfigJs(),
+      indent(4) + '});',
+      indent(2) + '});',
+      '<' + '/script>'
+    ].join('\n');
+  }
+
+  function snippetFloating() {
+    return [
+      '<!-- calrs floating-button embed -->',
+      '<script src="' + snippetBase + '/embed.js" defer><' + '/script>',
+      '<script>',
+      indent(2) + 'window.addEventListener("DOMContentLoaded", function () {',
+      indent(4) + 'Calrs.floatingButton({',
+      indent(6) + 'link: "' + snippetBase + calPath + '",',
+      indent(6) + 'buttonText: ' + JSON.stringify(state.buttonText) + ',',
+      indent(6) + 'buttonPosition: "' + state.buttonPosition + '",',
+      indent(6) + 'buttonColor: "' + state.buttonBg + '",',
+      indent(6) + 'textColor: "' + state.buttonFg + '",',
+      indent(6) + 'showIcon: ' + (state.showIcon ? 'true' : 'false') + ',',
+      indent(6) + 'config: ' + buildConfigJs(),
+      indent(4) + '});',
+      indent(2) + '});',
+      '<' + '/script>'
+    ].join('\n');
+  }
+
+  function snippetElement() {
+    return [
+      '<!-- calrs element-click embed -->',
+      '<!-- Add these attributes to any clickable element on your page: -->',
+      '<!--   data-calrs-link="' + snippetBase + calPath + '" -->',
+      '<!--   data-calrs-config=\'' + buildConfigJs() + '\' -->',
+      '<script src="' + snippetBase + '/embed.js" defer><' + '/script>'
+    ].join('\n');
+  }
+
+  // Live preview is just the embed runtime applied to a scoped container.
+  // We always tear down before rebuilding so swapping variants is clean.
+  var previewIframe = null;
+  var previewBtn = null;
+  function clearPreview() {
+    var frame = $('preview-frame');
+    var empty = $('preview-empty');
+    Array.prototype.slice.call(frame.children).forEach(function (c) {
+      if (c !== empty) c.remove();
+    });
+    empty.style.display = 'none';
+    previewIframe = null;
+    previewBtn = null;
+  }
+
+  function buildIframeSrc() {
+    var url = snippetBase + calPath + '?embed=1' +
+      '&layout=' + encodeURIComponent(state.layout) +
+      '&theme='  + encodeURIComponent(state.theme) +
+      '&brand='  + encodeURIComponent(state.brand.replace(/^#/, ''));
+    return url;
+  }
+
+  function renderPreview() {
+    clearPreview();
+    var frame = $('preview-frame');
+    if (state.variant === 'inline') {
+      var iframe = document.createElement('iframe');
+      iframe.src = buildIframeSrc();
+      iframe.style.cssText = 'width:100%;min-height:560px;border:0;display:block;';
+      frame.appendChild(iframe);
+      previewIframe = iframe;
+      // Auto-resize on message
+      window.addEventListener('message', function onMsg(ev) {
+        if (!iframe.isConnected) { window.removeEventListener('message', onMsg); return; }
+        if (!ev.data || ev.data.type !== 'calrs:resize') return;
+        if (ev.source !== iframe.contentWindow) return;
+        iframe.style.height = (Math.max(60, ev.data.height) + 8) + 'px';
+      });
+    } else if (state.variant === 'floating') {
+      // Render the floating button scoped to the preview area. We use
+      // absolute positioning relative to the preview container instead of
+      // fixed positioning so it doesn't escape the panel.
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = state.buttonText || 'Book a meeting';
+      var posStyles = {
+        'bottom-right': 'bottom:1rem;right:1rem;',
+        'bottom-left':  'bottom:1rem;left:1rem;',
+        'top-right':    'top:1rem;right:1rem;',
+        'top-left':     'top:1rem;left:1rem;'
+      };
+      btn.style.cssText =
+        'position:absolute;' + (posStyles[state.buttonPosition] || posStyles['bottom-right']) +
+        'padding:0.75rem 1.25rem;border:0;border-radius:999px;font:inherit;' +
+        'font-size:0.95rem;font-weight:600;cursor:pointer;display:inline-flex;' +
+        'align-items:center;gap:0.5rem;box-shadow:0 4px 14px rgba(0,0,0,0.18);' +
+        'background:' + state.buttonBg + ';color:' + state.buttonFg + ';';
+      if (state.showIcon) {
+        btn.insertAdjacentHTML('afterbegin',
+          '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;">' +
+          '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>' +
+          '<line x1="16" y1="2" x2="16" y2="6"></line>' +
+          '<line x1="8" y1="2" x2="8" y2="6"></line>' +
+          '<line x1="3" y1="10" x2="21" y2="10"></line></svg>');
+      }
+      btn.addEventListener('click', function () {
+        // Replace preview with iframe to simulate the modal experience.
+        clearPreview();
+        var iframe = document.createElement('iframe');
+        iframe.src = buildIframeSrc();
+        iframe.style.cssText = 'width:100%;min-height:560px;border:0;display:block;';
+        frame.appendChild(iframe);
+        var back = document.createElement('button');
+        back.type = 'button';
+        back.textContent = '← back to preview';
+        back.style.cssText = 'position:absolute;top:0.5rem;left:0.5rem;padding:0.25rem 0.625rem;border:1px solid var(--border);border-radius:6px;background:var(--surface);font:inherit;font-size:0.75rem;cursor:pointer;z-index:5;';
+        back.addEventListener('click', renderPreview);
+        frame.appendChild(back);
+      });
+      var hint = document.createElement('div');
+      hint.style.cssText = 'position:absolute;top:0.5rem;left:0.5rem;font-size:0.75rem;color:var(--text-muted);';
+      hint.textContent = 'Click the button to simulate the modal';
+      frame.appendChild(hint);
+      frame.appendChild(btn);
+      previewBtn = btn;
+    } else {
+      // element click — nothing to preview
+      $('preview-empty').style.display = 'flex';
+    }
+  }
+
+  function refresh() {
+    var snip;
+    if (state.variant === 'inline') snip = snippetInline();
+    else if (state.variant === 'floating') snip = snippetFloating();
+    else snip = snippetElement();
+    $('snippet-output').textContent = snip;
+    renderPreview();
+  }
+
+  // Variant tabs
+  document.querySelectorAll('.embed-tab').forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      document.querySelectorAll('.embed-tab').forEach(function (t) { t.classList.remove('active'); });
+      tab.classList.add('active');
+      state.variant = tab.dataset.variant;
+      document.querySelectorAll('.variant-floating').forEach(function (el) {
+        el.style.display = state.variant === 'floating' ? '' : 'none';
+      });
+      document.querySelectorAll('.variant-element').forEach(function (el) {
+        el.style.display = state.variant === 'element' ? '' : 'none';
+      });
+      refresh();
+    });
+  });
+
+  // Init fields from state
+  setVal('cfg-layout', state.layout);
+  setVal('cfg-theme', state.theme);
+  setVal('cfg-brand', state.brand);
+  setVal('cfg-brand-hex', state.brand);
+  $('cfg-brand').disabled = state.useOrgColor;
+  $('cfg-brand-hex').disabled = state.useOrgColor;
+  setVal('cfg-button-text', state.buttonText);
+  setVal('cfg-button-position', state.buttonPosition);
+  setVal('cfg-button-bg', state.buttonBg);
+  setVal('cfg-button-fg', state.buttonFg);
+  setVal('cfg-button-fg-hex', state.buttonFg);
+  $('cfg-show-icon').checked = state.showIcon;
+  document.querySelectorAll('.variant-floating').forEach(function (el) { el.style.display = 'none'; });
+  document.querySelectorAll('.variant-element').forEach(function (el) { el.style.display = 'none'; });
+
+  // Wire change handlers
+  $('cfg-layout').addEventListener('change', function (e) { state.layout = e.target.value; refresh(); });
+  $('cfg-theme').addEventListener('change', function (e) { state.theme = e.target.value; refresh(); });
+  $('cfg-use-org').addEventListener('change', function (e) {
+    state.useOrgColor = e.target.checked;
+    $('cfg-brand').disabled = state.useOrgColor;
+    $('cfg-brand-hex').disabled = state.useOrgColor;
+    if (state.useOrgColor) {
+      state.brand = orgAccent;
+      state.buttonBg = orgAccent;
+      setVal('cfg-brand', state.brand);
+      setVal('cfg-brand-hex', state.brand);
+      setVal('cfg-button-bg', state.buttonBg);
+    }
+    refresh();
+  });
+  $('cfg-brand').addEventListener('input', function (e) {
+    var v = hexNorm(e.target.value); if (!v) return;
+    state.brand = v; setVal('cfg-brand-hex', v); refresh();
+  });
+  $('cfg-brand-hex').addEventListener('input', function (e) {
+    var v = hexNorm(e.target.value); if (!v) return;
+    state.brand = v; setVal('cfg-brand', v); refresh();
+  });
+  $('cfg-button-text').addEventListener('input', function (e) { state.buttonText = e.target.value; refresh(); });
+  $('cfg-button-position').addEventListener('change', function (e) { state.buttonPosition = e.target.value; refresh(); });
+  $('cfg-button-bg').addEventListener('input', function (e) {
+    var v = hexNorm(e.target.value); if (!v) return;
+    state.buttonBg = v; refresh();
+  });
+  $('cfg-button-fg').addEventListener('input', function (e) {
+    var v = hexNorm(e.target.value); if (!v) return;
+    state.buttonFg = v; setVal('cfg-button-fg-hex', v); refresh();
+  });
+  $('cfg-button-fg-hex').addEventListener('input', function (e) {
+    var v = hexNorm(e.target.value); if (!v) return;
+    state.buttonFg = v; setVal('cfg-button-fg', v); refresh();
+  });
+  $('cfg-show-icon').addEventListener('change', function (e) { state.showIcon = e.target.checked; refresh(); });
+
+  // Copy
+  $('copy-btn').addEventListener('click', function () {
+    var btn = $('copy-btn');
+    var text = $('snippet-output').textContent;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { flashCopied(); }, fallbackCopy);
+    } else fallbackCopy();
+    function fallbackCopy() {
+      var ta = document.createElement('textarea');
+      ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+      document.body.appendChild(ta); ta.select();
+      try { document.execCommand('copy'); flashCopied(); } catch (e) {}
+      ta.remove();
+    }
+    function flashCopied() {
+      btn.textContent = 'Copied!';
+      btn.classList.add('copied');
+      setTimeout(function () { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 1500);
+    }
+  });
+
+  refresh();
+})();
+</script>
+{% endblock %}

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -82,6 +82,12 @@
   </div>
   {% endif %}
 
+  {% if team_visibility is defined and team_visibility == "private" %}
+  <div class="error" style="margin-bottom: 1rem;">
+    Heads up: this team is <strong>private</strong>. Embedded visitors can't book without the team invite link — the generated snippet won't carry one. Consider switching the team to public for direct embedding.
+  </div>
+  {% endif %}
+
   {% if not has_username %}
   <div class="error" style="margin-bottom: 1rem;">
     You need to set a <strong>username</strong> before you can embed this event type — the embed link is <code>/u/&lt;username&gt;/{{ event_type_slug }}</code>. <a href="/dashboard/settings" style="color: var(--accent);">Set a username in settings</a> and come back.

--- a/templates/slots.html
+++ b/templates/slots.html
@@ -942,6 +942,10 @@
   // non-clickable spans — used for logged-in team members viewing private/
   // internal team event types in availability-only mode.
   var canBook = {{ 'true' if can_book is not defined or can_book else 'false' }} || !!rescheduleBase;
+  // Embed mode threads ?embed=1&layout=...&theme=...&brand=... through every
+  // navigation so slot clicks, month nav, and the book form stay in the
+  // chrome-stripped embed flow.
+  var embedSuffix = decHtml("{{ embed_qs_amp | default('') }}");
 
   var format = localStorage.getItem('calrs_time_format') || '24';
   var i18n = calData.i18n || {};
@@ -1130,6 +1134,7 @@
       }
       if (guestTz) href += '&tz=' + encodeURIComponent(guestTz);
       if (inviteToken) href += '&invite=' + encodeURIComponent(inviteToken);
+      href += embedSuffix;
       if (canBook) {
         html += '<a href="' + href + '" class="slot-pill">' + formatTime(s.start) + '</a>';
       } else {
@@ -1147,6 +1152,7 @@
     if (isDynamicGroup) url += '&deferred=1';
     if (guestTz) url += '&tz=' + encodeURIComponent(guestTz);
     if (inviteToken) url += '&invite=' + encodeURIComponent(inviteToken);
+    url += embedSuffix;
 
     var layout = document.querySelector('.slots-layout');
     if (layout) {
@@ -1206,6 +1212,7 @@
       var prevUrl = basePath + '?month=' + data.prevMonth;
       if (guestTz) prevUrl += '&tz=' + encodeURIComponent(guestTz);
       if (inviteToken) prevUrl += '&invite=' + encodeURIComponent(inviteToken);
+      prevUrl += embedSuffix;
       var prev = document.createElement('a');
       prev.href = prevUrl;
       prev.innerHTML = '&larr;';
@@ -1224,6 +1231,7 @@
     var nextUrl = basePath + '?month=' + data.nextMonth;
     if (guestTz) nextUrl += '&tz=' + encodeURIComponent(guestTz);
     if (inviteToken) nextUrl += '&invite=' + encodeURIComponent(inviteToken);
+    nextUrl += embedSuffix;
     var next = document.createElement('a');
     next.href = nextUrl;
     next.innerHTML = '&rarr;';
@@ -1276,6 +1284,7 @@
     }
     if (guestTz) href += '&tz=' + encodeURIComponent(guestTz);
     if (inviteToken) href += '&invite=' + encodeURIComponent(inviteToken);
+    href += embedSuffix;
     return href;
   }
 
@@ -1458,6 +1467,7 @@
     var url = basePath + '?month=' + targetMonth;
     if (guestTz) url += '&tz=' + encodeURIComponent(guestTz);
     if (inviteToken) url += '&invite=' + encodeURIComponent(inviteToken);
+    url += embedSuffix;
 
     fetch(url).then(function(r) { return r.text(); }).then(function(html) {
       var parser = new DOMParser();
@@ -1626,6 +1636,7 @@
     if (calData.monthYear) deferUrl += '&month=' + calData.monthYear;
     if (guestTz) deferUrl += '&tz=' + encodeURIComponent(guestTz);
     if (inviteToken) deferUrl += '&invite=' + encodeURIComponent(inviteToken);
+    deferUrl += embedSuffix;
 
     fetch(deferUrl).then(function(r) { return r.text(); }).then(function(html) {
       var parser = new DOMParser();


### PR DESCRIPTION
This PR adds a Cal.com-style embed system that lets users embed their booking pages on any external website, without any backend changes or API keys.

A single self-contained script (assets/embed.js) that exposes window.Calrs with three methods:

- Calrs.inline({ selector, link, config }) — injects an auto-sizing iframe into an existing container element. Listens to calrs:resize postMessages from the iframe to keep height in sync with content.
- Calrs.floatingButton({ link, buttonText, buttonPosition, buttonColor, textColor, showIcon, config }) — renders a floating pill button (4 corner positions) that opens the booking page in a centered modal overlay.
- Calrs.elementClick() — auto-binds to any element with data-calrs-link / data-calrs-config attributes on DOMContentLoaded. Useful when the host page already has its own CTA buttons or links.

?embed=1 query param — embed mode for booking pages
When embed=1 is present, the booking flow (slots → book → confirmed):
- Strips navigation chrome (logo, footer, theme toggle)
- Sets permissive framing headers (X-Frame-Options: ALLOWALL, frame-ancestors * in CSP)
- Accepts layout, theme, and brand URL params to customize appearance per-embed
- Posts calrs:resize messages so the parent can autosize the iframe
- Uses SameSite=None; Secure for the CSRF cookie so it works correctly in cross-origin iframes (standard Lax is blocked by browsers in third-party frames)
- Propagates embed params through the full booking flow including form submissions and redirects

GET /dashboard/event-types/{slug}/embed — snippet generator
An authenticated dashboard page where users can:

- Pick variant (inline / floating button / element-click) via tabs
- Configure layout, theme, brand color
- Configure floating button appearance (text, position, background/text color, calendar icon)
- Copy the generated <script> snippet
- Preview the embed live in-page (inline as autosizing iframe, floating as scoped button + click-to-open simulation, element-click as clickable demo button + text link)

The Embed button is surfaced directly next to Edit/Disable in the event types list (not buried in the meatballs menu).



### Security

- CSP: embed mode is detected by csp_middleware and swaps frame-ancestors 'self' → frame-ancestors * without breaking captcha allowances
- CSRF: cross-origin iframe detection adds SameSite=None; Secure to the CSRF cookie only in embed context
- Brand color injection: validated as a strict 3 or 6 hex digit string before being interpolated into CSS — no injection vector
- postMessage origin check: the resize listener in embed.js checks ev.source === iframe.contentWindow before acting

### Bug fixes included

- Iframe autosize feedback loop: hovering time slots triggered transitionend events which called send(), which read documentElement.scrollHeight — coupled to the iframe viewport height the parent had set, causing +8px growth per hover. Fixed by measuring document.body only (which is min-height: 0 in embed mode and decoupled from the viewport).

### Important change
Increased embed page container max-width from 900px to 1400px for a wider, more realistic preview experience.
only in embed.html, not all the app

Before, with default values everywhere on the calrs app :
<img width="1888" height="1998" alt="image" src="https://github.com/user-attachments/assets/337ca66f-3b9d-4987-8b82-ac11ba6630ab" />

after for desktop views : 

<img width="1558" height="1856" alt="image" src="https://github.com/user-attachments/assets/116bf2a2-4876-49d4-92a9-3b179d43c22a" />
