### PR TITLE
fix(availability): detect same-day calendar events in busy-time check

### DIFF
--- a/src/commands/event_type.rs
+++ b/src/commands/event_type.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{Datelike, Duration, Local, NaiveTime};
+use chrono::{Datelike, Duration, Local, NaiveDateTime, NaiveTime};
 use chrono_tz::Tz;
 use clap::Subcommand;
 use colored::Colorize;
@@ -54,6 +54,44 @@ struct EventTypeRow {
     duration: String,
     #[tabled(rename = "Active")]
     active: String,
+}
+
+/// Fetch non-recurring, busy (non-cancelled, OPAQUE) events for `et_id` whose
+/// stored time range overlaps `[window_start, window_end]`.
+///
+/// Events are stored in compact iCal form ("YYYYMMDDTHHMMSS" for timed,
+/// "YYYYMMDD" for all-day), so both overlap bounds are formatted compact *with
+/// a time component*. A date-only upper bound ("YYYYMMDD") is a bug: a timed
+/// event sorts lexically after its own date prefix ("20260618T100000" >
+/// "20260618"), so a window ending on the event's own date would silently miss
+/// it. Returns raw (start_at, end_at, timezone) rows for tz conversion by the
+/// caller.
+async fn fetch_nonrecurring_busy_events(
+    pool: &SqlitePool,
+    et_id: &str,
+    window_start: NaiveDateTime,
+    window_end: NaiveDateTime,
+) -> Result<Vec<(String, String, Option<String>)>> {
+    let end_compact = window_end.format("%Y%m%dT%H%M%S").to_string();
+    let start_compact = window_start.format("%Y%m%dT%H%M%S").to_string();
+    let rows = sqlx::query_as(
+        "SELECT e.start_at, e.end_at, e.timezone FROM events e
+         JOIN calendars c ON c.id = e.calendar_id
+         WHERE c.is_busy = 1
+           AND (NOT EXISTS (SELECT 1 FROM event_type_calendars WHERE event_type_id = ?)
+                OR c.id IN (SELECT calendar_id FROM event_type_calendars WHERE event_type_id = ?))
+           AND (e.rrule IS NULL OR e.rrule = '')
+           AND (e.status IS NULL OR e.status != 'CANCELLED')
+           AND (e.transp IS NULL OR e.transp != 'TRANSPARENT')
+           AND e.start_at <= ? AND e.end_at >= ?",
+    )
+    .bind(et_id)
+    .bind(et_id)
+    .bind(&end_compact)
+    .bind(&start_compact)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
 }
 
 pub async fn run(pool: &SqlitePool, cmd: EventTypeCommands) -> Result<()> {
@@ -187,32 +225,12 @@ pub async fn run(pool: &SqlitePool, cmd: EventTypeCommands) -> Result<()> {
                 .and_then(|s| s.parse::<Tz>().ok())
                 .unwrap_or(Tz::UTC);
 
-            // Events are stored in compact iCal form ("YYYYMMDDTHHMMSS" timed,
-            // "YYYYMMDD" all-day). Both overlap bounds must be compact with a
-            // time component: a date-only upper bound misses same-day timed
-            // events because "20260618T100000" sorts after "20260618".
-            let end_compact = end_date.format("%Y%m%dT235959").to_string();
-            let now_compact = now.format("%Y%m%dT%H%M%S").to_string();
             let end_iso = end_date.format("%Y-%m-%dT23:59:59").to_string();
             let now_iso = now.format("%Y-%m-%dT%H:%M:%S").to_string();
+            let window_end_dt = end_date.and_hms_opt(23, 59, 59).unwrap_or(now);
 
             // Non-recurring events (with timezone for conversion)
-            let events: Vec<(String, String, Option<String>)> = sqlx::query_as(
-                "SELECT e.start_at, e.end_at, e.timezone FROM events e
-                 JOIN calendars c ON c.id = e.calendar_id
-                 WHERE c.is_busy = 1
-                   AND (NOT EXISTS (SELECT 1 FROM event_type_calendars WHERE event_type_id = ?)
-                        OR c.id IN (SELECT calendar_id FROM event_type_calendars WHERE event_type_id = ?))
-                   AND (e.rrule IS NULL OR e.rrule = '')
-                   AND (e.status IS NULL OR e.status != 'CANCELLED')
-                   AND (e.transp IS NULL OR e.transp != 'TRANSPARENT')
-                   AND e.start_at <= ? AND e.end_at >= ?",
-            )
-            .bind(&et_id).bind(&et_id)
-            .bind(&end_compact)
-            .bind(&now_compact)
-            .fetch_all(pool)
-            .await?;
+            let events = fetch_nonrecurring_busy_events(pool, &et_id, now, window_end_dt).await?;
 
             let mut busy_events: Vec<(String, String)> = events
                 .iter()
@@ -260,7 +278,6 @@ pub async fn run(pool: &SqlitePool, cmd: EventTypeCommands) -> Result<()> {
             .await
             .unwrap_or_default();
 
-            let window_end_dt = end_date.and_hms_opt(23, 59, 59).unwrap_or(now);
             for (s, e, rrule_str, raw_ical, event_tz) in &recurring {
                 if let (Some(ev_start), Some(ev_end)) =
                     (parse_ical_datetime(s), parse_ical_datetime(e))
@@ -609,5 +626,58 @@ mod tests {
         )
         .await;
         assert!(result.is_err(), "Duplicate slug should fail");
+    }
+
+    #[tokio::test]
+    async fn slots_busy_query_detects_same_day_compact_event() {
+        // Regression: the CLI slots busy query must detect a timed event stored
+        // in compact iCal form ("YYYYMMDDTHHMMSS") on the SAME day as the
+        // window's end. A date-only upper bound ("YYYYMMDD") sorts before
+        // "...T100000" and silently dropped the event, so the slot looked free.
+        let pool = setup_db().await;
+        let (_user_id, account_id) = seed_account(&pool).await;
+
+        let et_id = Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO event_types (id, account_id, slug, title, duration_min) VALUES (?, ?, 'demo', 'Demo', 60)")
+            .bind(&et_id).bind(&account_id).execute(&pool).await.unwrap();
+        let source_id = Uuid::new_v4().to_string();
+        let cal_id = Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO caldav_sources (id, account_id, name, url, username) VALUES (?, ?, 'S', 'https://x/dav', 'u')")
+            .bind(&source_id).bind(&account_id).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO calendars (id, source_id, href, display_name, is_busy) VALUES (?, ?, '/c/', 'C', 1)")
+            .bind(&cal_id).bind(&source_id).execute(&pool).await.unwrap();
+        let ev_id = Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO events (id, calendar_id, uid, summary, start_at, end_at, all_day, timezone, status, transp) VALUES (?, ?, 'u1', 'Busy', '20260618T100000', '20260618T113000', 0, 'Europe/Paris', 'CONFIRMED', 'OPAQUE')")
+            .bind(&ev_id).bind(&cal_id).execute(&pool).await.unwrap();
+
+        // Same-day window: end bound formatted from the event's own date.
+        let day = chrono::NaiveDate::from_ymd_opt(2026, 6, 18).unwrap();
+        let busy = fetch_nonrecurring_busy_events(
+            &pool,
+            &et_id,
+            day.and_hms_opt(0, 0, 0).unwrap(),
+            day.and_hms_opt(23, 59, 59).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(busy.len(), 1, "same-day compact event must be detected");
+        assert_eq!(busy[0].0, "20260618T100000");
+
+        // Guard: TRANSPARENT (free) events are still excluded.
+        sqlx::query("UPDATE events SET transp = 'TRANSPARENT' WHERE id = ?")
+            .bind(&ev_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let busy = fetch_nonrecurring_busy_events(
+            &pool,
+            &et_id,
+            day.and_hms_opt(0, 0, 0).unwrap(),
+            day.and_hms_opt(23, 59, 59).unwrap(),
+        )
+        .await
+        .unwrap();
+        assert!(busy.is_empty(), "TRANSPARENT events must not block");
     }
 }

--- a/src/commands/event_type.rs
+++ b/src/commands/event_type.rs
@@ -187,8 +187,11 @@ pub async fn run(pool: &SqlitePool, cmd: EventTypeCommands) -> Result<()> {
                 .and_then(|s| s.parse::<Tz>().ok())
                 .unwrap_or(Tz::UTC);
 
-            // Fetch all events in range (both YYYYMMDD and ISO formats)
-            let end_compact = end_date.format("%Y%m%d").to_string();
+            // Events are stored in compact iCal form ("YYYYMMDDTHHMMSS" timed,
+            // "YYYYMMDD" all-day). Both overlap bounds must be compact with a
+            // time component: a date-only upper bound misses same-day timed
+            // events because "20260618T100000" sorts after "20260618".
+            let end_compact = end_date.format("%Y%m%dT235959").to_string();
             let now_compact = now.format("%Y%m%dT%H%M%S").to_string();
             let end_iso = end_date.format("%Y-%m-%dT23:59:59").to_string();
             let now_iso = now.format("%Y-%m-%dT%H:%M:%S").to_string();
@@ -203,13 +206,11 @@ pub async fn run(pool: &SqlitePool, cmd: EventTypeCommands) -> Result<()> {
                    AND (e.rrule IS NULL OR e.rrule = '')
                    AND (e.status IS NULL OR e.status != 'CANCELLED')
                    AND (e.transp IS NULL OR e.transp != 'TRANSPARENT')
-                   AND ((e.start_at <= ? AND e.end_at >= ?) OR (e.start_at <= ? AND e.end_at >= ?))",
+                   AND e.start_at <= ? AND e.end_at >= ?",
             )
             .bind(&et_id).bind(&et_id)
             .bind(&end_compact)
             .bind(&now_compact)
-            .bind(&end_iso)
-            .bind(&now_iso)
             .fetch_all(pool)
             .await?;
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -11444,8 +11444,16 @@ async fn fetch_busy_times_for_user_ex(
     event_type_id: Option<&str>,
     exclude_booking_id: Option<&str>,
 ) -> Vec<(NaiveDateTime, NaiveDateTime)> {
-    let end_compact = window_end.format("%Y%m%d").to_string();
+    // Events are stored in compact iCal form ("YYYYMMDDTHHMMSS" for timed,
+    // "YYYYMMDD" for all-day), so both overlap bounds must also be compact
+    // with a time component. Using a date-only upper bound here ("YYYYMMDD")
+    // is a bug: a timed event sorts lexically *after* its own date prefix
+    // ("20260618T100000" > "20260618"), so a same-day window (window_end on the
+    // same date as the event, e.g. the single-slot window in pick_group_member)
+    // would silently miss the event and treat a busy member as free.
+    let end_compact = window_end.format("%Y%m%dT%H%M%S").to_string();
     let start_compact = window_start.format("%Y%m%dT%H%M%S").to_string();
+    // ISO bounds are for the bookings sub-query below (bookings store ISO times).
     let end_iso = window_end.format("%Y-%m-%dT%H:%M:%S").to_string();
     let start_iso = window_start.format("%Y-%m-%dT%H:%M:%S").to_string();
 
@@ -11463,15 +11471,13 @@ async fn fetch_busy_times_for_user_ex(
            AND (e.rrule IS NULL OR e.rrule = '')
            AND (e.status IS NULL OR e.status != 'CANCELLED')
            AND (e.transp IS NULL OR e.transp != 'TRANSPARENT')
-           AND ((e.start_at <= ? AND e.end_at >= ?) OR (e.start_at <= ? AND e.end_at >= ?))",
+           AND e.start_at <= ? AND e.end_at >= ?",
     )
     .bind(user_id)
     .bind(et_id_for_filter)
     .bind(et_id_for_filter)
     .bind(&end_compact)
     .bind(&start_compact)
-    .bind(&end_iso)
-    .bind(&start_iso)
     .fetch_all(pool)
     .await
     .unwrap_or_default();
@@ -18378,6 +18384,99 @@ mod tests {
             busy.is_empty(),
             "Cancelled bookings should not block availability"
         );
+    }
+
+    /// Seed a CalDAV source + busy calendar + one synced event under `account_id`.
+    /// `start_at`/`end_at` are compact iCal strings (e.g. "20260618T100000").
+    async fn seed_synced_event(
+        pool: &SqlitePool,
+        account_id: &str,
+        start_at: &str,
+        end_at: &str,
+        timezone: &str,
+        transp: &str,
+    ) {
+        let source_id = uuid::Uuid::new_v4().to_string();
+        let cal_id = uuid::Uuid::new_v4().to_string();
+        let event_id = uuid::Uuid::new_v4().to_string();
+        let uid = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO caldav_sources (id, account_id, name, url, username) VALUES (?, ?, 'Src', 'https://x/dav', 'u')")
+            .bind(&source_id).bind(account_id).execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO calendars (id, source_id, href, display_name, is_busy) VALUES (?, ?, '/cal/', 'Cal', 1)")
+            .bind(&cal_id).bind(&source_id).execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO events (id, calendar_id, uid, summary, start_at, end_at, all_day, timezone, status, transp) VALUES (?, ?, ?, 'Busy', ?, ?, 0, ?, 'CONFIRMED', ?)")
+            .bind(&event_id).bind(&cal_id).bind(&uid).bind(start_at).bind(end_at).bind(timezone).bind(transp)
+            .execute(pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_busy_times_detects_same_day_compact_event() {
+        // Regression: a timed CalDAV event stored in compact iCal form
+        // ("YYYYMMDDTHHMMSS") on the SAME day as the busy window must be
+        // detected. pick_group_member checks a single-slot window at booking
+        // time, so window_end lands on the event's own date. A date-only upper
+        // bound ("YYYYMMDD") sorts lexically before the event
+        // ("20260618T100000" > "20260618"), so the event was silently dropped
+        // and a busy member could be booked (the double-booking we hit prod).
+        let pool = setup_test_db().await;
+        let (user_id, account_id, _et_id) = seed_test_data(&pool).await;
+        seed_synced_event(
+            &pool,
+            &account_id,
+            "20260618T100000",
+            "20260618T113000",
+            "Europe/Paris",
+            "OPAQUE",
+        )
+        .await;
+
+        let paris: Tz = "Europe/Paris".parse().unwrap();
+        let busy = fetch_busy_times_for_user(
+            &pool,
+            &user_id,
+            dt(2026, 6, 18, 10, 0),
+            dt(2026, 6, 18, 11, 0),
+            paris,
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            busy.len(),
+            1,
+            "same-day compact event must be detected as busy"
+        );
+        assert_eq!(busy[0].0, dt(2026, 6, 18, 10, 0));
+        assert_eq!(busy[0].1, dt(2026, 6, 18, 11, 30));
+    }
+
+    #[tokio::test]
+    async fn fetch_busy_times_skips_transparent_same_day_event() {
+        // Guard: the fix must not start counting TRANSPARENT (free) events.
+        let pool = setup_test_db().await;
+        let (user_id, account_id, _et_id) = seed_test_data(&pool).await;
+        seed_synced_event(
+            &pool,
+            &account_id,
+            "20260618T100000",
+            "20260618T113000",
+            "Europe/Paris",
+            "TRANSPARENT",
+        )
+        .await;
+
+        let paris: Tz = "Europe/Paris".parse().unwrap();
+        let busy = fetch_busy_times_for_user(
+            &pool,
+            &user_id,
+            dt(2026, 6, 18, 10, 0),
+            dt(2026, 6, 18, 11, 0),
+            paris,
+            None,
+        )
+        .await;
+
+        assert!(busy.is_empty(), "TRANSPARENT events must not block");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Fixes a double-booking: a team round-robin member who already has a meeting on their connected calendar could still be assigned an overlapping slot.

Closes #133.

## Root cause

Events are stored in compact iCal form (`20260618T100000` for timed, `20260618` for all-day). The busy-time overlap query built its window **upper bound as a date only** (`%Y%m%d`) and compared it as text against the stored event strings. Since `20260618T100000` sorts *after* `20260618` lexically, any event on the same day as the window's end date was dropped.

This bit the booking gate hardest: `pick_group_member` checks a single-slot window (window_end on the slot's own day), so a busy member looked free and got assigned. The multi-day slot grid was usually unaffected because its window_end falls on a later date.

## The fix

- Give the events upper bound a time component (`%Y%m%dT%H%M%S` in `web/mod.rs`, `%Y%m%dT235959` in the CLI) and compare with a single compact predicate.
- Keep the ISO bounds only for the bookings sub-query (bookings store ISO times).
- Same change applied to the CLI `event-type slots` path.

## Tests

Adds the first tests covering the synced-events branch of the busy-time check:
- a same-day compact event is now detected as busy (fails before the fix, passes after, verified red-green),
- `TRANSPARENT` (free) events are still skipped.

Full suite green (760 passed), clippy and fmt clean.
