### PR TITLE
i18n → main: booking email validation fix (#129)

### DIFF
--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -67,6 +67,7 @@ book-name-label = Your name
 book-name-placeholder = Jane Doe
 book-email-label = Email
 book-email-placeholder = jane@example.com
+book-email-invalid = Please enter a complete email address, including the domain (e.g. jane@example.com).
 book-notes-label = Notes
 book-notes-optional = (optional)
 book-notes-placeholder = Anything you'd like to discuss?

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -67,6 +67,7 @@ book-name-label = Votre nom
 book-name-placeholder = Jeanne Dupont
 book-email-label = Adresse e-mail
 book-email-placeholder = jeanne@example.com
+book-email-invalid = Veuillez saisir une adresse e-mail complète, avec le nom de domaine (par ex. jeanne@example.com).
 book-notes-label = Notes
 book-notes-optional = (facultatif)
 book-notes-placeholder = Y a-t-il des points que vous aimeriez aborder ?

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8841,7 +8841,7 @@ async fn handle_group_booking(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
     let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, String, Option<String>)> = sqlx::query_as(
@@ -9655,7 +9655,7 @@ async fn handle_dynamic_group_booking(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(state, headers, "Invalid booking details", &e);
     }
 
     let usernames = match parse_dynamic_group_usernames(combined_username) {
@@ -10402,7 +10402,7 @@ async fn handle_booking_for_user(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
     let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, Option<String>)> = sqlx::query_as(
@@ -12457,7 +12457,7 @@ async fn handle_booking(
     }
 
     if let Err(e) = validate_booking_input(&form.name, &form.email, &form.notes) {
-        return Html(e).into_response();
+        return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
     let et: Option<(String, String, String, i32, i32, i32, i32, i32, Option<i32>, i32, String)> = sqlx::query_as(

--- a/templates/book.html
+++ b/templates/book.html
@@ -53,8 +53,24 @@
 
     <div class="form-group">
       <label for="email">{{ t("book-email-label") }}</label>
-      <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="{{ t('book-email-placeholder') }}">
+      <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="{{ t('book-email-placeholder') }}" pattern="[^@\s]+@[^@\s]+\.[^@\s]{2,}" title="{{ t('book-email-invalid') }}">
     </div>
+    <script>
+    (function() {
+      var email = document.getElementById('email');
+      if (!email) return;
+      var msg = {{ t("book-email-invalid") | tojson }};
+      function update() {
+        if (email.validity.typeMismatch || email.validity.patternMismatch) {
+          email.setCustomValidity(msg);
+        } else {
+          email.setCustomValidity('');
+        }
+      }
+      email.addEventListener('input', update);
+      email.addEventListener('blur', update);
+    })();
+    </script>
 
     <div class="form-group">
       <label for="notes">{{ t("book-notes-label") }} <span class="hint">{{ t("book-notes-optional") }}</span></label>


### PR DESCRIPTION
Periodic i18n branch merge. Brings #129 (booking email validation UX + new book-email-invalid Fluent key, EN/FR). ES/PL translations will follow through Weblate on the i18n branch as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)