### PR TITLE
feat(smtp): editable SMTP config from admin UI + explicit env/DB prio…

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -588,23 +588,26 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
             );
         }
         ConfigCommands::Show => {
-            let smtp: Option<(String, i32, String, String, Option<String>, bool)> = sqlx::query_as(
-                "SELECT host, port, username, from_email, from_name, enabled FROM smtp_config LIMIT 1",
-            )
-            .fetch_optional(pool)
-            .await?;
-
-            match smtp {
-                Some((host, port, username, from_email, from_name, enabled)) => {
+            // Go through `load_smtp_status` so the env block (CALRS_SMTP_*) is
+            // reflected here too — a direct SELECT would be blind to it and
+            // misleadingly report "No SMTP configured" when env is in use.
+            match crate::email::load_smtp_status(pool).await? {
+                Some(status) => {
                     println!("{}:", "SMTP".bold());
-                    println!("  Host:     {}:{}", host, port);
-                    println!("  Username: {}", username);
-                    println!(
-                        "  From:     {} <{}>",
-                        from_name.as_deref().unwrap_or(""),
-                        from_email
-                    );
-                    println!("  Enabled:  {}", if enabled { "✓" } else { "✗" });
+                    print!("  Host:     {}:{}", status.host, status.port);
+                    if status.from_env {
+                        println!(" {}", "(via environment)".dimmed());
+                    } else {
+                        println!();
+                    }
+                    println!("  Username: {}", status.username);
+                    if let Some(from_name) = status.from_name.as_deref() {
+                        println!("  From:     {} <{}>", from_name, status.from_email);
+                    } else {
+                        println!("  From:     {}", status.from_email);
+                    }
+                    println!("  TLS mode: {}", status.tls_mode);
+                    println!("  Enabled:  {}", if status.enabled { "✓" } else { "✗" });
                 }
                 None => {
                     println!("No SMTP configured. Run `calrs config smtp` to set it up.");

--- a/src/email.rs
+++ b/src/email.rs
@@ -79,9 +79,22 @@ impl SmtpTlsMode {
 pub struct SmtpStatus {
     pub host: String,
     pub port: u16,
+    pub username: String,
     pub from_email: String,
+    pub from_name: Option<String>,
+    pub tls_mode: String,
     pub enabled: bool,
     pub from_env: bool,
+}
+
+impl SmtpTlsMode {
+    /// Canonical lowercase string used in the DB and `<select>` values.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::StartTls => "starttls",
+            Self::Tls => "tls",
+        }
+    }
 }
 
 impl SmtpConfig {
@@ -1787,17 +1800,22 @@ const SMTP_ENV_VARS: &[&str] = &[
     "CALRS_SMTP_FROM_NAME",
 ];
 
-fn required_smtp_env(name: &str) -> Result<String> {
-    match std::env::var(name) {
-        Ok(value) if !value.trim().is_empty() => Ok(value),
-        Ok(_) => bail!("{} must not be empty", name),
-        Err(_) => bail!(
-            "{} is required when SMTP is configured via environment",
-            name
-        ),
-    }
+/// Read an SMTP env var, returning `Some(value)` only when set and non-empty.
+fn optional_smtp_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
 }
 
+/// Load the SMTP config from the `CALRS_SMTP_*` environment block.
+///
+/// Priority is "full block override": when the required block (host, username,
+/// password, from_email) is complete, the env wins over the database entirely.
+/// When no SMTP var is set, or the required block is only partially set, this
+/// returns `Ok(None)` so the caller falls back to the database config — a stray
+/// or incomplete env var no longer breaks SMTP. A required block that *is*
+/// complete but carries an invalid `PORT`/`TLS_MODE` still surfaces an error,
+/// since that is a genuine misconfiguration to fix rather than silently ignore.
 fn load_smtp_config_from_env() -> Result<Option<SmtpConfig>> {
     if !SMTP_ENV_VARS
         .iter()
@@ -1806,10 +1824,22 @@ fn load_smtp_config_from_env() -> Result<Option<SmtpConfig>> {
         return Ok(None);
     }
 
-    let host = required_smtp_env("CALRS_SMTP_HOST")?;
-    let username = required_smtp_env("CALRS_SMTP_USERNAME")?;
-    let password = required_smtp_env("CALRS_SMTP_PASSWORD")?;
-    let from_email = required_smtp_env("CALRS_SMTP_FROM_EMAIL")?;
+    let (host, username, password, from_email) = match (
+        optional_smtp_env("CALRS_SMTP_HOST"),
+        optional_smtp_env("CALRS_SMTP_USERNAME"),
+        optional_smtp_env("CALRS_SMTP_PASSWORD"),
+        optional_smtp_env("CALRS_SMTP_FROM_EMAIL"),
+    ) {
+        (Some(host), Some(username), Some(password), Some(from_email)) => {
+            (host, username, password, from_email)
+        }
+        _ => {
+            tracing::warn!(
+                "partial CALRS_SMTP_* environment block (missing one of HOST/USERNAME/PASSWORD/FROM_EMAIL); falling back to database SMTP config"
+            );
+            return Ok(None);
+        }
+    };
     let port = match std::env::var("CALRS_SMTP_PORT") {
         Ok(value) if value.trim().is_empty() => bail!("CALRS_SMTP_PORT must not be empty"),
         Ok(value) => value.trim().parse::<u16>().map_err(|_| {
@@ -1835,6 +1865,17 @@ fn load_smtp_config_from_env() -> Result<Option<SmtpConfig>> {
         from_name,
         tls_mode,
     }))
+}
+
+/// Returns true when the `CALRS_SMTP_*` environment block governs the config,
+/// meaning the database config is shadowed and must not be edited from the UI.
+///
+/// A complete env block (`Ok(Some)`) or a complete-but-invalid one (`Err`, e.g.
+/// a bad port) both govern — the env overrides the database either way, so the
+/// admin form is locked. A partial/absent block (`Ok(None)`) does not govern:
+/// the app falls back to the database, which stays editable.
+pub fn smtp_env_active() -> bool {
+    !matches!(load_smtp_config_from_env(), Ok(None))
 }
 
 /// Load SMTP config from environment or database.
@@ -1881,24 +1922,36 @@ pub async fn load_smtp_status(pool: &SqlitePool) -> Result<Option<SmtpStatus>> {
         return Ok(Some(SmtpStatus {
             host: config.host,
             port: config.port,
+            username: config.username,
             from_email: config.from_email,
+            from_name: config.from_name,
+            tls_mode: config.tls_mode.as_str().to_string(),
             enabled: true,
             from_env: true,
         }));
     }
 
-    let row: Option<(String, i32, String, bool)> =
-        sqlx::query_as("SELECT host, port, from_email, enabled FROM smtp_config LIMIT 1")
-            .fetch_optional(pool)
-            .await?;
+    // Prefer the enabled row so the status matches the row `load_smtp_config`
+    // would actually send from, in case legacy cleanup ever left extra rows.
+    let row: Option<(String, i32, String, String, Option<String>, String, bool)> = sqlx::query_as(
+        "SELECT host, port, username, from_email, from_name, tls_mode, enabled
+         FROM smtp_config ORDER BY enabled DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
 
-    Ok(row.map(|(host, port, from_email, enabled)| SmtpStatus {
-        host,
-        port: port as u16,
-        from_email,
-        enabled,
-        from_env: false,
-    }))
+    Ok(row.map(
+        |(host, port, username, from_email, from_name, tls_mode, enabled)| SmtpStatus {
+            host,
+            port: port as u16,
+            username,
+            from_email,
+            from_name,
+            tls_mode,
+            enabled,
+            from_env: false,
+        },
+    ))
 }
 
 /// Send a test email
@@ -2733,13 +2786,14 @@ mod tests {
     }
 
     #[test]
-    fn smtp_env_partial_config_errors() {
+    fn smtp_env_partial_config_falls_back_to_db() {
         let _env = SmtpEnvGuard::new();
+        // Only one of the required vars is set: the block is incomplete, so the
+        // env is ignored and the caller falls back to the database config
+        // (instead of erroring out and breaking SMTP entirely).
         std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
 
-        let err = smtp_env_error();
-
-        assert!(err.contains("CALRS_SMTP_USERNAME"));
+        assert!(load_smtp_config_from_env().unwrap().is_none());
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1357,6 +1357,9 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
             post(admin_update_google_oauth2),
         )
         .route("/dashboard/admin/captcha", post(admin_update_captcha))
+        .route("/dashboard/admin/smtp", post(admin_update_smtp))
+        .route("/dashboard/admin/smtp/test", post(admin_update_smtp_test))
+        .route("/dashboard/admin/smtp/clear", post(admin_update_smtp_clear))
         .route("/dashboard/admin/jitsi", post(admin_update_jitsi))
         .route(
             "/dashboard/admin/meeting-webhook",
@@ -14011,7 +14014,10 @@ async fn admin_dashboard(
         smtp_configured,
         smtp_host,
         smtp_port,
+        smtp_username,
         smtp_from_email,
+        smtp_from_name,
+        smtp_tls_mode,
         smtp_enabled,
         smtp_from_env,
         smtp_error,
@@ -14020,7 +14026,10 @@ async fn admin_dashboard(
             true,
             status.host,
             status.port,
+            status.username,
             status.from_email,
+            status.from_name.unwrap_or_default(),
+            status.tls_mode,
             status.enabled,
             status.from_env,
             String::new(),
@@ -14030,6 +14039,9 @@ async fn admin_dashboard(
             String::new(),
             0u16,
             String::new(),
+            String::new(),
+            String::new(),
+            "starttls".to_string(),
             false,
             false,
             String::new(),
@@ -14039,11 +14051,17 @@ async fn admin_dashboard(
             String::new(),
             0u16,
             String::new(),
+            String::new(),
+            String::new(),
+            "starttls".to_string(),
             false,
             true,
             e.to_string(),
         ),
     };
+
+    // Flash banner after a "send test email" round-trip (?smtp_test=sent|error).
+    let smtp_test_result = query.get("smtp_test").cloned().unwrap_or_default();
 
     let tmpl = match state.templates.get_template("admin.html") {
         Ok(t) => t,
@@ -14137,10 +14155,14 @@ async fn admin_dashboard(
             smtp_configured => smtp_configured,
             smtp_host => smtp_host,
             smtp_port => smtp_port,
+            smtp_username => smtp_username,
             smtp_from_email => smtp_from_email,
+            smtp_from_name => smtp_from_name,
+            smtp_tls_mode => smtp_tls_mode,
             smtp_enabled => smtp_enabled,
             smtp_from_env => smtp_from_env,
             smtp_error => smtp_error,
+            smtp_test_result => smtp_test_result,
             captcha_configured => captcha_configured,
             captcha_instance_url => captcha_instance_url,
             captcha_site_key => captcha_site_key,
@@ -14811,6 +14833,246 @@ async fn admin_update_captcha(
 
     tracing::info!(admin = %_admin.0.email, "admin: captcha config updated");
 
+    Redirect::to("/dashboard/admin").into_response()
+}
+
+// --- SMTP settings (database-backed, editable from the admin panel) ---
+
+#[derive(Deserialize)]
+struct AdminSmtpForm {
+    _csrf: Option<String>,
+    host: Option<String>,
+    port: Option<String>,
+    tls_mode: Option<String>,
+    username: Option<String>,
+    /// Leave empty to keep the currently stored password (keep-current pattern).
+    password: Option<String>,
+    from_email: Option<String>,
+    from_name: Option<String>,
+    /// HTML checkbox: present (any value) when checked, absent when unchecked.
+    enabled: Option<String>,
+}
+
+async fn admin_update_smtp(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminSmtpForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    // Defensive guard: when the env block governs, the DB config is shadowed and
+    // the UI form is locked. Refuse to write so the two channels never diverge.
+    if crate::email::smtp_env_active() {
+        return Redirect::to("/dashboard/admin").into_response();
+    }
+
+    let redirect_err = |msg: &str| {
+        let encoded = urlencoding::encode(msg).into_owned();
+        Redirect::to(&format!("/dashboard/admin?error={}", encoded)).into_response()
+    };
+
+    let host = form.host.unwrap_or_default().trim().to_string();
+    if host.is_empty() {
+        return redirect_err("SMTP host is required.");
+    }
+
+    let from_email = form.from_email.unwrap_or_default().trim().to_string();
+    if from_email.len() > 320
+        || !from_email.contains('@')
+        || from_email
+            .rsplit('@')
+            .next()
+            .is_none_or(|domain| !domain.contains('.'))
+    {
+        return redirect_err("Please enter a valid 'from' email address.");
+    }
+
+    let port: i32 = match form.port.as_deref().map(str::trim) {
+        Some("") | None => 587,
+        Some(p) => match p.parse::<u16>() {
+            Ok(p) => p as i32,
+            Err(_) => return redirect_err("SMTP port must be a number between 1 and 65535."),
+        },
+    };
+
+    let tls_mode = match form.tls_mode.as_deref().map(str::trim) {
+        Some("tls") => "tls",
+        Some("starttls") | Some("") | None => "starttls",
+        Some(_) => return redirect_err("TLS mode must be 'starttls' or 'tls'."),
+    };
+
+    let username = form.username.unwrap_or_default().trim().to_string();
+    let from_name = form.from_name.and_then(|s| {
+        let t = s.trim().to_string();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t)
+        }
+    });
+    let enabled = form.enabled.is_some();
+
+    let password = form.password.unwrap_or_default();
+    let password_provided = !password.trim().is_empty();
+
+    let existing: Option<(String,)> = match sqlx::query_as("SELECT id FROM smtp_config LIMIT 1")
+        .fetch_optional(&state.pool)
+        .await
+    {
+        Ok(row) => row,
+        Err(e) => return internal_error_response("check existing smtp config", &e),
+    };
+
+    let result = match existing {
+        Some((id,)) if password_provided => {
+            let password_enc = match crate::crypto::encrypt_password(&state.secret_key, &password) {
+                Ok(s) => s,
+                Err(e) => return internal_error_response("encrypt smtp password", &e),
+            };
+            sqlx::query(
+                "UPDATE smtp_config SET host = ?, port = ?, username = ?, password_enc = ?, from_email = ?, from_name = ?, tls_mode = ?, enabled = ? WHERE id = ?",
+            )
+            .bind(&host)
+            .bind(port)
+            .bind(&username)
+            .bind(&password_enc)
+            .bind(&from_email)
+            .bind(&from_name)
+            .bind(tls_mode)
+            .bind(enabled)
+            .bind(&id)
+            .execute(&state.pool)
+            .await
+        }
+        Some((id,)) => {
+            // Keep-current: do not touch password_enc.
+            sqlx::query(
+                "UPDATE smtp_config SET host = ?, port = ?, username = ?, from_email = ?, from_name = ?, tls_mode = ?, enabled = ? WHERE id = ?",
+            )
+            .bind(&host)
+            .bind(port)
+            .bind(&username)
+            .bind(&from_email)
+            .bind(&from_name)
+            .bind(tls_mode)
+            .bind(enabled)
+            .bind(&id)
+            .execute(&state.pool)
+            .await
+        }
+        None => {
+            // Fresh config needs a password — there is nothing to keep.
+            if !password_provided {
+                return redirect_err(
+                    "A password is required when configuring SMTP for the first time.",
+                );
+            }
+            let password_enc = match crate::crypto::encrypt_password(&state.secret_key, &password) {
+                Ok(s) => s,
+                Err(e) => return internal_error_response("encrypt smtp password", &e),
+            };
+            sqlx::query(
+                "INSERT INTO smtp_config (id, host, port, username, password_enc, from_email, from_name, tls_mode, enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&host)
+            .bind(port)
+            .bind(&username)
+            .bind(&password_enc)
+            .bind(&from_email)
+            .bind(&from_name)
+            .bind(tls_mode)
+            .bind(enabled)
+            .execute(&state.pool)
+            .await
+        }
+    };
+
+    if let Err(e) = result {
+        return internal_error_response("save smtp config", &e);
+    }
+
+    tracing::info!(admin = %_admin.0.email, "admin: smtp config updated");
+    Redirect::to("/dashboard/admin").into_response()
+}
+
+#[derive(Deserialize)]
+struct AdminSmtpTestForm {
+    _csrf: Option<String>,
+    to: Option<String>,
+}
+
+async fn admin_update_smtp_test(
+    State(state): State<Arc<AppState>>,
+    admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminSmtpTestForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    let to = form
+        .to
+        .and_then(|s| {
+            let t = s.trim().to_string();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t)
+            }
+        })
+        .unwrap_or_else(|| admin.0.email.clone());
+
+    let config = match crate::email::load_smtp_config(&state.pool, &state.secret_key).await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            return Redirect::to("/dashboard/admin?smtp_test=error").into_response();
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "admin: smtp test could not load config");
+            return Redirect::to("/dashboard/admin?smtp_test=error").into_response();
+        }
+    };
+
+    match crate::email::send_test_email(&config, &to).await {
+        Ok(()) => {
+            tracing::info!(admin = %admin.0.email, %to, "admin: smtp test email sent");
+            Redirect::to("/dashboard/admin?smtp_test=sent").into_response()
+        }
+        Err(e) => {
+            tracing::warn!(admin = %admin.0.email, error = %e, "admin: smtp test email failed");
+            Redirect::to("/dashboard/admin?smtp_test=error").into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct AdminSmtpClearForm {
+    _csrf: Option<String>,
+}
+
+async fn admin_update_smtp_clear(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminSmtpClearForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    if let Err(e) = sqlx::query("DELETE FROM smtp_config")
+        .execute(&state.pool)
+        .await
+    {
+        return internal_error_response("clear smtp config", &e);
+    }
+
+    tracing::info!(admin = %_admin.0.email, "admin: smtp config cleared");
     Redirect::to("/dashboard/admin").into_response()
 }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15065,6 +15065,12 @@ async fn admin_update_smtp_clear(
         return resp;
     }
 
+    // Same guard as admin_update_smtp: when the env block governs, the DB config
+    // is shadowed and the UI hides this button — refuse the write defensively.
+    if crate::email::smtp_env_active() {
+        return Redirect::to("/dashboard/admin").into_response();
+    }
+
     if let Err(e) = sqlx::query("DELETE FROM smtp_config")
         .execute(&state.pool)
         .await

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -457,18 +457,94 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
 <!-- SMTP settings -->
 <div class="card">
   <h2>SMTP settings</h2>
+
+  {% if smtp_test_result == "sent" %}
+  <p style="color: var(--success); font-size: 0.875rem;">✓ Test email sent.</p>
+  {% elif smtp_test_result == "error" %}
+  <p style="color: var(--error-text); font-size: 0.875rem;">✗ Test email could not be sent. Check the server logs and your SMTP settings.</p>
+  {% endif %}
+
   {% if smtp_error %}
   <p style="color: var(--error-text); font-size: 0.875rem;">SMTP environment configuration error: {{ smtp_error }}</p>
-  {% elif smtp_configured %}
-  <div style="font-size: 0.875rem; color: var(--text-secondary); line-height: 1.8;">
-    <div>Status: <strong style="color: var(--success);">configured</strong>{% if not smtp_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %}{% if smtp_from_env %} <span style="color: var(--text-muted);">(via environment)</span>{% endif %}</div>
-    <div>Host: <span style="color: var(--text-muted);">{{ smtp_host }}:{{ smtp_port }}</span></div>
-    <div>From: <span style="color: var(--text-muted);">{{ smtp_from_email }}</span></div>
+  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 0.75rem;">Fix the <code>CALRS_SMTP_*</code> environment variables, or unset them to manage SMTP from the database here.</p>
+
+  {% elif smtp_from_env %}
+  <div style="border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.85rem; color: var(--text-secondary);">
+    Managed via <strong>environment variables</strong> (overrides the database). Edit the <code>CALRS_SMTP_*</code> variables to change it, or unset them to manage SMTP from here.
   </div>
+  <div style="font-size: 0.875rem; color: var(--text-secondary); line-height: 1.8;">
+    <div>Status: <strong style="color: var(--success);">configured</strong>{% if not smtp_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %} <span style="color: var(--text-muted);">(via environment)</span></div>
+    <div>Host: <span style="color: var(--text-muted);">{{ smtp_host }}:{{ smtp_port }}</span> ({{ smtp_tls_mode }})</div>
+    <div>From: <span style="color: var(--text-muted);">{% if smtp_from_name %}{{ smtp_from_name }} {% endif %}&lt;{{ smtp_from_email }}&gt;</span></div>
+  </div>
+  <form method="post" action="/dashboard/admin/smtp/test" style="margin-top: 1rem;">
+    <div class="form-group">
+      <label>Send a test email to <span class="hint">(defaults to your account email)</span></label>
+      <input type="email" name="to" value="" placeholder="you@example.com">
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600;">Send test email</button>
+  </form>
+
   {% else %}
-  <p style="color: var(--text-muted); font-size: 0.875rem;">SMTP is not configured.</p>
+  <div style="margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
+    Status: {% if smtp_configured %}<strong style="color: var(--success);">configured</strong>{% if not smtp_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %}{% else %}<span style="color: var(--text-muted);">not configured</span>{% endif %}
+  </div>
+  <form method="post" action="/dashboard/admin/smtp">
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="enabled" value="on" {% if smtp_enabled or not smtp_configured %}checked{% endif %} style="width: 1rem; height: 1rem;">
+        SMTP enabled
+      </label>
+    </div>
+    <div class="form-group">
+      <label>Host</label>
+      <input type="text" name="host" value="{{ smtp_host }}" placeholder="smtp.example.com" required>
+    </div>
+    <div class="form-group">
+      <label>Port</label>
+      <input type="number" name="port" min="1" max="65535" value="{% if smtp_configured %}{{ smtp_port }}{% else %}587{% endif %}" placeholder="587">
+    </div>
+    <div class="form-group">
+      <label>TLS mode</label>
+      <select name="tls_mode">
+        <option value="starttls" {% if smtp_tls_mode != "tls" %}selected{% endif %}>STARTTLS (port 587)</option>
+        <option value="tls" {% if smtp_tls_mode == "tls" %}selected{% endif %}>Implicit TLS (port 465)</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label>Username</label>
+      <input type="text" name="username" value="{{ smtp_username }}" placeholder="user@example.com">
+    </div>
+    <div class="form-group">
+      <label>Password <span class="hint">(leave empty to keep current)</span></label>
+      <input type="password" name="password" value="" placeholder="Leave empty to keep unchanged">
+    </div>
+    <div class="form-group">
+      <label>From email</label>
+      <input type="email" name="from_email" value="{{ smtp_from_email }}" placeholder="noreply@example.com" required>
+    </div>
+    <div class="form-group">
+      <label>From name <span class="hint">(optional)</span></label>
+      <input type="text" name="from_name" value="{{ smtp_from_name }}" placeholder="calrs">
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save SMTP settings</button>
+  </form>
+
+  {% if smtp_configured %}
+  <form method="post" action="/dashboard/admin/smtp/test" style="margin-top: 1.25rem;">
+    <div class="form-group">
+      <label>Send a test email to <span class="hint">(defaults to your account email)</span></label>
+      <input type="email" name="to" value="" placeholder="you@example.com">
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600;">Send test email</button>
+  </form>
+  <form method="post" action="/dashboard/admin/smtp/clear" style="margin-top: 1rem;" onsubmit="return confirm('Delete the database SMTP configuration?');">
+    <button type="submit" class="slot-btn" style="cursor: pointer; color: var(--error-text); border-color: var(--error-text);">Clear database config</button>
+  </form>
   {% endif %}
-  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 0.75rem;">Configure via environment variables: <code>CALRS_SMTP_HOST</code>, <code>CALRS_SMTP_PORT</code>, <code>CALRS_SMTP_TLS_MODE</code> (<code>starttls</code> or <code>tls</code>), <code>CALRS_SMTP_USERNAME</code>, <code>CALRS_SMTP_PASSWORD</code>, <code>CALRS_SMTP_FROM_EMAIL</code>, <code>CALRS_SMTP_FROM_NAME</code>.</p>
+
+  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 1rem;">Alternatively, configure via environment variables (which override this): <code>CALRS_SMTP_HOST</code>, <code>CALRS_SMTP_PORT</code>, <code>CALRS_SMTP_TLS_MODE</code> (<code>starttls</code> or <code>tls</code>), <code>CALRS_SMTP_USERNAME</code>, <code>CALRS_SMTP_PASSWORD</code>, <code>CALRS_SMTP_FROM_EMAIL</code>, <code>CALRS_SMTP_FROM_NAME</code>.</p>
+  {% endif %}
 </div>
 
 <script>


### PR DESCRIPTION
feat(smtp): editable SMTP config from admin UI + explicit env/DB priority
The admin panel only displayed SMTP read-only, and the env-vs-DB priority
was fragile: a single stray CALRS_SMTP_* var made the env loader bail and
broke sending entirely, while `config show` was blind to env config.

- Admin panel: editable SMTP form (host/port/TLS/user/password/from/enabled)
  with keep-current password, plus "send test email" and "clear DB config".
  When the env block governs, the card is locked behind a banner.
- email.rs: load_smtp_config_from_env() now uses "full block override" —
  a complete env block wins over the DB, a partial/absent one falls back to
  the DB (warn) instead of erroring. A complete-but-invalid block still
  surfaces the error. New smtp_env_active() guards UI writes.
- SmtpStatus enriched (username/from_name/tls_mode), DB lookup prefers the
  enabled row for determinism.
- config show goes through load_smtp_status so it reflects env config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMTP status reporting so it reflects environment-driven settings when they’re fully provided, avoiding misleading “not configured” output.
  * Hardened environment handling so partially provided SMTP env blocks fall back to database configuration instead of failing.

* **New Features**
  * Added admin routes to test SMTP settings and to clear stored SMTP configuration.
  * Expanded the admin SMTP section with environment-aware status panels, richer configuration fields (including TLS mode and from details), and clearer test-result feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->