### PR TITLE
fix(caldav): detect Radicale calendars with spaced self-closing tag (#132)

### DIFF
--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -572,15 +572,55 @@ pub struct RawEvent {
     pub ical_data: String,
 }
 
+/// Detect a `calendar` resourcetype element with any (or no) namespace prefix.
+///
+/// Matches `<cal:calendar/>`, `<C:calendar/>`, `<C:calendar />` (Radicale emits a
+/// space before the self-closing slash), unprefixed `<calendar xmlns="…">`, and
+/// the open form `<C:calendar>`. It must NOT match longer local names that merely
+/// start with `calendar` (`calendar-color`, `calendar-data`,
+/// `supported-calendar-component-set`) nor `addressbook` collections, so we
+/// require the element's local name to end exactly after `calendar`.
+fn has_calendar_resourcetype(block: &str) -> bool {
+    const NAME: &str = "calendar";
+    let mut from = 0;
+    while let Some(rel) = block[from..].find(NAME) {
+        let start = from + rel;
+        let end = start + NAME.len();
+        from = end;
+
+        // The character after the local name must terminate it: a self-closing
+        // slash, the tag's closing '>', or whitespace before attributes. A '-'
+        // (or anything else) means a longer name like "calendar-color".
+        let terminates = matches!(block[end..].chars().next(), Some('/') | Some('>'))
+            || block[end..].chars().next().is_some_and(char::is_whitespace);
+        if !terminates {
+            continue;
+        }
+
+        // The text before "calendar" must open an element: '<' directly
+        // (unprefixed) or "<prefix:" (namespaced).
+        let before = &block[..start];
+        if before.ends_with('<') {
+            return true;
+        }
+        if let Some(prefix) = before.strip_suffix(':') {
+            let trimmed = prefix.trim_end_matches(|c: char| {
+                c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
+            });
+            if trimmed.len() < prefix.len() && trimmed.ends_with('<') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn parse_calendar_list(xml: &str) -> Vec<CalendarInfo> {
     let mut calendars = Vec::new();
     for response_block in split_responses(xml) {
-        // Only include actual calendar collections
-        // Match <cal:calendar/>, <C:calendar/>, <calendar xmlns="..."/>, etc.
-        // Some servers (SoGo) use unprefixed <calendar> with xmlns attribute
-        let has_calendar_resource =
-            response_block.contains("calendar/>") || response_block.contains("<calendar xmlns=");
-        if !has_calendar_resource {
+        // Only include actual calendar collections (resourcetype contains a
+        // `calendar` element), skipping plain collections and addressbooks.
+        if !has_calendar_resourcetype(response_block) {
             continue;
         }
         let href = extract_tag(response_block, "d:href").unwrap_or_default();
@@ -1205,6 +1245,60 @@ mod tests {
         let xml = "<d:multistatus></d:multistatus>";
         let cals = parse_calendar_list(xml);
         assert!(cals.is_empty());
+    }
+
+    #[test]
+    fn parse_calendars_radicale() {
+        // Radicale 3.7.3 (issue #132): default DAV namespace (unprefixed href/
+        // displayname/sync-token), C: for caldav, a SPACE before the self-closing
+        // slash (`<C:calendar />`), CR: addressbooks that must be skipped, and the
+        // principal collection itself (which must not be treated as a calendar).
+        let xml = r#"<?xml version='1.0' encoding='utf-8'?>
+<multistatus xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:CR="urn:ietf:params:xml:ns:carddav" xmlns:CS="http://calendarserver.org/ns/" xmlns:ICAL="http://apple.com/ns/ical/"><response><href>/greg/</href><propstat><prop><resourcetype><principal /><collection /></resourcetype></prop><status>HTTP/1.1 200 OK</status></propstat><propstat><prop><displayname /><ICAL:calendar-color /><CS:getctag /><sync-token /></prop><status>HTTP/1.1 404 Not Found</status></propstat></response><response><href>/greg/0ff70afa/</href><propstat><prop><resourcetype><C:calendar /><collection /></resourcetype><displayname>Calendrier Pro</displayname><ICAL:calendar-color>#f79f78ff</ICAL:calendar-color><CS:getctag>"ctag-pro"</CS:getctag><sync-token>http://radicale.org/ns/sync/pro</sync-token></prop><status>HTTP/1.1 200 OK</status></propstat></response><response><href>/greg/7d2395d4/</href><propstat><prop><resourcetype><CR:addressbook /><collection /></resourcetype><displayname>Contacts Pros</displayname><CS:getctag>"ctag-contacts"</CS:getctag><sync-token>http://radicale.org/ns/sync/contacts</sync-token></prop><status>HTTP/1.1 200 OK</status></propstat><propstat><prop><ICAL:calendar-color /></prop><status>HTTP/1.1 404 Not Found</status></propstat></response><response><href>/greg/a56013c9/</href><propstat><prop><resourcetype><C:calendar /><collection /></resourcetype><displayname>Calendrier Perso</displayname><ICAL:calendar-color>#74bda7ff</ICAL:calendar-color><CS:getctag>"ctag-perso"</CS:getctag><sync-token>http://radicale.org/ns/sync/perso</sync-token></prop><status>HTTP/1.1 200 OK</status></propstat></response></multistatus>"#;
+
+        let cals = parse_calendar_list(xml);
+        assert_eq!(
+            cals.len(),
+            2,
+            "should detect the two C:calendar collections, skipping principal + addressbook"
+        );
+
+        assert_eq!(cals[0].href, "/greg/0ff70afa/");
+        assert_eq!(cals[0].display_name, Some("Calendrier Pro".to_string()));
+        assert_eq!(cals[0].color, Some("#f79f78ff".to_string()));
+        assert_eq!(cals[0].ctag, Some("\"ctag-pro\"".to_string()));
+        assert_eq!(
+            cals[0].sync_token,
+            Some("http://radicale.org/ns/sync/pro".to_string())
+        );
+
+        assert_eq!(cals[1].href, "/greg/a56013c9/");
+        assert_eq!(cals[1].display_name, Some("Calendrier Perso".to_string()));
+        assert_eq!(cals[1].color, Some("#74bda7ff".to_string()));
+    }
+
+    #[test]
+    fn has_calendar_resourcetype_distinguishes_lookalikes() {
+        // Real calendar elements, various prefixes / spacing.
+        assert!(has_calendar_resourcetype("<C:calendar />"));
+        assert!(has_calendar_resourcetype("<C:calendar/>"));
+        assert!(has_calendar_resourcetype("<cal:calendar/>"));
+        assert!(has_calendar_resourcetype(
+            "<calendar xmlns=\"urn:ietf:params:xml:ns:caldav\"/>"
+        ));
+        assert!(has_calendar_resourcetype("<C:calendar></C:calendar>"));
+        // Lookalikes that must NOT count as a calendar resourcetype.
+        assert!(!has_calendar_resourcetype("<ICAL:calendar-color />"));
+        assert!(!has_calendar_resourcetype(
+            "<C:calendar-data>BEGIN:VCALENDAR</C:calendar-data>"
+        ));
+        assert!(!has_calendar_resourcetype(
+            "<C:supported-calendar-component-set />"
+        ));
+        assert!(!has_calendar_resourcetype(
+            "<CR:addressbook /><collection />"
+        ));
+        assert!(!has_calendar_resourcetype("<d:collection/>"));
     }
 
     // --- parse_event_responses ---


### PR DESCRIPTION
## Problem

cal.rs reported `calendar_count=0` against self-hosted Radicale (3.7.3), so no VEVENTs were synced and busy slots never blocked availability. Other clients (Cal.com, Thunderbird, DAVx5) work against the same server. Fixes #132.

## Root cause

`parse_calendar_list` detected calendar collections with a brittle substring match in `src/caldav/mod.rs`:

```rust
response_block.contains("calendar/>") || response_block.contains("<calendar xmlns=")
```

Radicale emits the resourcetype as `<C:calendar />` — **with a space** before the self-closing slash — so `"calendar/>"` never matched. (href/displayname/color/ctag already resolved fine via `extract_tag`'s unprefixed fallback; detection was the only break.)

## Fix

Replace the substring check with `has_calendar_resourcetype()`, which matches a `calendar` resourcetype element under any (or no) namespace prefix, self-closing or open, with or without the space, while rejecting lookalikes (`calendar-color`, `calendar-data`, `supported-calendar-component-set`) and `addressbook` collections.

## Verification

- Live PROPFIND depth:1 against a Radicale 3.7.3 instance confirms the `<C:calendar />` (spaced) format; the fix now parses it.
- New `parse_calendars_radicale` regression test (built from the reporter's XML: default `xmlns="DAV:"`, principal collection, addressbook, spaced `<C:calendar />`).
- New `has_calendar_resourcetype_distinguishes_lookalikes` unit test.
- Full suite: 763 passed, clippy clean.

## Out of scope

The reporter also noted "Preset: Radicale reverts to Generic CalDAV on save" — a separate UI/persistence bug, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)