### PR TITLE
fix: email verification not blank anymore

### DIFF
--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -67,6 +67,7 @@ book-name-label = Your name
 book-name-placeholder = Jane Doe
 book-email-label = Email
 book-email-placeholder = jane@example.com
+book-email-invalid = Please enter a complete email address, including the domain (e.g. jane@example.com).
 book-notes-label = Notes
 book-notes-optional = (optional)
 book-notes-placeholder = Anything you'd like to discuss?

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -67,6 +67,7 @@ book-name-label = Votre nom
 book-name-placeholder = Jeanne Dupont
 book-email-label = Adresse e-mail
 book-email-placeholder = jeanne@example.com
+book-email-invalid = Veuillez saisir une adresse e-mail complète, avec le nom de domaine (par ex. jeanne@example.com).
 book-notes-label = Notes
 book-notes-optional = (facultatif)
 book-notes-placeholder = Y a-t-il des points que vous aimeriez aborder ?

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8670,7 +8670,7 @@ async fn handle_group_booking(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
     let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, String, Option<String>)> = sqlx::query_as(
@@ -9472,7 +9472,7 @@ async fn handle_dynamic_group_booking(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(state, headers, "Invalid booking details", &e);
     }
 
     let usernames = match parse_dynamic_group_usernames(combined_username) {
@@ -10207,7 +10207,7 @@ async fn handle_booking_for_user(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
     let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, Option<String>)> = sqlx::query_as(
@@ -12250,7 +12250,7 @@ async fn handle_booking(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
     let et: Option<(String, String, String, i32, i32, i32, i32, i32, Option<i32>, i32, String)> = sqlx::query_as(

--- a/templates/book.html
+++ b/templates/book.html
@@ -53,8 +53,24 @@
 
     <div class="form-group">
       <label for="email">{{ t("book-email-label") }}</label>
-      <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="{{ t('book-email-placeholder') }}">
+      <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="{{ t('book-email-placeholder') }}" pattern="[^@\s]+@[^@\s]+\.[^@\s]{2,}" title="{{ t('book-email-invalid') }}">
     </div>
+    <script>
+    (function() {
+      var email = document.getElementById('email');
+      if (!email) return;
+      var msg = {{ t("book-email-invalid") | tojson }};
+      function update() {
+        if (email.validity.typeMismatch || email.validity.patternMismatch) {
+          email.setCustomValidity(msg);
+        } else {
+          email.setCustomValidity('');
+        }
+      }
+      email.addEventListener('input', update);
+      email.addEventListener('blur', update);
+    })();
+    </script>
 
     <div class="form-group">
       <label for="notes">{{ t("book-notes-label") }} <span class="hint">{{ t("book-notes-optional") }}</span></label>


### PR DESCRIPTION
Small fix, On public booking pages, entering an incomplete email address (e.g. `arthur@perrot`) passed the native HTML5 validation (`type="email"` accepts domains without a TLD), but then failed server-side, resulting in a blank page displaying only the text: "Please enter a valid email address."

## What changed

- **In-field validation**: added a `pattern` requiring `name@domain.tld` (at least 2 characters after the `.`) along with a localized `title` attribute on the email input in `book.html`. 
 A small script now propagates the message through `setCustomValidity` on `input` and `blur` events, ensuring the browser's native validation tooltip displays the translated text instead of the generic "Please match the requested format" message.
- **Server-side safety net**: all four booking handlers (`handle_booking`, `handle_booking_for_user`, `handle_group_booking`, `handle_dynamic_group_booking`) now route validation failures from `validate_booking_input` through `render_booking_action_error` instead of returning a raw `Html(e)` response.
 This prevents blank pages when JavaScript is disabled or the client-side pattern validation is bypassed.
- Added a new Fluent key: `book-email-invalid` (EN + FR; other locales continue to fall back to English as usual).


Before : 
<img width="345" height="115" alt="image" src="https://github.com/user-attachments/assets/1ac42794-061c-44f2-a0c8-53a7290b0e7a" />


After : 
<img width="828" height="645" alt="image" src="https://github.com/user-attachments/assets/c756271f-819d-4527-a915-6ddd265d202e" />
