### PR TITLE
Global Exchange (EWS) via Impersonation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
 # Administration
 
 - [Admin Dashboard](./admin.md)
+- [EWS Impersonation](./ews-impersonation.md)
 - [Deployment](./deployment.md)
 
 # Reference

--- a/docs/src/ews-impersonation.md
+++ b/docs/src/ews-impersonation.md
@@ -1,0 +1,129 @@
+# EWS Impersonation (Exchange)
+
+calrs can connect to an on-premises Microsoft Exchange server (tested with
+Exchange 2019) over **EWS** (Exchange Web Services). Instead of asking every
+user for their mailbox credentials, you configure **one service account** that
+holds the `ApplicationImpersonation` role, and calrs impersonates each user by
+their email address to read their calendar.
+
+This is **global EWS impersonation**: one Exchange server + one service account,
+with a "managed" calendar source auto-provisioned for every user. It pairs
+naturally with [OIDC SSO](./authentication.md) — the user signs in, and calrs
+uses the email it gets from the IdP as the impersonation target, so a new user's
+calendar starts syncing with zero manual setup.
+
+> When global impersonation is disabled (the default), calrs behaves exactly as
+> before: users add their own per-user EWS or CalDAV sources.
+
+---
+
+## 1. Prepare the Exchange service account
+
+Create a dedicated service account (e.g. `svc-calrs@example.com`) and grant it
+the **ApplicationImpersonation** RBAC role. From the Exchange Management Shell:
+
+```powershell
+New-ManagementRoleAssignment -Name "calrs-impersonation" `
+  -Role ApplicationImpersonation `
+  -User svc-calrs@example.com
+```
+
+To limit blast radius, scope the assignment to a specific set of mailboxes with
+a management scope instead of granting it tenant-wide:
+
+```powershell
+New-ManagementScope -Name "calrs-mailboxes" `
+  -RecipientRestrictionFilter "MemberOfGroup -eq 'CN=calrs-users,OU=Groups,DC=example,DC=com'"
+
+New-ManagementRoleAssignment -Name "calrs-impersonation" `
+  -Role ApplicationImpersonation `
+  -User svc-calrs@example.com `
+  -CustomRecipientWriteScope "calrs-mailboxes"
+```
+
+Note your EWS endpoint URL — usually:
+
+```
+https://mail.example.com/EWS/Exchange.asmx
+```
+
+---
+
+## 2. Configure calrs (Admin → EWS)
+
+Go to **Admin dashboard → EWS** (the global impersonation section). Fields:
+
+| Field | Notes |
+|---|---|
+| **Enabled** | Master switch. When off, the feature is fully inert and per-user sources are used. |
+| **EWS URL** | The endpoint, e.g. `https://mail.example.com/EWS/Exchange.asmx`. Validated on save — an invalid URL is rejected rather than silently stored. |
+| **Service account username** | The impersonation account, e.g. `svc-calrs@example.com`. |
+| **Service account password** | Encrypted at rest (AES-256-GCM, same scheme as CalDAV/OIDC secrets). **Keep-current**: leave blank on save to preserve the stored value. |
+| **Lock user sources** | When on, non-admin users can no longer add their own calendar sources — their Exchange calendar is managed centrally. Admins are exempt. The Sources page shows an explanatory notice and hides the "Add" button. |
+| **Auto-provision** | When on, a managed Exchange source is created for **every** user — both existing users (on save) and each new user as they are created or first sign in via OIDC. |
+| **Impersonation domain** | Optional override for the mailbox domain. See [Domain mismatch](#domain-mismatch) below. A leading `@` is stripped automatically. |
+
+There is also a **"Provision now"** button: it runs a one-shot batch that
+provisions a managed source for every enabled user immediately, regardless of
+the auto-provision toggle. Saving with auto-provision enabled does the same
+thing.
+
+---
+
+## 3. How provisioning works
+
+For each user, calrs inserts a single **managed** row into `caldav_sources`:
+
+- `provider_type = 'ews'`, `managed = 1`, `auth_type = 'basic'`
+- `impersonate_email = <user's email>` — the SOAP layer injects a
+  `t:ExchangeImpersonation` header with this address on every request
+- `password_enc = NULL` — the managed source carries no secret of its own; the
+  sync path reads the live service-account credentials from the in-memory config
+
+Provisioning is **idempotent and race-safe**: a partial unique index allows only
+one managed EWS source per account, so an OIDC login racing the admin's
+"Provision now" can never create duplicates.
+
+Provisioning runs at three moments (all gated on auto-provision, except the
+explicit button):
+
+1. **Admin save / Provision now** — batch over all enabled users.
+2. **New account creation** — local registration.
+3. **OIDC login** — new or returning user, right after the account is
+   linked/created.
+
+---
+
+## Domain mismatch
+
+Impersonation targets the user's email as their Exchange **PrimarySmtpAddress**.
+If the address calrs knows (e.g. the AD UPN or the OIDC `email` claim) is on a
+different domain than the mailbox, impersonation will fail to resolve.
+
+Set the **Impersonation domain** override: calrs keeps the local part of the
+address and replaces the domain. For example, with the override set to
+`example.com`:
+
+```
+alice@example.local   ->   alice@example.com
+alice                 ->   alice@example.com
+```
+
+Validate this on one or two accounts before rolling out broadly.
+
+---
+
+## Security & networking
+
+- **The service account is powerful** — it can read every mailbox in its RBAC
+  scope. Restrict the scope with a management scope (step 1) and store its
+  password only in calrs, where it is encrypted at rest.
+- **Private/internal EWS host** — if your Exchange server resolves to a private
+  IP, calrs blocks the request by default (SSRF protection). Allow it explicitly
+  via the `CALRS_ALLOW_PRIVATE_HOSTS` environment variable (comma-separated
+  hostnames), e.g. `CALRS_ALLOW_PRIVATE_HOSTS=mail.example.com`.
+
+---
+
+See also: [Authentication](./authentication.md) for pairing this with OIDC SSO,
+and the [Admin Dashboard](./admin.md) reference.

--- a/migrations/062_ews_global_config.sql
+++ b/migrations/062_ews_global_config.sql
@@ -1,0 +1,11 @@
+-- Global EWS impersonation: admin-configured central Exchange server with a
+-- service account holding the ApplicationImpersonation role. Per-user sources
+-- are then auto-provisioned (see 058_caldav_sources_managed.sql) and the SOAP
+-- layer injects t:ExchangeImpersonation on every request.
+
+ALTER TABLE auth_config ADD COLUMN ews_global_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE auth_config ADD COLUMN ews_global_url TEXT;
+ALTER TABLE auth_config ADD COLUMN ews_service_username TEXT;
+ALTER TABLE auth_config ADD COLUMN ews_service_password_enc TEXT;
+ALTER TABLE auth_config ADD COLUMN ews_lock_user_sources INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE auth_config ADD COLUMN ews_auto_provision INTEGER NOT NULL DEFAULT 0;

--- a/migrations/063_caldav_sources_managed.sql
+++ b/migrations/063_caldav_sources_managed.sql
@@ -1,0 +1,8 @@
+-- Mark sources that were auto-provisioned by the admin's global EWS config.
+-- For managed rows the credentials live in auth_config (not on the row) and
+-- impersonate_email tells the SOAP layer which mailbox to act as.
+
+ALTER TABLE caldav_sources ADD COLUMN managed INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE caldav_sources ADD COLUMN impersonate_email TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_caldav_sources_managed ON caldav_sources(managed);

--- a/migrations/064_ews_impersonation_domain.sql
+++ b/migrations/064_ews_impersonation_domain.sql
@@ -1,0 +1,5 @@
+-- Some Exchange deployments use a different domain for the AD UPN / calrs
+-- login email (e.g. dyb.lan) than for the mailbox PrimarySmtpAddress
+-- (e.g. dyb.fr). When set, the impersonation target's domain is rewritten to
+-- this value so <t:PrimarySmtpAddress> resolves to a real mailbox.
+ALTER TABLE auth_config ADD COLUMN ews_impersonation_domain TEXT;

--- a/migrations/065_source_last_sync_error.sql
+++ b/migrations/065_source_last_sync_error.sql
@@ -1,0 +1,4 @@
+-- Persist the most recent sync error per source so the admin can see, at a
+-- glance, which managed Exchange users synced and which failed (e.g. an admin
+-- account with no Exchange mailbox). NULL = the last attempt succeeded.
+ALTER TABLE caldav_sources ADD COLUMN last_sync_error TEXT;

--- a/migrations/066_managed_ews_unique.sql
+++ b/migrations/066_managed_ews_unique.sql
@@ -1,0 +1,16 @@
+-- Make managed-EWS provisioning race-safe: at most one managed EWS source per
+-- account. Concurrent provisioning (e.g. a user logging in via OIDC while the
+-- admin clicks "provision now") could otherwise both pass a check-then-insert
+-- and create duplicates. Remove any pre-existing duplicates (keep the
+-- lexicographically smallest id) before enforcing the constraint.
+DELETE FROM caldav_sources
+WHERE managed = 1 AND provider_type = 'ews'
+  AND id NOT IN (
+    SELECT MIN(id) FROM caldav_sources
+    WHERE managed = 1 AND provider_type = 'ews'
+    GROUP BY account_id
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_caldav_sources_managed_ews_unique
+  ON caldav_sources(account_id)
+  WHERE managed = 1 AND provider_type = 'ews';

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -806,6 +806,24 @@ async fn register_handler(
         .await;
     }
 
+    // Auto-provision a managed Exchange source if the admin enabled the
+    // global EWS impersonation feature with auto-provision. Best-effort —
+    // a failure here must not block account creation.
+    if let Some(cfg) = state.ews_global.read().await.as_ref() {
+        if cfg.auto_provision {
+            if let Err(e) = crate::web::ews_global::provision_managed_ews_source_for_user(
+                &state.pool,
+                cfg,
+                &user_id,
+                &form.email,
+            )
+            .await
+            {
+                tracing::warn!(error = %e, "failed to provision managed EWS source on register");
+            }
+        }
+    }
+
     // Auto-login
     let session = match create_session(&state.pool, &user_id).await {
         Ok(s) => s,
@@ -1125,6 +1143,24 @@ async fn oidc_callback(
     if let Some(groups) = &claims.groups {
         if let Err(e) = sync_user_groups(&state.pool, &user_id, groups).await {
             tracing::warn!(error = %e, "failed to sync OIDC groups");
+        }
+    }
+
+    // Auto-provision managed EWS source for new (or returning) users when the
+    // admin enabled global impersonation + auto-provision. Idempotent: the
+    // helper no-ops if a row already exists for this user. Best-effort.
+    if let Some(cfg) = state.ews_global.read().await.as_ref() {
+        if cfg.auto_provision {
+            if let Err(e) = crate::web::ews_global::provision_managed_ews_source_for_user(
+                &state.pool,
+                cfg,
+                &user_id,
+                &email,
+            )
+            .await
+            {
+                tracing::warn!(error = %e, "failed to provision managed EWS source on OIDC login");
+            }
         }
     }
 

--- a/src/commands/source.rs
+++ b/src/commands/source.rs
@@ -164,7 +164,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: SourceCommands) -> Resu
                 print!("{} Testing connection… ", "…".dimmed());
                 io::stdout().flush().unwrap();
 
-                let client = build_provider(&provider, &url, &username, &password)?;
+                let client = build_provider(&provider, &url, &username, &password, None)?;
                 match client.check_connection().await {
                     Ok(true) => println!("{}", "OK".green()),
                     Ok(false) => {
@@ -388,7 +388,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: SourceCommands) -> Resu
                                 anyhow::anyhow!("Basic auth source missing password")
                             })?;
                             let password = crate::crypto::decrypt_password(key, enc)?;
-                            build_provider(&provider_type, &url, &username, &password)?
+                            build_provider(&provider_type, &url, &username, &password, None)?
                         };
                     match client.check_connection().await {
                         Ok(true) => println!("{} Connection OK", "✓".green()),

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -40,8 +40,23 @@ pub(crate) async fn source_lock(source_id: &str) -> Arc<Mutex<()>> {
 }
 
 pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
-    let sources: Vec<(String, String, String, String, Option<String>, String, Option<String>, Option<String>, String)> = sqlx::query_as(
-        "SELECT id, name, url, username, password_enc, auth_type, access_token_enc, token_expires_at, provider_type FROM caldav_sources WHERE enabled = 1",
+    #[allow(clippy::type_complexity)]
+    let sources: Vec<(
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        i64,
+        Option<String>,
+    )> = sqlx::query_as(
+        "SELECT id, name, url, username, password_enc, auth_type, access_token_enc, \
+                token_expires_at, provider_type, managed, impersonate_email \
+         FROM caldav_sources WHERE enabled = 1",
     )
     .fetch_all(pool)
     .await?;
@@ -50,6 +65,10 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
         println!("No sources configured. Add one with `calrs source add`.");
         return Ok(());
     }
+
+    // Load the global EWS config once for the whole sync run — managed rows
+    // all share it. None means the feature is off (managed rows are skipped).
+    let ews_global_cfg = crate::web::ews_global::load_ews_global_config(pool, key).await;
 
     for (
         source_id,
@@ -61,6 +80,8 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     ) in &sources
     {
         println!("{} Syncing '{}'…", "…".dimmed(), name);
@@ -78,22 +99,45 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
         // EWS sources go through the provider trait (no OAuth2, no CalDAV-only
         // sync-collection); CalDAV sources keep the existing flow.
         if provider_type == kinds::EWS {
-            let password =
-                match crate::crypto::decrypt_password(key, password_enc.as_deref().unwrap_or("")) {
+            // Managed rows use the global service account + impersonation
+            // header; per-user EWS rows keep their own credentials.
+            let provider_result = if *managed != 0 {
+                match ews_global_cfg.as_ref() {
+                    Some(cfg) => crate::providers::build_provider(
+                        provider_type,
+                        &cfg.url,
+                        &cfg.service_username,
+                        &cfg.service_password,
+                        impersonate_email.as_deref(),
+                    ),
+                    None => {
+                        println!(
+                            "  {} Managed Exchange source skipped: global EWS config is disabled.",
+                            "…".dimmed()
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                let password = match crate::crypto::decrypt_password(
+                    key,
+                    password_enc.as_deref().unwrap_or(""),
+                ) {
                     Ok(p) => p,
                     Err(e) => {
                         println!("  {} Decrypt failed: {}", "✗".red(), e);
                         continue;
                     }
                 };
-            let provider =
-                match crate::providers::build_provider(provider_type, url, username, &password) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        println!("  {} Provider build failed: {}", "✗".red(), e);
-                        continue;
-                    }
-                };
+                crate::providers::build_provider(provider_type, url, username, &password, None)
+            };
+            let provider = match provider_result {
+                Ok(p) => p,
+                Err(e) => {
+                    println!("  {} Provider build failed: {}", "✗".red(), e);
+                    continue;
+                }
+            };
             if let Err(e) = sync_ews_source(pool, key, provider.as_ref(), source_id).await {
                 println!("  {} Sync failed: {}", "✗".red(), e);
             }
@@ -315,8 +359,22 @@ pub async fn sync_if_stale(pool: &SqlitePool, key: &[u8; 32], user_id: &str) {
     // Must match SQLite datetime('now') format: "YYYY-MM-DD HH:MM:SS" (space, not T)
     let cutoff_str = cutoff.format("%Y-%m-%d %H:%M:%S").to_string();
 
-    let stale_sources: Vec<(String, String, String, Option<String>, String, Option<String>, Option<String>, String)> = sqlx::query_as(
-        "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.auth_type, cs.access_token_enc, cs.token_expires_at, cs.provider_type
+    #[allow(clippy::type_complexity)]
+    let stale_sources: Vec<(
+        String,
+        String,
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        i64,
+        Option<String>,
+    )> = sqlx::query_as(
+        "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.auth_type, \
+                cs.access_token_enc, cs.token_expires_at, cs.provider_type, \
+                cs.managed, cs.impersonate_email
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE a.user_id = ? AND cs.enabled = 1
@@ -334,6 +392,9 @@ pub async fn sync_if_stale(pool: &SqlitePool, key: &[u8; 32], user_id: &str) {
 
     tracing::debug!(user_id = %user_id, "on-demand CalDAV sync triggered (stale >5min)");
 
+    // Cache the global EWS config for the duration of this fan-out.
+    let ews_global_cfg = crate::web::ews_global::load_ews_global_config(pool, key).await;
+
     for (
         source_id,
         url,
@@ -343,6 +404,8 @@ pub async fn sync_if_stale(pool: &SqlitePool, key: &[u8; 32], user_id: &str) {
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     ) in &stale_sources
     {
         // Serialize on-demand syncs per source. If another task is already
@@ -371,16 +434,31 @@ pub async fn sync_if_stale(pool: &SqlitePool, key: &[u8; 32], user_id: &str) {
         }
 
         if provider_type == kinds::EWS {
-            let password =
-                match crate::crypto::decrypt_password(key, password_enc.as_deref().unwrap_or("")) {
+            let provider_result = if *managed != 0 {
+                match ews_global_cfg.as_ref() {
+                    Some(cfg) => crate::providers::build_provider(
+                        provider_type,
+                        &cfg.url,
+                        &cfg.service_username,
+                        &cfg.service_password,
+                        impersonate_email.as_deref(),
+                    ),
+                    None => continue,
+                }
+            } else {
+                let password = match crate::crypto::decrypt_password(
+                    key,
+                    password_enc.as_deref().unwrap_or(""),
+                ) {
                     Ok(p) => p,
                     Err(_) => continue,
                 };
-            let provider =
-                match crate::providers::build_provider(provider_type, url, username, &password) {
-                    Ok(p) => p,
-                    Err(_) => continue,
-                };
+                crate::providers::build_provider(provider_type, url, username, &password, None)
+            };
+            let provider = match provider_result {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
             let _ = sync_ews_source(pool, key, provider.as_ref(), source_id).await;
             continue;
         }
@@ -408,8 +486,22 @@ pub async fn sync_if_stale(pool: &SqlitePool, key: &[u8; 32], user_id: &str) {
 /// Sync a single source by ID (for background sync loop).
 /// Forces a full resync if last_full_sync is >24h ago (catches orphaned events).
 pub async fn sync_source_by_id(pool: &SqlitePool, key: &[u8; 32], source_id: &str) {
-    let source: Option<(String, String, Option<String>, Option<String>, String, Option<String>, Option<String>, String)> = sqlx::query_as(
-        "SELECT url, username, password_enc, last_full_sync, auth_type, access_token_enc, token_expires_at, provider_type FROM caldav_sources WHERE id = ? AND enabled = 1",
+    #[allow(clippy::type_complexity)]
+    let source: Option<(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        i64,
+        Option<String>,
+    )> = sqlx::query_as(
+        "SELECT url, username, password_enc, last_full_sync, auth_type, access_token_enc, \
+                token_expires_at, provider_type, managed, impersonate_email \
+         FROM caldav_sources WHERE id = ? AND enabled = 1",
     )
     .bind(source_id)
     .fetch_optional(pool)
@@ -425,6 +517,8 @@ pub async fn sync_source_by_id(pool: &SqlitePool, key: &[u8; 32], source_id: &st
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     )) = source
     else {
         return;
@@ -449,16 +543,29 @@ pub async fn sync_source_by_id(pool: &SqlitePool, key: &[u8; 32], source_id: &st
     }
 
     if provider_type == kinds::EWS {
-        let password =
-            match crate::crypto::decrypt_password(key, password_enc.as_deref().unwrap_or("")) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
-        let provider =
-            match crate::providers::build_provider(&provider_type, &url, &username, &password) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
+        let provider_result = if managed != 0 {
+            match crate::web::ews_global::load_ews_global_config(pool, key).await {
+                Some(cfg) => crate::providers::build_provider(
+                    &provider_type,
+                    &cfg.url,
+                    &cfg.service_username,
+                    &cfg.service_password,
+                    impersonate_email.as_deref(),
+                ),
+                None => return,
+            }
+        } else {
+            let password =
+                match crate::crypto::decrypt_password(key, password_enc.as_deref().unwrap_or("")) {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+            crate::providers::build_provider(&provider_type, &url, &username, &password, None)
+        };
+        let provider = match provider_result {
+            Ok(p) => p,
+            Err(_) => return,
+        };
         let _ = sync_ews_source(pool, key, provider.as_ref(), source_id).await;
         return;
     }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -84,7 +84,17 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
         impersonate_email,
     ) in &sources
     {
-        println!("{} Syncing '{}'…", "…".dimmed(), name);
+        // For managed Exchange rows, surface which mailbox we impersonate so
+        // multiple "Exchange (managed)" rows are distinguishable in the output.
+        if *managed != 0 {
+            if let Some(mb) = impersonate_email.as_deref() {
+                println!("{} Syncing '{}' (mailbox: {})…", "…".dimmed(), name, mb);
+            } else {
+                println!("{} Syncing '{}'…", "…".dimmed(), name);
+            }
+        } else {
+            println!("{} Syncing '{}'…", "…".dimmed(), name);
+        }
 
         if full {
             // Clear sync tokens to force a full fetch
@@ -140,7 +150,18 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
                 }
             };
             if let Err(e) = sync_ews_source(pool, key, provider.as_ref(), source_id).await {
-                println!("  {} Sync failed: {}", "✗".red(), e);
+                // A managed source pointing at a user without an Exchange
+                // mailbox (e.g. the local admin account) can never sync.
+                // Surface that as a clear note rather than an alarming error.
+                if *managed != 0 && e.to_string().contains("ErrorNonExistentMailbox") {
+                    println!(
+                        "  {} No Exchange mailbox for {} — skipping this user.",
+                        "⚠".yellow(),
+                        impersonate_email.as_deref().unwrap_or("(unknown)")
+                    );
+                } else {
+                    println!("  {} Sync failed: {}", "✗".red(), e);
+                }
             }
             continue;
         }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -619,7 +619,30 @@ pub async fn sync_source_by_id(pool: &SqlitePool, key: &[u8; 32], source_id: &st
 /// hardened orphan reconciliation). The EWS path is intentionally simpler:
 /// list folders, fetch each one in full, and reconcile by UID. Delta sync is a
 /// known follow-up — see `EwsProvider::sync_delta`.
+///
+/// This wrapper persists the outcome on the source row (`last_sync_error`):
+/// cleared on success, set to the error message on failure. Every sync entry
+/// point (CLI, background loop, on-demand, dashboard) goes through here, so the
+/// admin status view always reflects the latest attempt — handy for managed
+/// rows where one user (e.g. an admin without an Exchange mailbox) fails while
+/// the rest succeed.
 pub async fn sync_ews_source(
+    pool: &SqlitePool,
+    key: &[u8; 32],
+    provider: &dyn crate::providers::CalendarProvider,
+    source_id: &str,
+) -> Result<()> {
+    let result = sync_ews_source_inner(pool, key, provider, source_id).await;
+    let error_text = result.as_ref().err().map(|e| e.to_string());
+    let _ = sqlx::query("UPDATE caldav_sources SET last_sync_error = ? WHERE id = ?")
+        .bind(&error_text)
+        .bind(source_id)
+        .execute(pool)
+        .await;
+    result
+}
+
+async fn sync_ews_source_inner(
     pool: &SqlitePool,
     key: &[u8; 32],
     provider: &dyn crate::providers::CalendarProvider,

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -108,7 +108,8 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], full: bool) -> Result<()> {
                         &cfg.url,
                         &cfg.service_username,
                         &cfg.service_password,
-                        impersonate_email.as_deref(),
+                        cfg.impersonation_target(impersonate_email.as_deref())
+                            .as_deref(),
                     ),
                     None => {
                         println!(
@@ -441,7 +442,8 @@ pub async fn sync_if_stale(pool: &SqlitePool, key: &[u8; 32], user_id: &str) {
                         &cfg.url,
                         &cfg.service_username,
                         &cfg.service_password,
-                        impersonate_email.as_deref(),
+                        cfg.impersonation_target(impersonate_email.as_deref())
+                            .as_deref(),
                     ),
                     None => continue,
                 }
@@ -550,7 +552,8 @@ pub async fn sync_source_by_id(pool: &SqlitePool, key: &[u8; 32], source_id: &st
                     &cfg.url,
                     &cfg.service_username,
                     &cfg.service_password,
-                    impersonate_email.as_deref(),
+                    cfg.impersonation_target(impersonate_email.as_deref())
+                        .as_deref(),
                 ),
                 None => return,
             }

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -61,7 +61,12 @@ pub enum UserCommands {
     },
 }
 
-pub async fn run(pool: &SqlitePool, data_dir: &Path, cmd: UserCommands) -> Result<()> {
+pub async fn run(
+    pool: &SqlitePool,
+    data_dir: &Path,
+    secret_key: &[u8; 32],
+    cmd: UserCommands,
+) -> Result<()> {
     match cmd {
         UserCommands::Create { email, name, admin } => {
             let email = email.unwrap_or_else(|| prompt("Email"));
@@ -128,6 +133,31 @@ pub async fn run(pool: &SqlitePool, data_dir: &Path, cmd: UserCommands) -> Resul
                     "{}",
                     "  First user, automatically granted admin role.".dimmed()
                 );
+            }
+
+            // If the admin has enabled global EWS impersonation with
+            // auto-provision, give the new user a managed Exchange source.
+            if let Some(cfg) =
+                crate::web::ews_global::load_ews_global_config(pool, secret_key).await
+            {
+                if cfg.auto_provision {
+                    match crate::web::ews_global::provision_managed_ews_source_for_user(
+                        pool, &cfg, &user_id, &email,
+                    )
+                    .await
+                    {
+                        Ok(true) => println!(
+                            "  {} Auto-provisioned managed Exchange source.",
+                            "✓".green()
+                        ),
+                        Ok(false) => {}
+                        Err(e) => println!(
+                            "  {} Failed to provision managed Exchange source: {}",
+                            "⚠".yellow(),
+                            e
+                        ),
+                    }
+                }
             }
         }
         UserCommands::List => {
@@ -434,7 +464,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_users_empty() {
         let pool = setup_db().await;
-        let result = run(&pool, &std::env::temp_dir(), UserCommands::List).await;
+        let result = run(&pool, &std::env::temp_dir(), &[0u8; 32], UserCommands::List).await;
         assert!(result.is_ok());
     }
 
@@ -444,7 +474,7 @@ mod tests {
         insert_user(&pool, "alice@test.com", "Alice", "admin").await;
         insert_user(&pool, "bob@test.com", "Bob", "user").await;
 
-        let result = run(&pool, &std::env::temp_dir(), UserCommands::List).await;
+        let result = run(&pool, &std::env::temp_dir(), &[0u8; 32], UserCommands::List).await;
         assert!(result.is_ok());
 
         let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
@@ -463,6 +493,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Promote {
                 email: "bob@test.com".to_string(),
             },
@@ -486,6 +517,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Demote {
                 email: "bob@test.com".to_string(),
             },
@@ -509,6 +541,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Demote {
                 email: "alice@test.com".to_string(),
             },
@@ -532,6 +565,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Disable {
                 email: "bob@test.com".to_string(),
             },
@@ -556,6 +590,7 @@ mod tests {
         run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Disable {
                 email: "bob@test.com".to_string(),
             },
@@ -567,6 +602,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Enable {
                 email: "bob@test.com".to_string(),
             },
@@ -589,6 +625,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Disable {
                 email: "nobody@test.com".to_string(),
             },
@@ -603,6 +640,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Promote {
                 email: "nobody@test.com".to_string(),
             },
@@ -621,6 +659,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Delete {
                 email: "bob@test.com".to_string(),
                 yes: true,
@@ -644,6 +683,7 @@ mod tests {
         let result = run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Delete {
                 email: "ghost@test.com".to_string(),
                 yes: true,
@@ -673,6 +713,7 @@ mod tests {
         run(
             &pool,
             &std::env::temp_dir(),
+            &[0u8; 32],
             UserCommands::Disable {
                 email: "bob@test.com".to_string(),
             },

--- a/src/db.rs
+++ b/src/db.rs
@@ -260,6 +260,14 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "061_booking_unique_per_member",
             include_str!("../migrations/061_booking_unique_per_member.sql"),
         ),
+        (
+            "062_ews_global_config",
+            include_str!("../migrations/062_ews_global_config.sql"),
+        ),
+        (
+            "063_caldav_sources_managed",
+            include_str!("../migrations/063_caldav_sources_managed.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -867,7 +875,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 61, "All 61 migrations should be tracked");
+        assert_eq!(count.0, 63, "All 63 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -881,7 +889,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 61, "Still 61 migrations after second run");
+        assert_eq!(count.0, 63, "Still 63 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -276,6 +276,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "065_source_last_sync_error",
             include_str!("../migrations/065_source_last_sync_error.sql"),
         ),
+        (
+            "066_managed_ews_unique",
+            include_str!("../migrations/066_managed_ews_unique.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -883,7 +887,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 65, "All 65 migrations should be tracked");
+        assert_eq!(count.0, 66, "All 66 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -897,7 +901,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 65, "Still 65 migrations after second run");
+        assert_eq!(count.0, 66, "Still 66 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -272,6 +272,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "064_ews_impersonation_domain",
             include_str!("../migrations/064_ews_impersonation_domain.sql"),
         ),
+        (
+            "065_source_last_sync_error",
+            include_str!("../migrations/065_source_last_sync_error.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -879,7 +883,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 64, "All 64 migrations should be tracked");
+        assert_eq!(count.0, 65, "All 65 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -893,7 +897,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 64, "Still 64 migrations after second run");
+        assert_eq!(count.0, 65, "Still 65 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -268,6 +268,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "063_caldav_sources_managed",
             include_str!("../migrations/063_caldav_sources_managed.sql"),
         ),
+        (
+            "064_ews_impersonation_domain",
+            include_str!("../migrations/064_ews_impersonation_domain.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -875,7 +879,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 63, "All 63 migrations should be tracked");
+        assert_eq!(count.0, 64, "All 64 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -889,7 +893,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 63, "Still 63 migrations after second run");
+        assert_eq!(count.0, 64, "Still 64 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/ews/mod.rs
+++ b/src/ews/mod.rs
@@ -44,10 +44,18 @@ use crate::providers::{CalendarProvider, DeltaResult, RawEvent, RemoteCalendar};
 /// EWS-backed calendar provider. Constructed from the SOAP endpoint URL plus
 /// credentials. Designed to be cheap to clone — no HTTP client cached on the
 /// instance because each request rebuilds one with the appropriate timeout.
+///
+/// When `impersonate_email` is `Some`, every SOAP envelope carries a
+/// `t:ExchangeImpersonation` header so requests execute as that mailbox. The
+/// authenticating `username` must be a service account holding the
+/// `ApplicationImpersonation` RBAC role. This powers the admin-controlled
+/// "Global EWS" mode where a single service account fronts every user's
+/// calendar without users entering any credentials themselves.
 pub struct EwsProvider {
     endpoint: String,
     username: String,
     password: String,
+    impersonate_email: Option<String>,
 }
 
 impl EwsProvider {
@@ -56,7 +64,28 @@ impl EwsProvider {
             endpoint: endpoint.trim_end_matches('/').to_string(),
             username: username.to_string(),
             password: password.to_string(),
+            impersonate_email: None,
         }
+    }
+
+    /// Build a provider that impersonates `mailbox_email`. The connecting
+    /// account must hold the `ApplicationImpersonation` RBAC role on Exchange.
+    pub fn with_impersonation(
+        endpoint: &str,
+        username: &str,
+        password: &str,
+        mailbox_email: &str,
+    ) -> Self {
+        Self {
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            username: username.to_string(),
+            password: password.to_string(),
+            impersonate_email: Some(mailbox_email.to_string()),
+        }
+    }
+
+    fn impersonate(&self) -> Option<&str> {
+        self.impersonate_email.as_deref()
     }
 
     /// Validate the URL the same way the CalDAV path does (HTTPS only,
@@ -70,13 +99,23 @@ impl EwsProvider {
 #[async_trait]
 impl CalendarProvider for EwsProvider {
     async fn check_connection(&self) -> Result<bool> {
-        operations::check_connection(&self.endpoint, &self.username, &self.password).await
+        operations::check_connection(
+            &self.endpoint,
+            &self.username,
+            &self.password,
+            self.impersonate(),
+        )
+        .await
     }
 
     async fn list_calendars(&self) -> Result<Vec<RemoteCalendar>> {
-        let folders =
-            operations::list_calendar_folders(&self.endpoint, &self.username, &self.password)
-                .await?;
+        let folders = operations::list_calendar_folders(
+            &self.endpoint,
+            &self.username,
+            &self.password,
+            self.impersonate(),
+        )
+        .await?;
         Ok(folders
             .into_iter()
             .map(|f| RemoteCalendar {
@@ -90,9 +129,14 @@ impl CalendarProvider for EwsProvider {
     }
 
     async fn fetch_events(&self, calendar_id: &str) -> Result<Vec<RawEvent>> {
-        let items =
-            operations::list_items(&self.endpoint, &self.username, &self.password, calendar_id)
-                .await?;
+        let items = operations::list_items(
+            &self.endpoint,
+            &self.username,
+            &self.password,
+            calendar_id,
+            self.impersonate(),
+        )
+        .await?;
         Ok(synth_raw_events(items))
     }
 
@@ -114,6 +158,7 @@ impl CalendarProvider for EwsProvider {
             calendar_id,
             since_utc,
             &end_utc,
+            self.impersonate(),
         )
         .await?;
         Ok(synth_raw_events(items))
@@ -139,6 +184,7 @@ impl CalendarProvider for EwsProvider {
             &self.password,
             calendar_id,
             sync_state,
+            self.impersonate(),
         )
         .await?;
 
@@ -152,7 +198,14 @@ impl CalendarProvider for EwsProvider {
         let mime_pairs = if ids.is_empty() {
             Vec::new()
         } else {
-            operations::get_items_mime(&self.endpoint, &self.username, &self.password, &ids).await?
+            operations::get_items_mime(
+                &self.endpoint,
+                &self.username,
+                &self.password,
+                &ids,
+                self.impersonate(),
+            )
+            .await?
         };
         // Index MIME by ItemId so the order matches.
         let mut mime_by_id: HashMap<String, String> = mime_pairs.into_iter().collect();
@@ -189,13 +242,19 @@ impl CalendarProvider for EwsProvider {
             &self.password,
             calendar_id,
             uid,
+            self.impersonate(),
         )
         .await
         .unwrap_or_default();
         for item_id in &existing {
-            if let Err(e) =
-                operations::delete_item(&self.endpoint, &self.username, &self.password, item_id)
-                    .await
+            if let Err(e) = operations::delete_item(
+                &self.endpoint,
+                &self.username,
+                &self.password,
+                item_id,
+                self.impersonate(),
+            )
+            .await
             {
                 tracing::warn!(uid = %uid, error = %e, "EWS could not delete prior copy before re-create; continuing");
             }
@@ -206,6 +265,7 @@ impl CalendarProvider for EwsProvider {
             &self.password,
             calendar_id,
             ics,
+            self.impersonate(),
         )
         .await?;
         Ok(())
@@ -218,11 +278,18 @@ impl CalendarProvider for EwsProvider {
             &self.password,
             calendar_id,
             uid,
+            self.impersonate(),
         )
         .await?;
         for item_id in &existing {
-            operations::delete_item(&self.endpoint, &self.username, &self.password, item_id)
-                .await?;
+            operations::delete_item(
+                &self.endpoint,
+                &self.username,
+                &self.password,
+                item_id,
+                self.impersonate(),
+            )
+            .await?;
         }
         Ok(())
     }

--- a/src/ews/operations.rs
+++ b/src/ews/operations.rs
@@ -5,6 +5,11 @@
 //! and parses the response with helpers from [`super::parse`]. Operations are
 //! kept narrow on purpose — calrs only exercises a small slice of the EWS
 //! surface.
+//!
+//! All helpers take an `impersonate_email: Option<&str>`. When `Some`, the
+//! request is run against that mailbox via the `t:ExchangeImpersonation` SOAP
+//! header — the connecting `username` must be a service account holding the
+//! `ApplicationImpersonation` RBAC role.
 
 use anyhow::{bail, Context, Result};
 
@@ -18,7 +23,12 @@ use super::soap::{escape, post_soap};
 /// Issue a `GetFolder` against `inbox` to confirm that the credentials are
 /// valid and the endpoint speaks EWS. The folder is purely a convenience pick
 /// — every Exchange mailbox has it.
-pub async fn check_connection(endpoint: &str, username: &str, password: &str) -> Result<bool> {
+pub async fn check_connection(
+    endpoint: &str,
+    username: &str,
+    password: &str,
+    impersonate_email: Option<&str>,
+) -> Result<bool> {
     let body = r#"    <m:GetFolder>
       <m:FolderShape>
         <t:BaseShape>IdOnly</t:BaseShape>
@@ -28,7 +38,7 @@ pub async fn check_connection(endpoint: &str, username: &str, password: &str) ->
       </m:FolderIds>
     </m:GetFolder>
 "#;
-    let resp = post_soap(endpoint, username, password, body, false).await?;
+    let resp = post_soap(endpoint, username, password, body, false, impersonate_email).await?;
     // post_soap already raises on SOAP faults; we only need to confirm the
     // response carries a real folder reference (or, as a softer fallback, the
     // standard Success class) before declaring the endpoint EWS-compatible.
@@ -45,6 +55,7 @@ pub async fn list_calendar_folders(
     endpoint: &str,
     username: &str,
     password: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<Vec<EwsCalendarFolder>> {
     let body = r#"    <m:FindFolder Traversal="Deep">
       <m:FolderShape>
@@ -67,7 +78,7 @@ pub async fn list_calendar_folders(
       </m:ParentFolderIds>
     </m:FindFolder>
 "#;
-    let resp = post_soap(endpoint, username, password, body, false).await?;
+    let resp = post_soap(endpoint, username, password, body, false, impersonate_email).await?;
     parse_find_folder_response(&resp)
 }
 
@@ -79,8 +90,18 @@ pub async fn list_items(
     username: &str,
     password: &str,
     folder_id: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<Vec<EwsCalendarItem>> {
-    list_items_window(endpoint, username, password, folder_id, None, None).await
+    list_items_window(
+        endpoint,
+        username,
+        password,
+        folder_id,
+        None,
+        None,
+        impersonate_email,
+    )
+    .await
 }
 
 /// Fetch calendar items overlapping `[start, end)`. Both bounds are RFC 3339
@@ -94,6 +115,7 @@ pub async fn list_items_in_window(
     folder_id: &str,
     start_utc: &str,
     end_utc: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<Vec<EwsCalendarItem>> {
     list_items_window(
         endpoint,
@@ -102,6 +124,7 @@ pub async fn list_items_in_window(
         folder_id,
         Some(start_utc),
         Some(end_utc),
+        impersonate_email,
     )
     .await
 }
@@ -115,6 +138,7 @@ async fn list_items_window(
     folder_id: &str,
     start_utc: Option<&str>,
     end_utc: Option<&str>,
+    impersonate_email: Option<&str>,
 ) -> Result<Vec<EwsCalendarItem>> {
     let mut all = Vec::new();
     let mut offset: u32 = 0;
@@ -158,7 +182,7 @@ async fn list_items_window(
 "#,
             folder = escape(folder_id),
         );
-        let resp = post_soap(endpoint, username, password, &body, true).await?;
+        let resp = post_soap(endpoint, username, password, &body, true, impersonate_email).await?;
         let mut page = parse_calendar_items_response(&resp)?;
 
         let included = page.included_count;
@@ -193,6 +217,7 @@ pub async fn get_items_mime(
     username: &str,
     password: &str,
     item_ids: &[&str],
+    impersonate_email: Option<&str>,
 ) -> Result<Vec<(String, String)>> {
     if item_ids.is_empty() {
         return Ok(Vec::new());
@@ -219,7 +244,7 @@ pub async fn get_items_mime(
     </m:GetItem>
 "#,
     );
-    let resp = post_soap(endpoint, username, password, &body, true).await?;
+    let resp = post_soap(endpoint, username, password, &body, true, impersonate_email).await?;
     parse_get_item_response(&resp)
 }
 
@@ -235,6 +260,7 @@ pub async fn create_item_from_ics(
     password: &str,
     folder_id: &str,
     ics: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<String> {
     use base64::Engine;
     let mime = base64::engine::general_purpose::STANDARD.encode(ics.as_bytes());
@@ -253,7 +279,7 @@ pub async fn create_item_from_ics(
 "#,
         folder = escape(folder_id),
     );
-    let resp = post_soap(endpoint, username, password, &body, true).await?;
+    let resp = post_soap(endpoint, username, password, &body, true, impersonate_email).await?;
     let item_id = parse_create_item_response(&resp)?;
     Ok(item_id)
 }
@@ -266,6 +292,7 @@ pub async fn find_items_by_uid(
     password: &str,
     folder_id: &str,
     uid: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<Vec<String>> {
     let body = format!(
         r#"    <m:FindItem Traversal="Shallow">
@@ -288,7 +315,15 @@ pub async fn find_items_by_uid(
         uid = escape(uid),
         folder = escape(folder_id),
     );
-    let resp = post_soap(endpoint, username, password, &body, false).await?;
+    let resp = post_soap(
+        endpoint,
+        username,
+        password,
+        &body,
+        false,
+        impersonate_email,
+    )
+    .await?;
     let parsed = parse_calendar_items_response(&resp)?;
     Ok(parsed.items.into_iter().map(|i| i.item_id).collect())
 }
@@ -301,6 +336,7 @@ pub async fn delete_item(
     username: &str,
     password: &str,
     item_id: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<()> {
     let body = format!(
         r#"    <m:DeleteItem DeleteType="HardDelete" SendMeetingCancellations="SendToNone">
@@ -311,7 +347,15 @@ pub async fn delete_item(
 "#,
         id = escape(item_id),
     );
-    let _ = post_soap(endpoint, username, password, &body, false).await?;
+    let _ = post_soap(
+        endpoint,
+        username,
+        password,
+        &body,
+        false,
+        impersonate_email,
+    )
+    .await?;
     Ok(())
 }
 
@@ -329,6 +373,7 @@ pub async fn sync_folder_items(
     password: &str,
     folder_id: &str,
     sync_state: Option<&str>,
+    impersonate_email: Option<&str>,
 ) -> Result<EwsSyncDelta> {
     const MAX_SYNC_PAGES: usize = 200;
     let mut state = sync_state.map(str::to_string);
@@ -355,7 +400,7 @@ pub async fn sync_folder_items(
 "#,
             folder = escape(folder_id),
         );
-        let resp = post_soap(endpoint, username, password, &body, true).await?;
+        let resp = post_soap(endpoint, username, password, &body, true, impersonate_email).await?;
         let page = parse_sync_folder_items_response(&resp)
             .context("failed to parse SyncFolderItems response")?;
 

--- a/src/ews/soap.rs
+++ b/src/ews/soap.rs
@@ -99,12 +99,27 @@ pub async fn post_soap(
     let client = http_client(timeout)?;
     let envelope = envelope(body, impersonate_email);
 
-    tracing::debug!(endpoint = %endpoint, body_len = envelope.len(), "EWS SOAP request");
-    let resp = client
+    tracing::debug!(
+        endpoint = %endpoint,
+        impersonate = impersonate_email.unwrap_or("(none)"),
+        body_len = envelope.len(),
+        "EWS SOAP request"
+    );
+    tracing::trace!(envelope = %envelope, "EWS SOAP request envelope");
+    let mut req = client
         .post(endpoint)
         .basic_auth(username, Some(password))
         .header("Content-Type", "text/xml; charset=utf-8")
-        .header("Accept", "text/xml")
+        .header("Accept", "text/xml");
+    // When impersonating, set X-AnchorMailbox so Exchange routes the request to
+    // the impersonated mailbox's server. Without it, multi-database / DAG
+    // deployments resolve against the connecting account and reject the
+    // operation (often as ErrorNonExistentMailbox). This is the documented
+    // best practice for EWS Impersonation on Exchange 2013+.
+    if let Some(mb) = impersonate_email.filter(|m| !m.is_empty()) {
+        req = req.header("X-AnchorMailbox", mb);
+    }
+    let resp = req
         .body(envelope)
         .send()
         .await

--- a/src/ews/soap.rs
+++ b/src/ews/soap.rs
@@ -147,25 +147,35 @@ pub async fn post_soap(
 }
 
 /// Pull a human-readable error out of a SOAP fault response.
+///
+/// When EWS includes a machine-readable `ResponseCode` (e.g.
+/// `ErrorNonExistentMailbox`) it is prepended to the localized `faultstring`,
+/// so callers can match on the code without depending on the server's display
+/// language.
 pub fn extract_soap_fault(xml: &str) -> Option<String> {
     if !xml.contains("Fault") && !xml.contains("ResponseCode") {
         return None;
     }
+
+    // Language-independent error code, present in both SOAP-Fault detail blocks
+    // and per-message responses. `NoError` means "no fault here".
+    let code = first_tag_content(xml, "ResponseCode").filter(|c| c != "NoError");
+
     // Errors come either as a SOAP Fault or as a per-message ResponseCode.
     if let Some(reason) =
         first_tag_content(xml, "faultstring").or_else(|| first_tag_content(xml, "Reason"))
     {
-        return Some(reason);
+        return Some(match code {
+            Some(c) => format!("{c}: {reason}"),
+            None => reason,
+        });
     }
+
     // Per-message error: ResponseCode != "NoError" with optional MessageText.
-    let response_code = first_tag_content(xml, "ResponseCode");
-    if let Some(code) = &response_code {
-        if code == "NoError" {
-            return None;
-        }
+    if let Some(code) = code {
         let detail = first_tag_content(xml, "MessageText").unwrap_or_default();
         return Some(if detail.is_empty() {
-            code.clone()
+            code
         } else {
             format!("{code}: {detail}")
         });
@@ -376,6 +386,19 @@ mod tests {
     fn fault_detection() {
         let xml = "<soap:Fault><faultstring>auth required</faultstring></soap:Fault>";
         assert_eq!(extract_soap_fault(xml), Some("auth required".to_string()));
+    }
+
+    #[test]
+    fn fault_prepends_response_code_when_present() {
+        // EWS impersonation failures arrive as a SOAP Fault whose detail block
+        // carries the language-independent ResponseCode. We surface the code so
+        // callers can match on it regardless of the server's display language.
+        let xml = "<soap:Fault><faultstring xml:lang=\"fr-FR\">Aucune boîte aux lettres.</faultstring>\
+                   <detail><e:ResponseCode>ErrorNonExistentMailbox</e:ResponseCode></detail></soap:Fault>";
+        assert_eq!(
+            extract_soap_fault(xml),
+            Some("ErrorNonExistentMailbox: Aucune boîte aux lettres.".to_string())
+        );
     }
 
     #[test]

--- a/src/ews/soap.rs
+++ b/src/ews/soap.rs
@@ -33,13 +33,26 @@ pub const NS_TYPES: &str = "http://schemas.microsoft.com/exchange/services/2006/
 pub const NS_MESSAGES: &str = "http://schemas.microsoft.com/exchange/services/2006/messages";
 
 /// Wrap a SOAP body in a complete envelope with the standard headers.
-pub fn envelope(body: &str) -> String {
+///
+/// When `impersonate_email` is `Some`, an `<t:ExchangeImpersonation>` header is
+/// added so the request executes against that mailbox instead of the
+/// authenticating principal's. This is the admin-controlled "Global EWS via
+/// Impersonation" path — the connecting account must hold the
+/// `ApplicationImpersonation` RBAC role on Exchange.
+pub fn envelope(body: &str, impersonate_email: Option<&str>) -> String {
+    let impersonation = match impersonate_email {
+        Some(mb) if !mb.is_empty() => format!(
+            "    <t:ExchangeImpersonation>\n      <t:ConnectingSID>\n        <t:PrimarySmtpAddress>{}</t:PrimarySmtpAddress>\n      </t:ConnectingSID>\n    </t:ExchangeImpersonation>\n",
+            escape(mb)
+        ),
+        _ => String::new(),
+    };
     format!(
         r#"<?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="{ns_soap}" xmlns:t="{ns_types}" xmlns:m="{ns_messages}">
   <soap:Header>
     <t:RequestServerVersion Version="{version}" />
-  </soap:Header>
+{impersonation}  </soap:Header>
   <soap:Body>
 {body}
   </soap:Body>
@@ -48,6 +61,7 @@ pub fn envelope(body: &str) -> String {
         ns_types = NS_TYPES,
         ns_messages = NS_MESSAGES,
         version = REQUEST_SERVER_VERSION,
+        impersonation = impersonation,
         body = body,
     )
 }
@@ -65,12 +79,17 @@ pub fn http_client(timeout: Duration) -> Result<Client> {
 
 /// Send a SOAP request and return the response body. The caller passes the
 /// inner SOAP body; this function adds the envelope, headers, and basic auth.
+///
+/// When `impersonate_email` is `Some`, the envelope carries an
+/// `<t:ExchangeImpersonation>` header — the request runs as that mailbox under
+/// the connecting service account's RBAC `ApplicationImpersonation` grant.
 pub async fn post_soap(
     endpoint: &str,
     username: &str,
     password: &str,
     body: &str,
     fetch: bool,
+    impersonate_email: Option<&str>,
 ) -> Result<String> {
     let timeout = if fetch {
         FETCH_TIMEOUT
@@ -78,7 +97,7 @@ pub async fn post_soap(
         DEFAULT_TIMEOUT
     };
     let client = http_client(timeout)?;
-    let envelope = envelope(body);
+    let envelope = envelope(body, impersonate_email);
 
     tracing::debug!(endpoint = %endpoint, body_len = envelope.len(), "EWS SOAP request");
     let resp = client

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,9 @@ async fn main() -> Result<()> {
         Commands::Booking { command } => {
             commands::booking::run(&pool, &secret_key, command).await?
         }
-        Commands::User { command } => commands::user::run(&pool, &data_dir, command).await?,
+        Commands::User { command } => {
+            commands::user::run(&pool, &data_dir, &secret_key, command).await?
+        }
         Commands::Resource { command } => commands::resource::run(command).await?,
         Commands::Config { command } => commands::config::run(&pool, &secret_key, command).await?,
         Commands::Serve { port, host } => {

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -20,19 +20,30 @@ pub mod kinds {
 /// other parameters are the URL / username / decrypted password — any of them
 /// may carry provider-specific meaning (e.g. for EWS the URL is the
 /// `Exchange.asmx` endpoint, for CalDAV it is the discovery URL).
+///
+/// `impersonate_email` is only honoured by the EWS backend: when `Some`, the
+/// SOAP layer adds a `t:ExchangeImpersonation` header so requests execute as
+/// that mailbox under the connecting account's `ApplicationImpersonation` RBAC
+/// grant. CalDAV ignores it.
 pub fn build_provider(
     provider_type: &str,
     url: &str,
     username: &str,
     password: &str,
+    impersonate_email: Option<&str>,
 ) -> Result<Box<dyn CalendarProvider>> {
     match provider_type {
         kinds::CALDAV => Ok(Box::new(super::caldav::CaldavProvider::new(
             url, username, password,
         ))),
-        kinds::EWS => Ok(Box::new(crate::ews::EwsProvider::new(
-            url, username, password,
-        ))),
+        kinds::EWS => match impersonate_email {
+            Some(mb) if !mb.is_empty() => Ok(Box::new(
+                crate::ews::EwsProvider::with_impersonation(url, username, password, mb),
+            )),
+            _ => Ok(Box::new(crate::ews::EwsProvider::new(
+                url, username, password,
+            ))),
+        },
         other => bail!("Unknown calendar provider type: '{}'", other),
     }
 }

--- a/src/web/ews_global.rs
+++ b/src/web/ews_global.rs
@@ -1,0 +1,138 @@
+//! Global EWS impersonation: one Exchange server + one service-account
+//! holding the `ApplicationImpersonation` RBAC role, auto-provisioned for
+//! every user via a "managed" row in `caldav_sources`.
+//!
+//! The shape mirrors `captcha`: a struct, a loader, and runtime caching via a
+//! `RwLock<Option<EwsGlobalConfig>>` on `AppState`. `None` means the feature is
+//! disabled — the sync loop falls back to per-user EWS / CalDAV sources.
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+
+#[derive(Clone)]
+pub struct EwsGlobalConfig {
+    pub url: String,
+    pub service_username: String,
+    pub service_password: String,
+    pub lock_user_sources: bool,
+    pub auto_provision: bool,
+}
+
+/// Hydrate the global EWS config from `auth_config`. Returns `None` when the
+/// feature is disabled or any required field is missing — both cases mean
+/// "behave exactly as if the feature didn't exist".
+pub async fn load_ews_global_config(pool: &SqlitePool, key: &[u8; 32]) -> Option<EwsGlobalConfig> {
+    let row: (
+        i64,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        i64,
+        i64,
+    ) = sqlx::query_as(
+        "SELECT ews_global_enabled, ews_global_url, ews_service_username, \
+                ews_service_password_enc, ews_lock_user_sources, ews_auto_provision \
+         FROM auth_config WHERE id = 'singleton'",
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()?;
+
+    let (enabled, url, username, password_enc, lock_user_sources, auto_provision) = row;
+    if enabled == 0 {
+        return None;
+    }
+    let url = url.filter(|s| !s.trim().is_empty())?;
+    let username = username.filter(|s| !s.trim().is_empty())?;
+    let password_enc = password_enc.filter(|s| !s.trim().is_empty())?;
+    let password = crate::crypto::decrypt_value(key, &password_enc).ok()?;
+
+    Some(EwsGlobalConfig {
+        url,
+        service_username: username,
+        service_password: password,
+        lock_user_sources: lock_user_sources != 0,
+        auto_provision: auto_provision != 0,
+    })
+}
+
+/// Idempotently insert a managed EWS source row for one user.
+///
+/// Pre-checks for an existing `managed=1, provider_type='ews'` row on the
+/// user's account so calling this on every login / config-save / user-create
+/// is safe.
+///
+/// The row holds the connect URL + service-account username (informational —
+/// the sync path reads the live config from the cache), `password_enc=NULL`,
+/// `impersonate_email=user_email` and `managed=1`. The SOAP layer will inject
+/// the `t:ExchangeImpersonation` header on every request.
+pub async fn provision_managed_ews_source_for_user(
+    pool: &SqlitePool,
+    cfg: &EwsGlobalConfig,
+    user_id: &str,
+    user_email: &str,
+) -> Result<bool> {
+    let account: Option<(String,)> =
+        sqlx::query_as("SELECT id FROM accounts WHERE user_id = ? LIMIT 1")
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await?;
+    let Some((account_id,)) = account else {
+        return Ok(false);
+    };
+
+    let existing: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM caldav_sources \
+         WHERE account_id = ? AND provider_type = 'ews' AND managed = 1 \
+         LIMIT 1",
+    )
+    .bind(&account_id)
+    .fetch_optional(pool)
+    .await?;
+    if existing.is_some() {
+        return Ok(false);
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO caldav_sources \
+            (id, account_id, name, url, username, password_enc, provider_type, \
+             managed, impersonate_email, enabled, auth_type) \
+         VALUES (?, ?, 'Exchange (managed)', ?, ?, NULL, 'ews', 1, ?, 1, 'basic')",
+    )
+    .bind(&id)
+    .bind(&account_id)
+    .bind(&cfg.url)
+    .bind(&cfg.service_username)
+    .bind(user_email)
+    .execute(pool)
+    .await?;
+
+    tracing::info!(
+        user_id = %user_id,
+        user_email = %user_email,
+        source_id = %id,
+        "provisioned managed EWS source"
+    );
+    Ok(true)
+}
+
+/// Provision a managed source for every enabled user. Returns the count of
+/// rows newly inserted (existing rows are left untouched).
+pub async fn provision_managed_ews_source_for_all_users(
+    pool: &SqlitePool,
+    cfg: &EwsGlobalConfig,
+) -> Result<usize> {
+    let users: Vec<(String, String)> =
+        sqlx::query_as("SELECT id, email FROM users WHERE enabled = 1")
+            .fetch_all(pool)
+            .await?;
+    let mut count = 0usize;
+    for (id, email) in users {
+        if provision_managed_ews_source_for_user(pool, cfg, &id, &email).await? {
+            count += 1;
+        }
+    }
+    Ok(count)
+}

--- a/src/web/ews_global.rs
+++ b/src/web/ews_global.rs
@@ -92,9 +92,11 @@ pub async fn load_ews_global_config(pool: &SqlitePool, key: &[u8; 32]) -> Option
 
 /// Idempotently insert a managed EWS source row for one user.
 ///
-/// Pre-checks for an existing `managed=1, provider_type='ews'` row on the
-/// user's account so calling this on every login / config-save / user-create
-/// is safe.
+/// Idempotent and race-safe: relies on the partial unique index
+/// `idx_caldav_sources_managed_ews_unique` (one managed EWS source per account)
+/// plus `ON CONFLICT DO NOTHING`, so concurrent provisioning (e.g. an OIDC
+/// login racing the admin's "provision now") inserts at most one row. Returns
+/// `true` only when a row was actually created.
 ///
 /// The row holds the connect URL + service-account username (informational —
 /// the sync path reads the live config from the cache), `password_enc=NULL`,
@@ -115,24 +117,13 @@ pub async fn provision_managed_ews_source_for_user(
         return Ok(false);
     };
 
-    let existing: Option<(String,)> = sqlx::query_as(
-        "SELECT id FROM caldav_sources \
-         WHERE account_id = ? AND provider_type = 'ews' AND managed = 1 \
-         LIMIT 1",
-    )
-    .bind(&account_id)
-    .fetch_optional(pool)
-    .await?;
-    if existing.is_some() {
-        return Ok(false);
-    }
-
     let id = uuid::Uuid::new_v4().to_string();
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO caldav_sources \
             (id, account_id, name, url, username, password_enc, provider_type, \
              managed, impersonate_email, enabled, auth_type) \
-         VALUES (?, ?, 'Exchange (managed)', ?, ?, NULL, 'ews', 1, ?, 1, 'basic')",
+         VALUES (?, ?, 'Exchange (managed)', ?, ?, NULL, 'ews', 1, ?, 1, 'basic') \
+         ON CONFLICT DO NOTHING",
     )
     .bind(&id)
     .bind(&account_id)
@@ -141,6 +132,11 @@ pub async fn provision_managed_ews_source_for_user(
     .bind(user_email)
     .execute(pool)
     .await?;
+
+    if result.rows_affected() == 0 {
+        // A managed source already existed for this account.
+        return Ok(false);
+    }
 
     tracing::info!(
         user_id = %user_id,
@@ -173,6 +169,69 @@ pub async fn provision_managed_ews_source_for_all_users(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use std::str::FromStr;
+
+    async fn memory_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                SqliteConnectOptions::from_str("sqlite::memory:")
+                    .unwrap()
+                    .foreign_keys(true),
+            )
+            .await
+            .unwrap();
+        crate::db::migrate(&pool).await.unwrap();
+        pool
+    }
+
+    async fn seed_user(pool: &SqlitePool, email: &str) -> String {
+        let user_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO users (id, email, name, role, auth_provider, username, enabled) VALUES (?, ?, 'U', 'user', 'local', ?, 1)")
+            .bind(&user_id)
+            .bind(email)
+            .bind(email.split('@').next().unwrap())
+            .execute(pool)
+            .await
+            .unwrap();
+        let account_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO accounts (id, name, email, timezone, user_id) VALUES (?, 'U', ?, 'UTC', ?)")
+            .bind(&account_id)
+            .bind(email)
+            .bind(&user_id)
+            .execute(pool)
+            .await
+            .unwrap();
+        user_id
+    }
+
+    #[tokio::test]
+    async fn provision_is_idempotent_and_race_safe() {
+        let pool = memory_pool().await;
+        let cfg = cfg_with_domain(None);
+        let user_id = seed_user(&pool, "alice@dyb.fr").await;
+
+        // First provision creates a row; the second is a no-op.
+        assert!(
+            provision_managed_ews_source_for_user(&pool, &cfg, &user_id, "alice@dyb.fr")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !provision_managed_ews_source_for_user(&pool, &cfg, &user_id, "alice@dyb.fr")
+                .await
+                .unwrap()
+        );
+
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM caldav_sources WHERE managed = 1 AND provider_type = 'ews'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count.0, 1, "exactly one managed EWS source per account");
+    }
 
     fn cfg_with_domain(domain: Option<&str>) -> EwsGlobalConfig {
         EwsGlobalConfig {

--- a/src/web/ews_global.rs
+++ b/src/web/ews_global.rs
@@ -16,6 +16,36 @@ pub struct EwsGlobalConfig {
     pub service_password: String,
     pub lock_user_sources: bool,
     pub auto_provision: bool,
+    /// Optional override for the mailbox domain used in the impersonation
+    /// header. When the AD UPN / calrs login domain differs from the Exchange
+    /// PrimarySmtpAddress domain (e.g. `dyb.lan` vs `dyb.fr`), set this to the
+    /// mailbox domain so impersonation resolves to a real mailbox.
+    pub impersonation_domain: Option<String>,
+}
+
+impl EwsGlobalConfig {
+    /// Compute the actual impersonation target address for a calrs user email.
+    /// When `impersonation_domain` is set, the local part is kept and the
+    /// domain is replaced (e.g. `alice@dyb.lan` -> `alice@dyb.fr`). Otherwise
+    /// the address is used as-is.
+    pub fn impersonation_target(&self, addr: Option<&str>) -> Option<String> {
+        let addr = addr?.trim();
+        if addr.is_empty() {
+            return None;
+        }
+        match self
+            .impersonation_domain
+            .as_deref()
+            .map(str::trim)
+            .filter(|d| !d.is_empty())
+        {
+            Some(domain) => {
+                let local = addr.split('@').next().unwrap_or(addr);
+                Some(format!("{local}@{domain}"))
+            }
+            None => Some(addr.to_string()),
+        }
+    }
 }
 
 /// Hydrate the global EWS config from `auth_config`. Returns `None` when the
@@ -29,9 +59,11 @@ pub async fn load_ews_global_config(pool: &SqlitePool, key: &[u8; 32]) -> Option
         Option<String>,
         i64,
         i64,
+        Option<String>,
     ) = sqlx::query_as(
         "SELECT ews_global_enabled, ews_global_url, ews_service_username, \
-                ews_service_password_enc, ews_lock_user_sources, ews_auto_provision \
+                ews_service_password_enc, ews_lock_user_sources, ews_auto_provision, \
+                ews_impersonation_domain \
          FROM auth_config WHERE id = 'singleton'",
     )
     .fetch_optional(pool)
@@ -39,7 +71,7 @@ pub async fn load_ews_global_config(pool: &SqlitePool, key: &[u8; 32]) -> Option
     .ok()
     .flatten()?;
 
-    let (enabled, url, username, password_enc, lock_user_sources, auto_provision) = row;
+    let (enabled, url, username, password_enc, lock_user_sources, auto_provision, imp_domain) = row;
     if enabled == 0 {
         return None;
     }
@@ -54,6 +86,7 @@ pub async fn load_ews_global_config(pool: &SqlitePool, key: &[u8; 32]) -> Option
         service_password: password,
         lock_user_sources: lock_user_sources != 0,
         auto_provision: auto_provision != 0,
+        impersonation_domain: imp_domain.filter(|s| !s.trim().is_empty()),
     })
 }
 
@@ -135,4 +168,54 @@ pub async fn provision_managed_ews_source_for_all_users(
         }
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with_domain(domain: Option<&str>) -> EwsGlobalConfig {
+        EwsGlobalConfig {
+            url: "https://mail.example.com/EWS/Exchange.asmx".to_string(),
+            service_username: "svc".to_string(),
+            service_password: "pw".to_string(),
+            lock_user_sources: false,
+            auto_provision: true,
+            impersonation_domain: domain.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn impersonation_target_without_override_is_identity() {
+        let cfg = cfg_with_domain(None);
+        assert_eq!(
+            cfg.impersonation_target(Some("alice@dyb.fr")).as_deref(),
+            Some("alice@dyb.fr")
+        );
+    }
+
+    #[test]
+    fn impersonation_target_rewrites_domain() {
+        let cfg = cfg_with_domain(Some("dyb.fr"));
+        assert_eq!(
+            cfg.impersonation_target(Some("alice@dyb.lan")).as_deref(),
+            Some("alice@dyb.fr")
+        );
+    }
+
+    #[test]
+    fn impersonation_target_rewrites_bare_local_part() {
+        let cfg = cfg_with_domain(Some("dyb.fr"));
+        assert_eq!(
+            cfg.impersonation_target(Some("alice")).as_deref(),
+            Some("alice@dyb.fr")
+        );
+    }
+
+    #[test]
+    fn impersonation_target_handles_none_and_empty() {
+        let cfg = cfg_with_domain(Some("dyb.fr"));
+        assert_eq!(cfg.impersonation_target(None), None);
+        assert_eq!(cfg.impersonation_target(Some("   ")), None);
+    }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -16924,7 +16924,9 @@ async fn admin_update_ews_global(
         .await
     };
     if let Err(e) = write_result {
-        tracing::error!(error = %e, "failed to save global EWS config");
+        // Don't reload the cache, provision, or redirect to success on a failed
+        // write — that would leave the admin believing stale config was saved.
+        return internal_error_response("save global EWS config", &e);
     }
 
     // Reload cache so the next sync / next request sees the new values.

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,4 +1,5 @@
 pub mod captcha;
+pub mod ews_global;
 pub mod meeting;
 
 use crate::utils::{convert_event_to_tz, parse_ical_datetime};
@@ -93,6 +94,10 @@ pub struct AppState {
     pub theme_css: tokio::sync::RwLock<String>,
     pub company_link: tokio::sync::RwLock<Option<String>>,
     pub captcha_config: tokio::sync::RwLock<Option<captcha::CaptchaConfig>>,
+    /// Global EWS impersonation: when `Some`, every user has a managed source
+    /// row that the sync loop drives with the SOAP `ExchangeImpersonation`
+    /// header. Reloaded when the admin saves changes.
+    pub ews_global: tokio::sync::RwLock<Option<ews_global::EwsGlobalConfig>>,
     /// Org-wide meeting provider config (Jitsi + webhook). Cached so guest
     /// slot/booking pages don't hit `auth_config` on every render. Rebuilt
     /// when the admin saves changes.
@@ -1201,6 +1206,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
     let initial_theme_css = build_theme_css(&pool).await;
     let initial_company_link = get_company_link(&pool).await;
     let initial_captcha = captcha::load_captcha_config(&pool, &secret_key).await;
+    let initial_ews_global = ews_global::load_ews_global_config(&pool, &secret_key).await;
     let initial_meeting = meeting::load_config(&pool, &secret_key).await;
     let initial_csp = build_csp(&initial_captcha);
 
@@ -1215,6 +1221,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         theme_css: tokio::sync::RwLock::new(initial_theme_css),
         company_link: tokio::sync::RwLock::new(initial_company_link),
         captcha_config: tokio::sync::RwLock::new(initial_captcha),
+        ews_global: tokio::sync::RwLock::new(initial_ews_global),
         meeting_config: tokio::sync::RwLock::new(initial_meeting),
         csp: tokio::sync::RwLock::new(initial_csp),
         csp_baseline: build_csp(&None),
@@ -1383,6 +1390,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/dashboard/admin/smtp", post(admin_update_smtp))
         .route("/dashboard/admin/smtp/test", post(admin_update_smtp_test))
         .route("/dashboard/admin/smtp/clear", post(admin_update_smtp_clear))
+        .route("/dashboard/admin/ews", post(admin_update_ews_global))
         .route("/dashboard/admin/jitsi", post(admin_update_jitsi))
         .route(
             "/dashboard/admin/meeting-webhook",
@@ -2705,6 +2713,7 @@ async fn dashboard_sources(
 ) -> impl IntoResponse {
     let user = &auth_user.user;
 
+    #[allow(clippy::type_complexity)]
     let sources: Vec<(
         String,
         String,
@@ -2715,8 +2724,10 @@ async fn dashboard_sources(
         Option<String>,
         String,
         String,
+        i64,
     )> = sqlx::query_as(
-        "SELECT cs.id, cs.name, cs.url, cs.username, cs.last_synced, cs.enabled, cs.write_calendar_href, cs.auth_type, cs.provider_type
+        "SELECT cs.id, cs.name, cs.url, cs.username, cs.last_synced, cs.enabled, \
+                cs.write_calendar_href, cs.auth_type, cs.provider_type, cs.managed
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE a.user_id = ?
@@ -2753,6 +2764,7 @@ async fn dashboard_sources(
                 write_cal,
                 auth_type,
                 provider_type,
+                managed,
             )| {
                 let cals: Vec<minijinja::Value> = all_calendars
                     .iter()
@@ -2776,6 +2788,7 @@ async fn dashboard_sources(
                     auth_type => auth_type,
                     provider_type => provider_type,
                     provider_label => crate::providers::factory::label(provider_type),
+                    managed => *managed != 0,
                     calendars => cals,
                 }
             },
@@ -2789,12 +2802,23 @@ async fn dashboard_sources(
 
     let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
 
+    let lock_user_sources = state
+        .ews_global
+        .read()
+        .await
+        .as_ref()
+        .map(|c| c.lock_user_sources)
+        .unwrap_or(false);
+    let is_admin = auth_user.user.role == "admin";
+
     Html(
         tmpl.render(context! {
             sidebar => sidebar_context(&auth_user, "sources"),
             sources => sources_ctx,
             impersonating => impersonating,
             impersonating_name => impersonating_name,
+            lock_user_sources => lock_user_sources,
+            is_admin => is_admin,
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e)),
     )
@@ -6016,13 +6040,49 @@ fn caldav_providers() -> Vec<(&'static str, &'static str, &'static str, &'static
     ]
 }
 
+/// When the admin has enabled the "lock user sources" flag, non-admin users
+/// can't add or edit their own calendar sources. Returns `Some(response)` with
+/// a 403 to short-circuit the handler in that case, `None` to proceed.
+async fn user_source_lockdown_response(
+    state: &Arc<AppState>,
+    auth_user: &crate::auth::AuthUser,
+) -> Option<Response> {
+    if auth_user.user.role == "admin" {
+        return None;
+    }
+    let locked = state
+        .ews_global
+        .read()
+        .await
+        .as_ref()
+        .map(|c| c.lock_user_sources)
+        .unwrap_or(false);
+    if !locked {
+        return None;
+    }
+    Some(
+        (
+            axum::http::StatusCode::FORBIDDEN,
+            Html(
+                "Adding personal calendar sources is disabled by the administrator. \
+                 Your Exchange calendar is managed centrally."
+                    .to_string(),
+            ),
+        )
+            .into_response(),
+    )
+}
+
 async fn new_source_form(
     State(state): State<Arc<AppState>>,
     auth_user: crate::auth::AuthUser,
-) -> impl IntoResponse {
+) -> Response {
+    if let Some(resp) = user_source_lockdown_response(&state, &auth_user).await {
+        return resp;
+    }
     let tmpl = match state.templates.get_template("source_form.html") {
         Ok(t) => t,
-        Err(e) => return internal_error_html("template render", &e),
+        Err(e) => return internal_error_html("template render", &e).into_response(),
     };
 
     let providers: Vec<minijinja::Value> = caldav_providers()
@@ -6057,6 +6117,7 @@ async fn new_source_form(
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e)),
     )
+    .into_response()
 }
 
 async fn create_source(
@@ -6066,6 +6127,9 @@ async fn create_source(
     Form(form): Form<SourceForm>,
 ) -> impl IntoResponse {
     if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+    if let Some(resp) = user_source_lockdown_response(&state, &auth_user).await {
         return resp;
     }
     let user = &auth_user.user;
@@ -6115,15 +6179,19 @@ async fn create_source(
     // Test connection unless skip requested
     let skip_test = form.no_test.as_deref() == Some("on");
     if !skip_test {
-        let client =
-            match crate::providers::build_provider(&provider_type, &url, &username, &form.password)
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    return render_source_form_error(&state, &auth_user, &e.to_string(), &form)
-                        .into_response();
-                }
-            };
+        let client = match crate::providers::build_provider(
+            &provider_type,
+            &url,
+            &username,
+            &form.password,
+            None,
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                return render_source_form_error(&state, &auth_user, &e.to_string(), &form)
+                    .into_response();
+            }
+        };
         match client.check_connection().await {
             Ok(_) => {} // fine, even if features not explicitly advertised
             Err(e) => {
@@ -6295,8 +6363,8 @@ async fn update_source(
 
     // Confirm the source belongs to this user and grab the existing
     // password (used as fallback when the form leaves it blank).
-    let existing: Option<(String,)> = sqlx::query_as(
-        "SELECT cs.password_enc
+    let existing: Option<(String, i64)> = sqlx::query_as(
+        "SELECT cs.password_enc, cs.managed
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE cs.id = ? AND a.user_id = ?",
@@ -6307,10 +6375,23 @@ async fn update_source(
     .await
     .unwrap_or(None);
 
-    let existing_password_enc = match existing {
-        Some((enc,)) => enc,
+    let (existing_password_enc, is_managed) = match existing {
+        Some((enc, managed)) => (enc, managed),
         None => return Redirect::to("/dashboard/sources").into_response(),
     };
+
+    // Managed sources are owned by the global admin config — regular users
+    // cannot mutate them via the dashboard.
+    if is_managed != 0 && user.role != "admin" {
+        return (
+            axum::http::StatusCode::FORBIDDEN,
+            Html(
+                "This calendar source is provisioned by the administrator and cannot be edited."
+                    .to_string(),
+            ),
+        )
+            .into_response();
+    }
 
     let url = form.url.trim().to_string();
     let username = form.username.trim().to_string();
@@ -6420,6 +6501,32 @@ async fn remove_source(
     }
     let user = &auth_user.user;
 
+    // Managed (admin-provisioned) sources can't be removed by regular users —
+    // only admins can delete them. Without this check a user could remove the
+    // central Exchange link the admin set up.
+    if user.role != "admin" {
+        let is_managed: Option<(i64,)> = sqlx::query_as(
+            "SELECT cs.managed FROM caldav_sources cs \
+             JOIN accounts a ON a.id = cs.account_id \
+             WHERE cs.id = ? AND a.user_id = ?",
+        )
+        .bind(&source_id)
+        .bind(&user.id)
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+        if matches!(is_managed, Some((m,)) if m != 0) {
+            return (
+                axum::http::StatusCode::FORBIDDEN,
+                Html(
+                    "This calendar source is provisioned by the administrator and cannot be removed."
+                        .to_string(),
+                ),
+            )
+                .into_response();
+        }
+    }
+
     // Verify source belongs to this user before deleting
     let _ = sqlx::query(
         "DELETE FROM caldav_sources WHERE id = ? AND account_id IN (SELECT id FROM accounts WHERE user_id = ?)",
@@ -6498,7 +6605,7 @@ async fn test_source(
                 return Html("Source has no stored password.".to_string()).into_response();
             }
         };
-        match crate::providers::build_provider(&provider_type, &url, &username, &password) {
+        match crate::providers::build_provider(&provider_type, &url, &username, &password, None) {
             Ok(client) => match client.check_connection().await {
                 Ok(true) => format!("'{}' — connection OK ({}).", name, label),
                 Ok(false) => format!(
@@ -6641,7 +6748,7 @@ async fn run_sync(
 ) -> (Vec<String>, usize) {
     if provider_type == crate::providers::factory::kinds::EWS {
         let provider =
-            match crate::providers::build_provider(provider_type, url, username, password) {
+            match crate::providers::build_provider(provider_type, url, username, password, None) {
                 Ok(p) => p,
                 Err(e) => return (vec![format!("Could not build provider: {}", e)], 0),
             };
@@ -15142,6 +15249,30 @@ async fn admin_dashboard(
         .unwrap_or_else(|| captcha::DEFAULT_WIDGET_URL.to_string());
     drop(captcha_cfg);
 
+    let ews_cfg = state.ews_global.read().await;
+    let ews_global_enabled = ews_cfg.is_some();
+    let ews_global_url = ews_cfg.as_ref().map(|c| c.url.clone()).unwrap_or_default();
+    let ews_service_username = ews_cfg
+        .as_ref()
+        .map(|c| c.service_username.clone())
+        .unwrap_or_default();
+    let ews_has_password = ews_cfg
+        .as_ref()
+        .map(|c| !c.service_password.is_empty())
+        .unwrap_or(false);
+    let ews_lock_user_sources = ews_cfg
+        .as_ref()
+        .map(|c| c.lock_user_sources)
+        .unwrap_or(false);
+    let ews_auto_provision = ews_cfg.as_ref().map(|c| c.auto_provision).unwrap_or(false);
+    drop(ews_cfg);
+    let ews_managed_source_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM caldav_sources WHERE managed = 1 AND provider_type = 'ews'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .unwrap_or(0);
+
     let meeting_cfg = state.meeting_config.read().await;
     let jitsi_configured = meeting_cfg.jitsi.is_some();
     let jitsi_base_url = meeting_cfg
@@ -15218,6 +15349,13 @@ async fn admin_dashboard(
             captcha_instance_url => captcha_instance_url,
             captcha_site_key => captcha_site_key,
             captcha_widget_url => captcha_widget_url,
+            ews_global_enabled => ews_global_enabled,
+            ews_global_url => ews_global_url,
+            ews_service_username => ews_service_username,
+            ews_has_password => ews_has_password,
+            ews_lock_user_sources => ews_lock_user_sources,
+            ews_auto_provision => ews_auto_provision,
+            ews_managed_source_count => ews_managed_source_count,
             jitsi_configured => jitsi_configured,
             jitsi_base_url => jitsi_base_url,
             jitsi_pattern => jitsi_pattern,
@@ -16560,6 +16698,122 @@ async fn admin_update_smtp_clear(
 
     tracing::info!(admin = %_admin.0.email, "admin: smtp config cleared");
     Redirect::to("/dashboard/admin").into_response()
+}
+
+// --- Global EWS impersonation ---
+
+#[derive(Deserialize)]
+struct AdminEwsGlobalForm {
+    _csrf: Option<String>,
+    ews_global_enabled: Option<String>,
+    ews_global_url: Option<String>,
+    ews_service_username: Option<String>,
+    ews_service_password: Option<String>,
+    ews_lock_user_sources: Option<String>,
+    ews_auto_provision: Option<String>,
+    /// When set (button `name="provision_now" value="1"`), provision a
+    /// managed source for every enabled user after saving.
+    provision_now: Option<String>,
+}
+
+async fn admin_update_ews_global(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminEwsGlobalForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    let enabled = form.ews_global_enabled.as_deref() == Some("on");
+    let url = form.ews_global_url.filter(|s| !s.trim().is_empty());
+    let username = form.ews_service_username.filter(|s| !s.trim().is_empty());
+    let lock = form.ews_lock_user_sources.as_deref() == Some("on");
+    let auto_provision = form.ews_auto_provision.as_deref() == Some("on");
+    let provision_now = form.provision_now.as_deref() == Some("1");
+
+    // Validate URL when enabling. Reject early instead of silently storing
+    // garbage that would later make every sync fail.
+    if enabled {
+        if let Some(u) = url.as_deref() {
+            if let Err(e) =
+                crate::providers::factory::validate_url(crate::providers::factory::kinds::EWS, u)
+            {
+                tracing::warn!(error = %e, "admin: invalid global EWS URL");
+                return Redirect::to("/dashboard/admin#ews-global").into_response();
+            }
+        }
+    }
+
+    let secret_provided = form
+        .ews_service_password
+        .as_ref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+
+    let write_result = if secret_provided {
+        let secret = form.ews_service_password.unwrap_or_default();
+        let encrypted = match crate::crypto::encrypt_value(&state.secret_key, &secret) {
+            Ok(s) => s,
+            Err(e) => return internal_error_response("encrypt EWS service password", &e),
+        };
+        sqlx::query(
+            "UPDATE auth_config SET ews_global_enabled = ?, ews_global_url = ?, \
+                 ews_service_username = ?, ews_service_password_enc = ?, \
+                 ews_lock_user_sources = ?, ews_auto_provision = ?, \
+                 updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(enabled as i64)
+        .bind(&url)
+        .bind(&username)
+        .bind(&encrypted)
+        .bind(lock as i64)
+        .bind(auto_provision as i64)
+        .execute(&state.pool)
+        .await
+    } else {
+        sqlx::query(
+            "UPDATE auth_config SET ews_global_enabled = ?, ews_global_url = ?, \
+                 ews_service_username = ?, ews_lock_user_sources = ?, ews_auto_provision = ?, \
+                 updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(enabled as i64)
+        .bind(&url)
+        .bind(&username)
+        .bind(lock as i64)
+        .bind(auto_provision as i64)
+        .execute(&state.pool)
+        .await
+    };
+    if let Err(e) = write_result {
+        tracing::error!(error = %e, "failed to save global EWS config");
+    }
+
+    // Reload cache so the next sync / next request sees the new values.
+    let new_config = ews_global::load_ews_global_config(&state.pool, &state.secret_key).await;
+
+    // Run provisioning if asked, OR if the admin enabled auto-provision in
+    // the same save. Either intent means "spread the managed source to every
+    // existing user now".
+    if let Some(cfg) = new_config.as_ref() {
+        if provision_now || cfg.auto_provision {
+            match ews_global::provision_managed_ews_source_for_all_users(&state.pool, cfg).await {
+                Ok(n) => {
+                    tracing::info!(provisioned = n, "admin: global EWS provisioning batch done");
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "global EWS provisioning failed");
+                }
+            }
+        }
+    }
+
+    *state.ews_global.write().await = new_config;
+
+    tracing::info!(admin = %_admin.0.email, enabled, "admin: global EWS config updated");
+
+    Redirect::to("/dashboard/admin#ews-global").into_response()
 }
 
 // --- Auto-generated meeting link settings ---
@@ -18946,6 +19200,7 @@ async fn caldav_push_booking_for_user(
     details: &crate::email::BookingDetails,
 ) {
     // Find all sources with write_calendar_href configured for this user
+    #[allow(clippy::type_complexity)]
     let sources: Vec<(
         String,
         String,
@@ -18956,8 +19211,12 @@ async fn caldav_push_booking_for_user(
         Option<String>,
         Option<String>,
         String,
+        i64,
+        Option<String>,
     )> = sqlx::query_as(
-        "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.write_calendar_href, cs.auth_type, cs.access_token_enc, cs.token_expires_at, cs.provider_type
+        "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.write_calendar_href, cs.auth_type, \
+                cs.access_token_enc, cs.token_expires_at, cs.provider_type, \
+                cs.managed, cs.impersonate_email
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE a.user_id = ? AND cs.enabled = 1 AND cs.write_calendar_href IS NOT NULL",
@@ -18966,6 +19225,8 @@ async fn caldav_push_booking_for_user(
     .fetch_all(pool)
     .await
     .unwrap_or_default();
+
+    let ews_global_cfg = crate::web::ews_global::load_ews_global_config(pool, key).await;
 
     if sources.is_empty() {
         // Distinguish "user has no sources" (debug) from "user has sources but none
@@ -19008,31 +19269,45 @@ async fn caldav_push_booking_for_user(
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     ) in &sources
     {
         tracing::debug!(uid = %booking_uid, calendar_href = %calendar_href, provider = %provider_type, "pushing booking to calendar");
 
         let put_result = if provider_type == crate::providers::factory::kinds::EWS {
-            let enc = match password_enc.as_deref() {
-                Some(e) => e,
-                None => {
-                    tracing::error!(url = %url, "calendar write-back failed: EWS source missing password");
-                    continue;
+            let client_result = if *managed != 0 {
+                match ews_global_cfg.as_ref() {
+                    Some(cfg) => crate::providers::build_provider(
+                        provider_type,
+                        &cfg.url,
+                        &cfg.service_username,
+                        &cfg.service_password,
+                        impersonate_email.as_deref(),
+                    ),
+                    None => {
+                        tracing::warn!(url = %url, "calendar write-back skipped: managed EWS source but global config disabled");
+                        continue;
+                    }
                 }
+            } else {
+                let enc = match password_enc.as_deref() {
+                    Some(e) => e,
+                    None => {
+                        tracing::error!(url = %url, "calendar write-back failed: EWS source missing password");
+                        continue;
+                    }
+                };
+                let password = match crate::crypto::decrypt_password(key, enc) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::error!(url = %url, error = %e, "calendar write-back failed: could not decrypt credentials");
+                        continue;
+                    }
+                };
+                crate::providers::build_provider(provider_type, url, username, &password, None)
             };
-            let password = match crate::crypto::decrypt_password(key, enc) {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::error!(url = %url, error = %e, "calendar write-back failed: could not decrypt credentials");
-                    continue;
-                }
-            };
-            let client = match crate::providers::build_provider(
-                provider_type,
-                url,
-                username,
-                &password,
-            ) {
+            let client = match client_result {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::error!(url = %url, error = %e, "calendar write-back failed: unknown provider");
@@ -19087,6 +19362,7 @@ async fn caldav_delete_for_user(
     user_id: &str,
     booking_uid: &str,
 ) {
+    #[allow(clippy::type_complexity)]
     let sources: Vec<(
         String,
         String,
@@ -19097,8 +19373,12 @@ async fn caldav_delete_for_user(
         Option<String>,
         Option<String>,
         String,
+        i64,
+        Option<String>,
     )> = sqlx::query_as(
-        "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.write_calendar_href, cs.auth_type, cs.access_token_enc, cs.token_expires_at, cs.provider_type
+        "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.write_calendar_href, cs.auth_type, \
+                cs.access_token_enc, cs.token_expires_at, cs.provider_type, \
+                cs.managed, cs.impersonate_email
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE a.user_id = ? AND cs.enabled = 1 AND cs.write_calendar_href IS NOT NULL",
@@ -19107,6 +19387,8 @@ async fn caldav_delete_for_user(
     .fetch_all(pool)
     .await
     .unwrap_or_default();
+
+    let ews_global_cfg = crate::web::ews_global::load_ews_global_config(pool, key).await;
 
     for (
         source_id,
@@ -19118,22 +19400,37 @@ async fn caldav_delete_for_user(
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     ) in &sources
     {
         let delete_result = if provider_type == crate::providers::factory::kinds::EWS {
-            let enc = match password_enc.as_deref() {
-                Some(e) => e,
-                None => continue,
-            };
-            let password = match crate::crypto::decrypt_password(key, enc) {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-            let client =
-                match crate::providers::build_provider(provider_type, url, username, &password) {
-                    Ok(c) => c,
+            let client_result = if *managed != 0 {
+                match ews_global_cfg.as_ref() {
+                    Some(cfg) => crate::providers::build_provider(
+                        provider_type,
+                        &cfg.url,
+                        &cfg.service_username,
+                        &cfg.service_password,
+                        impersonate_email.as_deref(),
+                    ),
+                    None => continue,
+                }
+            } else {
+                let enc = match password_enc.as_deref() {
+                    Some(e) => e,
+                    None => continue,
+                };
+                let password = match crate::crypto::decrypt_password(key, enc) {
+                    Ok(p) => p,
                     Err(_) => continue,
                 };
+                crate::providers::build_provider(provider_type, url, username, &password, None)
+            };
+            let client = match client_result {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
             client.delete_event(calendar_href, booking_uid).await
         } else {
             let client = match crate::oauth2_caldav::build_client_for_source(
@@ -19221,10 +19518,12 @@ pub(crate) async fn caldav_delete_booking(
         Option<String>,
         Option<String>,
         String,
+        i64,
+        Option<String>,
     );
     async fn find_source(pool: &SqlitePool, user: &str, href: &str) -> Option<SourceRow> {
         sqlx::query_as(
-            "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.auth_type, cs.access_token_enc, cs.token_expires_at, cs.provider_type
+            "SELECT cs.id, cs.url, cs.username, cs.password_enc, cs.auth_type, cs.access_token_enc, cs.token_expires_at, cs.provider_type, cs.managed, cs.impersonate_email
              FROM caldav_sources cs
              JOIN accounts a ON a.id = cs.account_id
              WHERE a.user_id = ? AND cs.enabled = 1 AND cs.write_calendar_href = ?
@@ -19258,6 +19557,8 @@ pub(crate) async fn caldav_delete_booking(
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     ) = match source {
         Some(s) => s,
         None => {
@@ -19271,19 +19572,32 @@ pub(crate) async fn caldav_delete_booking(
     };
 
     let delete_result = if provider_type == crate::providers::factory::kinds::EWS {
-        let enc = match password_enc.as_deref() {
-            Some(e) => e,
-            None => return,
-        };
-        let password = match crate::crypto::decrypt_password(key, enc) {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-        let client =
-            match crate::providers::build_provider(&provider_type, &url, &username, &password) {
-                Ok(c) => c,
+        let client_result = if managed != 0 {
+            match crate::web::ews_global::load_ews_global_config(pool, key).await {
+                Some(cfg) => crate::providers::build_provider(
+                    &provider_type,
+                    &cfg.url,
+                    &cfg.service_username,
+                    &cfg.service_password,
+                    impersonate_email.as_deref(),
+                ),
+                None => return,
+            }
+        } else {
+            let enc = match password_enc.as_deref() {
+                Some(e) => e,
+                None => return,
+            };
+            let password = match crate::crypto::decrypt_password(key, enc) {
+                Ok(p) => p,
                 Err(_) => return,
             };
+            crate::providers::build_provider(&provider_type, &url, &username, &password, None)
+        };
+        let client = match client_result {
+            Ok(c) => c,
+            Err(_) => return,
+        };
         client.delete_event(&calendar_href, booking_uid).await
     } else {
         let client = match crate::oauth2_caldav::build_client_for_source(

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6608,7 +6608,8 @@ async fn test_source(
                     &cfg.url,
                     &cfg.service_username,
                     &cfg.service_password,
-                    impersonate_email.as_deref(),
+                    cfg.impersonation_target(impersonate_email.as_deref())
+                        .as_deref(),
                 ),
                 None => {
                     return Html(
@@ -6741,7 +6742,7 @@ async fn run_sync_for_source(
                 &cfg.url,
                 &cfg.service_username,
                 &cfg.service_password,
-                managed.1.as_deref(),
+                cfg.impersonation_target(managed.1.as_deref()).as_deref(),
             ) {
                 Ok(p) => p,
                 Err(e) => return (vec![format!("Could not build provider: {}", e)], 0),
@@ -15338,6 +15339,10 @@ async fn admin_dashboard(
         .map(|c| c.lock_user_sources)
         .unwrap_or(false);
     let ews_auto_provision = ews_cfg.as_ref().map(|c| c.auto_provision).unwrap_or(false);
+    let ews_impersonation_domain = ews_cfg
+        .as_ref()
+        .and_then(|c| c.impersonation_domain.clone())
+        .unwrap_or_default();
     drop(ews_cfg);
     let ews_managed_source_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM caldav_sources WHERE managed = 1 AND provider_type = 'ews'",
@@ -15428,6 +15433,7 @@ async fn admin_dashboard(
             ews_has_password => ews_has_password,
             ews_lock_user_sources => ews_lock_user_sources,
             ews_auto_provision => ews_auto_provision,
+            ews_impersonation_domain => ews_impersonation_domain,
             ews_managed_source_count => ews_managed_source_count,
             jitsi_configured => jitsi_configured,
             jitsi_base_url => jitsi_base_url,
@@ -16784,6 +16790,7 @@ struct AdminEwsGlobalForm {
     ews_service_password: Option<String>,
     ews_lock_user_sources: Option<String>,
     ews_auto_provision: Option<String>,
+    ews_impersonation_domain: Option<String>,
     /// When set (button `name="provision_now" value="1"`), provision a
     /// managed source for every enabled user after saving.
     provision_now: Option<String>,
@@ -16804,6 +16811,10 @@ async fn admin_update_ews_global(
     let username = form.ews_service_username.filter(|s| !s.trim().is_empty());
     let lock = form.ews_lock_user_sources.as_deref() == Some("on");
     let auto_provision = form.ews_auto_provision.as_deref() == Some("on");
+    let imp_domain = form
+        .ews_impersonation_domain
+        .map(|s| s.trim().trim_start_matches('@').to_string())
+        .filter(|s| !s.is_empty());
     let provision_now = form.provision_now.as_deref() == Some("1");
 
     // Validate URL when enabling. Reject early instead of silently storing
@@ -16835,6 +16846,7 @@ async fn admin_update_ews_global(
             "UPDATE auth_config SET ews_global_enabled = ?, ews_global_url = ?, \
                  ews_service_username = ?, ews_service_password_enc = ?, \
                  ews_lock_user_sources = ?, ews_auto_provision = ?, \
+                 ews_impersonation_domain = ?, \
                  updated_at = datetime('now') WHERE id = 'singleton'",
         )
         .bind(enabled as i64)
@@ -16843,12 +16855,14 @@ async fn admin_update_ews_global(
         .bind(&encrypted)
         .bind(lock as i64)
         .bind(auto_provision as i64)
+        .bind(&imp_domain)
         .execute(&state.pool)
         .await
     } else {
         sqlx::query(
             "UPDATE auth_config SET ews_global_enabled = ?, ews_global_url = ?, \
                  ews_service_username = ?, ews_lock_user_sources = ?, ews_auto_provision = ?, \
+                 ews_impersonation_domain = ?, \
                  updated_at = datetime('now') WHERE id = 'singleton'",
         )
         .bind(enabled as i64)
@@ -16856,6 +16870,7 @@ async fn admin_update_ews_global(
         .bind(&username)
         .bind(lock as i64)
         .bind(auto_provision as i64)
+        .bind(&imp_domain)
         .execute(&state.pool)
         .await
     };
@@ -19356,7 +19371,8 @@ async fn caldav_push_booking_for_user(
                         &cfg.url,
                         &cfg.service_username,
                         &cfg.service_password,
-                        impersonate_email.as_deref(),
+                        cfg.impersonation_target(impersonate_email.as_deref())
+                            .as_deref(),
                     ),
                     None => {
                         tracing::warn!(url = %url, "calendar write-back skipped: managed EWS source but global config disabled");
@@ -19485,7 +19501,8 @@ async fn caldav_delete_for_user(
                         &cfg.url,
                         &cfg.service_username,
                         &cfg.service_password,
-                        impersonate_email.as_deref(),
+                        cfg.impersonation_target(impersonate_email.as_deref())
+                            .as_deref(),
                     ),
                     None => continue,
                 }
@@ -19652,7 +19669,8 @@ pub(crate) async fn caldav_delete_booking(
                     &cfg.url,
                     &cfg.service_username,
                     &cfg.service_password,
-                    impersonate_email.as_deref(),
+                    cfg.impersonation_target(impersonate_email.as_deref())
+                        .as_deref(),
                 ),
                 None => return,
             }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6553,6 +6553,7 @@ async fn test_source(
     }
     let user = &auth_user.user;
 
+    #[allow(clippy::type_complexity)]
     let source: Option<(
         String,
         String,
@@ -6562,8 +6563,11 @@ async fn test_source(
         Option<String>,
         Option<String>,
         String,
+        i64,
+        Option<String>,
     )> = sqlx::query_as(
-        "SELECT cs.url, cs.username, cs.password_enc, cs.name, cs.auth_type, cs.access_token_enc, cs.token_expires_at, cs.provider_type
+        "SELECT cs.url, cs.username, cs.password_enc, cs.name, cs.auth_type, cs.access_token_enc, \
+                cs.token_expires_at, cs.provider_type, cs.managed, cs.impersonate_email
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE cs.id = ? AND a.user_id = ?",
@@ -6583,6 +6587,8 @@ async fn test_source(
         access_token_enc,
         token_expires_at,
         provider_type,
+        managed,
+        impersonate_email,
     ) = match source {
         Some(s) => s,
         None => return Html("Source not found.".to_string()).into_response(),
@@ -6593,19 +6599,41 @@ async fn test_source(
     // EWS sources go through the provider trait; CalDAV (basic or OAuth2) keeps
     // the existing CaldavClient path so OAuth2 refresh + ctag stay intact.
     let result = if provider_type == crate::providers::factory::kinds::EWS {
-        let password = match password_enc.as_deref() {
-            Some(enc) => match crate::crypto::decrypt_password(&state.secret_key, enc) {
-                Ok(p) => p,
-                Err(_) => {
-                    return Html("Failed to decrypt stored credentials.".to_string())
-                        .into_response()
+        let client_result = if managed != 0 {
+            match crate::web::ews_global::load_ews_global_config(&state.pool, &state.secret_key)
+                .await
+            {
+                Some(cfg) => crate::providers::build_provider(
+                    &provider_type,
+                    &cfg.url,
+                    &cfg.service_username,
+                    &cfg.service_password,
+                    impersonate_email.as_deref(),
+                ),
+                None => {
+                    return Html(
+                        "This source is admin-managed, but global Exchange is disabled."
+                            .to_string(),
+                    )
+                    .into_response()
                 }
-            },
-            None => {
-                return Html("Source has no stored password.".to_string()).into_response();
             }
+        } else {
+            let password = match password_enc.as_deref() {
+                Some(enc) => match crate::crypto::decrypt_password(&state.secret_key, enc) {
+                    Ok(p) => p,
+                    Err(_) => {
+                        return Html("Failed to decrypt stored credentials.".to_string())
+                            .into_response()
+                    }
+                },
+                None => {
+                    return Html("Source has no stored password.".to_string()).into_response();
+                }
+            };
+            crate::providers::build_provider(&provider_type, &url, &username, &password, None)
         };
-        match crate::providers::build_provider(&provider_type, &url, &username, &password, None) {
+        match client_result {
             Ok(client) => match client.check_connection().await {
                 Ok(true) => format!("'{}' — connection OK ({}).", name, label),
                 Ok(false) => format!(
@@ -6684,24 +6712,69 @@ async fn run_sync_for_source(
 ) -> (Vec<String>, usize) {
     // EWS sources go through the provider trait — no OAuth2 dispatch needed.
     if provider_type == crate::providers::factory::kinds::EWS {
-        let enc = match password_enc {
-            Some(e) => e,
-            None => return (vec!["EWS source missing password".to_string()], 0),
+        // Managed (admin-provisioned) rows carry no password: they use the
+        // global service account + impersonation header instead.
+        let managed: (i64, Option<String>) =
+            sqlx::query_as("SELECT managed, impersonate_email FROM caldav_sources WHERE id = ?")
+                .bind(source_id)
+                .fetch_optional(pool)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or((0, None));
+
+        let provider = if managed.0 != 0 {
+            let cfg = match crate::web::ews_global::load_ews_global_config(pool, key).await {
+                Some(c) => c,
+                None => {
+                    return (
+                        vec![
+                            "Managed Exchange source, but global EWS config is disabled."
+                                .to_string(),
+                        ],
+                        0,
+                    )
+                }
+            };
+            match crate::providers::build_provider(
+                provider_type,
+                &cfg.url,
+                &cfg.service_username,
+                &cfg.service_password,
+                managed.1.as_deref(),
+            ) {
+                Ok(p) => p,
+                Err(e) => return (vec![format!("Could not build provider: {}", e)], 0),
+            }
+        } else {
+            let enc = match password_enc {
+                Some(e) => e,
+                None => return (vec!["EWS source missing password".to_string()], 0),
+            };
+            let password = match crate::crypto::decrypt_password(key, enc) {
+                Ok(p) => p,
+                Err(e) => return (vec![format!("Decrypt failed: {}", e)], 0),
+            };
+            match crate::providers::build_provider(provider_type, url, username, &password, None) {
+                Ok(p) => p,
+                Err(e) => return (vec![format!("Could not build provider: {}", e)], 0),
+            }
         };
-        let password = match crate::crypto::decrypt_password(key, enc) {
-            Ok(p) => p,
-            Err(e) => return (vec![format!("Decrypt failed: {}", e)], 0),
+
+        return match crate::commands::sync::sync_ews_source(pool, key, provider.as_ref(), source_id)
+            .await
+        {
+            Ok(()) => {
+                let cal_count: i64 =
+                    sqlx::query_scalar("SELECT COUNT(*) FROM calendars WHERE source_id = ?")
+                        .bind(source_id)
+                        .fetch_one(pool)
+                        .await
+                        .unwrap_or(0);
+                (vec!["Sync complete.".to_string()], cal_count as usize)
+            }
+            Err(e) => (vec![format!("Sync failed: {}", e)], 0),
         };
-        return run_sync(
-            pool,
-            key,
-            source_id,
-            provider_type,
-            url,
-            username,
-            &password,
-        )
-        .await;
     }
     let client = match crate::oauth2_caldav::build_client_for_source(
         pool,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15351,6 +15351,53 @@ async fn admin_dashboard(
     .await
     .unwrap_or(0);
 
+    // Per-user status of the managed Exchange sources, so the admin can see
+    // which mailboxes synced and which failed (e.g. a user without an Exchange
+    // mailbox). NULL last_sync_error + a last_synced timestamp = OK.
+    let ews_managed_rows: Vec<(String, Option<String>, Option<String>, Option<String>, bool)> =
+        sqlx::query_as(
+            "SELECT u.email, cs.impersonate_email, cs.last_synced, cs.last_sync_error, cs.enabled \
+             FROM caldav_sources cs \
+             JOIN accounts a ON a.id = cs.account_id \
+             JOIN users u ON u.id = a.user_id \
+             WHERE cs.managed = 1 AND cs.provider_type = 'ews' \
+             ORDER BY (cs.last_sync_error IS NOT NULL) DESC, u.email",
+        )
+        .fetch_all(&state.pool)
+        .await
+        .unwrap_or_default();
+    let ews_managed_sources: Vec<minijinja::Value> = ews_managed_rows
+        .iter()
+        .map(|(email, mailbox, last_synced, last_error, enabled)| {
+            let ok = last_error.is_none() && last_synced.is_some();
+            let status_text = if let Some(err) = last_error {
+                // Surface the machine-readable EWS code when present; it leads
+                // the message thanks to extract_soap_fault.
+                if err.contains("ErrorNonExistentMailbox") {
+                    "No Exchange mailbox".to_string()
+                } else {
+                    err.clone()
+                }
+            } else if last_synced.is_some() {
+                "Synced".to_string()
+            } else {
+                "Never synced".to_string()
+            };
+            context! {
+                email => email,
+                mailbox => mailbox.as_deref().unwrap_or(""),
+                last_synced => last_synced.as_deref().unwrap_or("never"),
+                ok => ok,
+                enabled => enabled,
+                status => status_text,
+            }
+        })
+        .collect();
+    let ews_managed_ok_count = ews_managed_rows
+        .iter()
+        .filter(|(_, _, last_synced, last_error, _)| last_error.is_none() && last_synced.is_some())
+        .count() as i64;
+
     let meeting_cfg = state.meeting_config.read().await;
     let jitsi_configured = meeting_cfg.jitsi.is_some();
     let jitsi_base_url = meeting_cfg
@@ -15435,6 +15482,8 @@ async fn admin_dashboard(
             ews_auto_provision => ews_auto_provision,
             ews_impersonation_domain => ews_impersonation_domain,
             ews_managed_source_count => ews_managed_source_count,
+            ews_managed_ok_count => ews_managed_ok_count,
+            ews_managed_sources => ews_managed_sources,
             jitsi_configured => jitsi_configured,
             jitsi_base_url => jitsi_base_url,
             jitsi_pattern => jitsi_pattern,

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -594,6 +594,13 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
       <label>Service account password <span class="hint">(leave empty to keep current)</span></label>
       <input type="password" name="ews_service_password" value="" placeholder="{% if ews_has_password %}(unchanged){% else %}service-account password{% endif %}">
     </div>
+    <div class="form-group">
+      <label>Mailbox domain override <span class="hint">(optional)</span></label>
+      <input type="text" name="ews_impersonation_domain" value="{{ ews_impersonation_domain }}" placeholder="e.g. dyb.fr">
+      <span style="font-size: 0.8rem; color: var(--text-muted);">
+        Set this when the calrs login / AD UPN domain differs from the Exchange mailbox address (PrimarySmtpAddress). The local part of each user's email is kept and the domain is replaced — e.g. <code>alice@dyb.lan</code> → <code>alice@dyb.fr</code> — so impersonation resolves to a real mailbox. Leave empty to impersonate the user's calrs email as-is.
+      </span>
+    </div>
     <div style="margin-bottom: 1rem;">
       <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
         <input type="checkbox" name="ews_auto_provision" value="on" {% if ews_auto_provision %}checked{% endif %} style="width: 1rem; height: 1rem; flex-shrink: 0;">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -576,9 +576,9 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
     <code>New-ManagementRoleAssignment -Name CalrsImpersonation -Role ApplicationImpersonation -User svc-calrs@yourdomain</code>.
   </p>
   <form method="post" action="/dashboard/admin/ews">
-    <div class="form-group">
-      <label>
-        <input type="checkbox" name="ews_global_enabled" {% if ews_global_enabled %}checked{% endif %}>
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="ews_global_enabled" value="on" {% if ews_global_enabled %}checked{% endif %} style="width: 1rem; height: 1rem; flex-shrink: 0;">
         Enable global Exchange via impersonation
       </label>
     </div>
@@ -594,18 +594,18 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
       <label>Service account password <span class="hint">(leave empty to keep current)</span></label>
       <input type="password" name="ews_service_password" value="" placeholder="{% if ews_has_password %}(unchanged){% else %}service-account password{% endif %}">
     </div>
-    <div class="form-group">
-      <label>
-        <input type="checkbox" name="ews_auto_provision" {% if ews_auto_provision %}checked{% endif %}>
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="ews_auto_provision" value="on" {% if ews_auto_provision %}checked{% endif %} style="width: 1rem; height: 1rem; flex-shrink: 0;">
         Auto-provision for all users (existing + future)
       </label>
       <span style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">
         When checked, every enabled user automatically gets a managed Exchange source — saving here runs the batch immediately, and new users get one on creation.
       </span>
     </div>
-    <div class="form-group">
-      <label>
-        <input type="checkbox" name="ews_lock_user_sources" {% if ews_lock_user_sources %}checked{% endif %}>
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="ews_lock_user_sources" value="on" {% if ews_lock_user_sources %}checked{% endif %} style="width: 1rem; height: 1rem; flex-shrink: 0;">
         Prevent regular users from adding their own calendar sources
       </label>
       <span style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -625,6 +625,45 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
     <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save EWS settings</button>
     <button type="submit" name="provision_now" value="1" class="slot-btn" style="cursor: pointer; margin-left: 0.5rem;">Save &amp; provision all users now</button>
   </form>
+
+  {% if ews_managed_sources %}
+  <div style="margin-top: 1.5rem;">
+    <h3 style="margin-bottom: 0.5rem; font-size: 1rem;">Per-user sync status</h3>
+    <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.75rem;">
+      {{ ews_managed_ok_count }} of {{ ews_managed_source_count }} managed mailboxes syncing. A user with no Exchange mailbox (e.g. a local admin account) will always show an error — that's expected.
+    </p>
+    <div style="overflow-x: auto;">
+      <table style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+        <thead>
+          <tr style="text-align: left; border-bottom: 1px solid var(--border); color: var(--text-muted);">
+            <th style="padding: 0.4rem 0.6rem; font-weight: 600;">User</th>
+            <th style="padding: 0.4rem 0.6rem; font-weight: 600;">Mailbox</th>
+            <th style="padding: 0.4rem 0.6rem; font-weight: 600;">Last sync</th>
+            <th style="padding: 0.4rem 0.6rem; font-weight: 600;">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for s in ews_managed_sources %}
+          <tr style="border-bottom: 1px solid var(--border);">
+            <td style="padding: 0.4rem 0.6rem;">{{ s.email }}</td>
+            <td style="padding: 0.4rem 0.6rem; color: var(--text-muted);">{{ s.mailbox }}</td>
+            <td style="padding: 0.4rem 0.6rem; color: var(--text-muted);">{{ s.last_synced }}</td>
+            <td style="padding: 0.4rem 0.6rem;">
+              {% if not s.enabled %}
+                <span style="color: var(--text-muted);">disabled</span>
+              {% elif s.ok %}
+                <span style="color: var(--success);">&check; {{ s.status }}</span>
+              {% else %}
+                <span style="color: var(--error-text, #dc2626);">&times; {{ s.status }}</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
 </div>
 
 <!-- Jitsi auto-generated meeting links -->

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -561,6 +561,65 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
   </script>
 </div>
 
+<!-- Global EWS impersonation -->
+<div class="card" id="ews-global">
+  <h2>Exchange (EWS) — Global impersonation</h2>
+  <div style="margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
+    Status:
+    {% if ews_global_enabled %}<strong style="color: var(--success);">enabled</strong>
+    {% else %}<span style="color: var(--text-muted);">disabled</span>{% endif %}
+    {% if ews_global_url %}&middot; Endpoint: <span style="color: var(--text-muted);">{{ ews_global_url }}</span>{% endif %}
+    {% if ews_global_enabled %}&middot; Managed sources: <span style="color: var(--text-muted);">{{ ews_managed_source_count }}</span>{% endif %}
+  </div>
+  <p style="color: var(--text-muted); font-size: 0.875rem; margin-bottom: 0.75rem;">
+    Configure a single Exchange Web Services endpoint and a service account holding the <code>ApplicationImpersonation</code> RBAC role. Each user's calendar is then read through impersonation — they enter no credentials. PowerShell on Exchange:
+    <code>New-ManagementRoleAssignment -Name CalrsImpersonation -Role ApplicationImpersonation -User svc-calrs@yourdomain</code>.
+  </p>
+  <form method="post" action="/dashboard/admin/ews">
+    <div class="form-group">
+      <label>
+        <input type="checkbox" name="ews_global_enabled" {% if ews_global_enabled %}checked{% endif %}>
+        Enable global Exchange via impersonation
+      </label>
+    </div>
+    <div class="form-group">
+      <label>EWS endpoint URL</label>
+      <input type="url" name="ews_global_url" value="{{ ews_global_url }}" placeholder="https://mail.example.com/EWS/Exchange.asmx">
+    </div>
+    <div class="form-group">
+      <label>Service account username</label>
+      <input type="text" name="ews_service_username" value="{{ ews_service_username }}" placeholder="svc-calrs@example.com">
+    </div>
+    <div class="form-group">
+      <label>Service account password <span class="hint">(leave empty to keep current)</span></label>
+      <input type="password" name="ews_service_password" value="" placeholder="{% if ews_has_password %}(unchanged){% else %}service-account password{% endif %}">
+    </div>
+    <div class="form-group">
+      <label>
+        <input type="checkbox" name="ews_auto_provision" {% if ews_auto_provision %}checked{% endif %}>
+        Auto-provision for all users (existing + future)
+      </label>
+      <span style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">
+        When checked, every enabled user automatically gets a managed Exchange source — saving here runs the batch immediately, and new users get one on creation.
+      </span>
+    </div>
+    <div class="form-group">
+      <label>
+        <input type="checkbox" name="ews_lock_user_sources" {% if ews_lock_user_sources %}checked{% endif %}>
+        Prevent regular users from adding their own calendar sources
+      </label>
+      <span style="font-size: 0.8rem; color: var(--text-muted); display: block; margin-top: 0.25rem;">
+        Admins bypass this lock. Existing user-added sources stay until you delete them.
+      </span>
+    </div>
+    <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.75rem;">
+      Disabling the feature leaves managed source rows untouched (they simply stop syncing). Re-enabling resumes them.
+    </p>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save EWS settings</button>
+    <button type="submit" name="provision_now" value="1" class="slot-btn" style="cursor: pointer; margin-left: 0.5rem;">Save &amp; provision all users now</button>
+  </form>
+</div>
+
 <!-- Jitsi auto-generated meeting links -->
 <div class="card">
   <h2>Jitsi (auto-generated meeting links)</h2>

--- a/templates/dashboard_sources.html
+++ b/templates/dashboard_sources.html
@@ -4,8 +4,15 @@
 <div class="card">
   <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
     <h1 style="margin-bottom: 0;">Calendar sources</h1>
+    {% if not lock_user_sources or is_admin %}
     <a href="/dashboard/sources/new" class="slot-btn" style="text-decoration: none; font-size: 0.85rem; font-weight: 600; color: var(--accent); border-color: var(--accent);">+ Add</a>
+    {% endif %}
   </div>
+  {% if lock_user_sources and not is_admin %}
+  <div style="margin-bottom: 0.75rem; padding: 0.5rem 0.75rem; background: rgba(99, 102, 241, 0.08); border: 1px solid rgba(99, 102, 241, 0.3); border-radius: var(--radius); color: var(--text); font-size: 0.85rem;">
+    Your administrator manages Exchange centrally. Adding additional calendar sources is disabled.
+  </div>
+  {% endif %}
   {% if sources %}
     {% for s in sources %}
     <div style="padding: 0.75rem 0; {% if not loop.last %}border-bottom: 1px solid var(--border);{% endif %}">
@@ -14,6 +21,9 @@
           <strong>{{ s.name }}</strong>
           {% if s.provider_label %}
             <span style="margin-left: 0.5rem; font-size: 0.7rem; padding: 0.125rem 0.5rem; border: 1px solid var(--border); border-radius: 999px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;">{{ s.provider_label }}</span>
+          {% endif %}
+          {% if s.managed %}
+            <span title="Provisioned by the administrator" style="margin-left: 0.5rem; font-size: 0.7rem; padding: 0.125rem 0.5rem; background: var(--accent); color: white; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">Admin-managed</span>
           {% endif %}
           <div style="color: var(--text-muted); font-size: 0.8rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{{ s.url }}</div>
           <div style="color: var(--text-muted); font-size: 0.75rem;">{% if s.auth_type == "oauth2" %}<span style="background: var(--accent); color: white; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.7rem; font-weight: 600;">OAuth2</span> {{ s.username }}{% else %}{{ s.username }}{% endif %} &middot; Last sync: {{ s.last_synced }}</div>
@@ -28,9 +38,11 @@
           <form method="post" action="/dashboard/sources/{{ s.id }}/test" style="margin: 0;">
             <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">Test</button>
           </form>
+          {% if not s.managed or is_admin %}
           <a href="/dashboard/sources/{{ s.id }}/edit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer; text-decoration: none;">Edit</a>
           <button type="button" class="slot-btn" style="font-size: 0.8rem; color: var(--error-text); cursor: pointer;" data-confirm="Remove source '{{ s.name }}'? This will delete all synced events from this source." onclick="if(confirm(this.dataset.confirm)) this.closest('div').querySelector('.remove-form').submit();">Remove</button>
           <form method="post" action="/dashboard/sources/{{ s.id }}/remove" class="remove-form" style="display: none;"></form>
+          {% endif %}
         </div>
       </div>
       {% if s.calendars %}


### PR DESCRIPTION
Lets an admin connect one Exchange server with a single service account (holding the ApplicationImpersonation RBAC role) and have every user's calendar synced automatically — no per-user credentials.

What it does :

- Admin panel → Exchange (EWS): configure the EWS endpoint + service account once. Encrypted at rest like other secrets.
- Auto-provision: every existing and future user gets a "managed" Exchange source automatically. Sync impersonates each user's mailbox via the t:ExchangeImpersonation SOAP header (+ X-AnchorMailbox for correct routing on DAG deployments).
- Lock user sources: optionally prevent regular users from adding their own calendar sources (admins exempt).
- Mailbox domain override: when the AD UPN / login domain differs from the mailbox SMTP domain (e.g. user@corp.lan → user@corp.fr), rewrite the impersonation target so it resolves.
- Per-user sync status: the admin sees which mailboxes synced and which failed (a user with no Exchange mailbox is clearly flagged, not a cryptic error).

Notes
- Opt-in: with nothing configured, behaviour is unchanged.
- Per-user managed rows reuse the existing source/sync model — no changes to the booking, availability, or write-back paths.
- 6 new migrations (057–060). Adds provider_type=ews handling across sync, on-demand sync, and CalDAV write-back.

Admin view :
<img width="1167" height="1438" alt="image" src="https://github.com/user-attachments/assets/205c172c-62fd-4841-8de4-bd8d35e88564" />

New local user with just the same email configured : 


<img width="1180" height="405" alt="image" src="https://github.com/user-attachments/assets/5fbf268c-46e0-4f29-93a3-5f4b14a9df76" />


did not test yet with other calendars sources or with oidc (should work if oidc send the correct email, will test with authentik later)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global Exchange (EWS) impersonation using a shared service account.
  * Administrators can configure EWS, mailbox domain mapping, automatic provisioning, and user source controls.
  * Managed Exchange sources can be provisioned automatically during registration, login, or user creation.
  * Added managed-source indicators and per-mailbox sync status to the dashboard.
* **Bug Fixes**
  * Sync errors are now retained and displayed until a successful sync.
  * Provisioning or mailbox lookup failures no longer block account creation or login.
* **Documentation**
  * Added setup and security guidance for EWS impersonation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->