### PR TITLE
feat(config): make base URL and private-host allowlist DB/UI configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ calrs/
 │   ├── 042_event_transp.sql      ← TRANSP column on events (skip TRANSPARENT)
 │   ├── 043_event_type_watchers.sql ← event_type_watchers junction (team watches event type)
 │   ├── 044_booking_claim.sql     ← claimed_by_user_id/claimed_at on bookings + booking_claim_tokens
-│   └── 055_provider_type.sql     ← provider_type on caldav_sources (caldav/ews) for the calendar-provider abstraction
+│   ├── 055_provider_type.sql     ← provider_type on caldav_sources (caldav/ews) for the calendar-provider abstraction
+│   ├── 056_meeting_links.sql     ← jitsi + webhook meeting-provider columns on auth_config
+│   └── 057_runtime_settings.sql  ← base_url + allow_private_hosts on auth_config (env-overridable runtime settings)
 ├── templates/
 │   ├── base.html                 ← base layout + CSS (light/dark mode)
 │   ├── dashboard_base.html       ← sidebar layout (extends base.html, all dashboard pages extend this)
@@ -144,6 +146,7 @@ calrs/
     │                               axum extractors (AuthUser, AdminUser), web handlers
     ├── email.rs                  ← SMTP email with .ics calendar invites, HTML templates
     ├── rrule.rs                  ← RRULE expansion (DAILY/WEEKLY/MONTHLY, EXDATE, BYDAY)
+    ├── settings.rs               ← runtime settings (base_url, allow_private_hosts): env-overrides-DB, process-global cache
     ├── utils.rs                  ← shared utilities: split_vevents(), extract_vevent_field()
     ├── caldav/
     │   └── mod.rs                ← CalDAV client: discovery, calendar list, event fetch, write-back

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -145,7 +145,10 @@ cal.example.com {
 |---|---|---|
 | `CALRS_DATA_DIR` | SQLite database directory | `/var/lib/calrs` (Docker/systemd) or XDG (dev) |
 | `CALRS_BASE_URL` | Public URL (required for OIDC callbacks and email action links) | `http://localhost:3000` |
+| `CALRS_ALLOW_PRIVATE_HOSTS` | Comma-separated hostnames allowed to resolve to private IPs for CalDAV/EWS (SSRF opt-out) | _(none)_ |
 | `RUST_LOG` | Log level filter | `calrs=info,tower_http=info` |
+
+`CALRS_BASE_URL` and `CALRS_ALLOW_PRIVATE_HOSTS` can also be set without environment variables — from the admin panel (**System settings**) or the CLI (`calrs config general`). The stored value is persisted in the database; when the matching environment variable is set it takes precedence at runtime. The other variables (`CALRS_DATA_DIR`, `RUST_LOG`, and `CALRS_SECRET_KEY`) are bootstrap settings and remain environment-only.
 
 ## Observability
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -119,13 +119,17 @@ This check resolves the hostname once at validation time, so a DNS-rebinding att
 
 #### Allowing private CalDAV hosts (self-hosting)
 
-Self-hosted deployments often run calrs and the CalDAV server on the same private network (e.g. a docker-compose stack where `http://radicale:5232` resolves to an RFC1918 address). To permit specific hostnames to resolve to private/reserved IPs, set the `CALRS_ALLOW_PRIVATE_HOSTS` environment variable to a comma-separated list of hostnames (or literal IPs):
+Self-hosted deployments often run calrs and the CalDAV server on the same private network (e.g. a docker-compose stack where `http://radicale:5232` resolves to an RFC1918 address). To permit specific hostnames to resolve to private/reserved IPs, configure a comma-separated allowlist of hostnames (or literal IPs). Two ways, in order of precedence:
 
-```
-CALRS_ALLOW_PRIVATE_HOSTS=radicale,nextcloud.local,127.0.0.1
-```
+1. **Environment variable** (takes precedence — ops override):
+   ```
+   CALRS_ALLOW_PRIVATE_HOSTS=radicale,nextcloud.local,127.0.0.1
+   ```
+2. **Admin UI / CLI** (persisted in the DB, used when the env var is unset):
+   - Admin panel → **System settings** → *Private-host allowlist*
+   - `calrs config general --allow-private-hosts radicale,nextcloud.local,127.0.0.1`
 
-Matching is case-insensitive and exact (no wildcards or subdomain matching). Only the listed hosts bypass the private-IP check; every other host is still validated. Keep this list as small as possible, scheme validation (http/https only) still applies.
+When the environment variable is set it overrides the stored value (the admin panel shows a "set by environment" badge). Matching is case-insensitive and exact (no wildcards or subdomain matching). Only the listed hosts bypass the private-IP check; every other host is still validated. Keep this list as small as possible, scheme validation (http/https only) still applies.
 
 In a trusted multi-user deployment (e.g., behind OIDC) this is low risk. For public-registration instances, configure egress filtering at the network level.
 

--- a/migrations/057_runtime_settings.sql
+++ b/migrations/057_runtime_settings.sql
@@ -1,0 +1,8 @@
+-- Runtime settings that were previously env-only, now overridable from the DB
+-- (admin UI / `calrs config general`). The environment variable still takes
+-- precedence at runtime when set — see `src/settings.rs`.
+--
+-- base_url            ← CALRS_BASE_URL (public URL for OIDC redirects & email links)
+-- allow_private_hosts ← CALRS_ALLOW_PRIVATE_HOSTS (comma-separated SSRF allowlist)
+ALTER TABLE auth_config ADD COLUMN base_url TEXT;
+ALTER TABLE auth_config ADD COLUMN allow_private_hosts TEXT;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -922,7 +922,7 @@ async fn build_oidc_client_with_redirect(
 
     let redirect_url = RedirectUrl::new(format!(
         "{}/auth/oidc/callback",
-        std::env::var("CALRS_BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string())
+        crate::settings::base_url().unwrap_or_else(|| "http://localhost:3000".to_string())
     ))
     .map_err(|e| anyhow::anyhow!("Invalid redirect URL: {}", e))?;
 

--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -42,16 +42,14 @@ fn is_private_ip(ip: &IpAddr) -> bool {
     }
 }
 
-/// Parse the `CALRS_ALLOW_PRIVATE_HOSTS` env var into a list of hostnames that
-/// are permitted to resolve to private/reserved IPs. Comma-separated,
-/// whitespace-trimmed, case-insensitive. Empty entries are ignored.
+/// Hostnames that are permitted to resolve to private/reserved IPs.
+///
+/// Resolved from the `CALRS_ALLOW_PRIVATE_HOSTS` env var (which takes
+/// precedence) or, as a fallback, the DB-stored value loaded into the
+/// process-global cache. See [`crate::settings`] for the precedence rules.
+/// Comma-separated, whitespace-trimmed, case-insensitive; empty entries ignored.
 pub fn private_host_allowlist() -> Vec<String> {
-    std::env::var("CALRS_ALLOW_PRIVATE_HOSTS")
-        .unwrap_or_default()
-        .split(',')
-        .map(|h| h.trim().to_ascii_lowercase())
-        .filter(|h| !h.is_empty())
-        .collect()
+    crate::settings::private_host_allowlist()
 }
 
 /// Whether `host` is in the configured private-host allowlist (case-insensitive).

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -42,6 +42,16 @@ pub enum ConfigCommands {
         #[arg(long)]
         allowed_domains: Option<String>,
     },
+    /// Configure general/system settings (public base URL, SSRF allowlist)
+    General {
+        /// Public base URL, e.g. https://cal.example.com (empty string clears it)
+        #[arg(long)]
+        base_url: Option<String>,
+        /// Comma-separated hostnames allowed to resolve to private IPs for
+        /// CalDAV/EWS (empty string clears it)
+        #[arg(long)]
+        allow_private_hosts: Option<String>,
+    },
     /// Dump all configuration as JSON
     Dump {
         /// Pretty-print the JSON output
@@ -81,6 +91,8 @@ struct AuthConfigDump {
     oidc_issuer_url: Option<String>,
     oidc_client_id: Option<String>,
     oidc_auto_register: bool,
+    base_url: Option<String>,
+    allow_private_hosts: Option<String>,
     accent_color: String,
     theme: String,
     custom_accent: Option<String>,
@@ -328,6 +340,7 @@ async fn build_dump_output(pool: &SqlitePool) -> Result<serde_json::Value> {
     let auth_json = sqlx::query_as::<_, AuthConfigDump>(
         "SELECT registration_enabled, allowed_email_domains, oidc_enabled, \
          oidc_issuer_url, oidc_client_id, oidc_auto_register, \
+         base_url, allow_private_hosts, \
          accent_color, theme, custom_accent, custom_accent_hover, custom_bg, \
          custom_surface, custom_text, company_link, \
          captcha_instance_url, captcha_site_key, captcha_widget_url, \
@@ -736,6 +749,121 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                 }
             }
         }
+        ConfigCommands::General {
+            base_url,
+            allow_private_hosts,
+        } => {
+            // Load the cache so we can report the effective values (env-aware).
+            crate::settings::load_from_db(pool).await;
+
+            if base_url.is_none() && allow_private_hosts.is_none() {
+                // Show current values.
+                println!("{}:", "General".bold());
+                let stored_base: Option<String> =
+                    sqlx::query_scalar("SELECT base_url FROM auth_config WHERE id = 'singleton'")
+                        .fetch_one(pool)
+                        .await
+                        .unwrap_or(None);
+                let stored_hosts: Option<String> = sqlx::query_scalar(
+                    "SELECT allow_private_hosts FROM auth_config WHERE id = 'singleton'",
+                )
+                .fetch_one(pool)
+                .await
+                .unwrap_or(None);
+
+                let base_env = crate::settings::base_url_from_env();
+                println!(
+                    "  Base URL (stored):    {}",
+                    stored_base
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or("(not set)")
+                );
+                println!(
+                    "  Base URL (effective): {}{}",
+                    crate::settings::base_url().as_deref().unwrap_or("(none)"),
+                    if base_env {
+                        " [from env]".to_string()
+                    } else {
+                        String::new()
+                    }
+                );
+
+                let hosts_env = crate::settings::allow_private_hosts_from_env();
+                println!(
+                    "  Allow private hosts (stored):    {}",
+                    stored_hosts
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or("(not set)")
+                );
+                let eff = crate::settings::private_host_allowlist();
+                println!(
+                    "  Allow private hosts (effective): {}{}",
+                    if eff.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        eff.join(", ")
+                    },
+                    if hosts_env {
+                        " [from env]".to_string()
+                    } else {
+                        String::new()
+                    }
+                );
+            } else {
+                if let Some(url) = base_url {
+                    let value = {
+                        let trimmed = url.trim().trim_end_matches('/');
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    };
+                    sqlx::query(
+                        "UPDATE auth_config SET base_url = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+                    )
+                    .bind(&value)
+                    .execute(pool)
+                    .await?;
+                    match &value {
+                        Some(v) => println!("{} Base URL set to: {}", "✓".green(), v),
+                        None => println!("{} Base URL cleared", "✓".green()),
+                    }
+                }
+                if let Some(hosts) = allow_private_hosts {
+                    let parsed = crate::settings::parse_host_list(&hosts);
+                    let value = if parsed.is_empty() {
+                        None
+                    } else {
+                        Some(parsed.join(","))
+                    };
+                    sqlx::query(
+                        "UPDATE auth_config SET allow_private_hosts = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+                    )
+                    .bind(&value)
+                    .execute(pool)
+                    .await?;
+                    match &value {
+                        Some(v) => println!("{} Allowed private hosts set to: {}", "✓".green(), v),
+                        None => println!("{} Allowed private hosts cleared", "✓".green()),
+                    }
+                }
+                if crate::settings::base_url_from_env() {
+                    println!(
+                        "{} CALRS_BASE_URL is set in the environment and overrides the stored value at runtime.",
+                        "note:".dimmed()
+                    );
+                }
+                if crate::settings::allow_private_hosts_from_env() {
+                    println!(
+                        "{} CALRS_ALLOW_PRIVATE_HOSTS is set in the environment and overrides the stored value at runtime.",
+                        "note:".dimmed()
+                    );
+                }
+            }
+        }
         ConfigCommands::Dump { pretty } => {
             let output = build_dump_output(pool).await?;
             let json = if pretty {
@@ -1058,6 +1186,70 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn config_general_set_and_clear() {
+        let pool = setup_db().await;
+        let key = [0u8; 32];
+
+        // Set both values; a trailing slash on the base URL is normalised away.
+        run(
+            &pool,
+            &key,
+            ConfigCommands::General {
+                base_url: Some("https://cal.example.com/".to_string()),
+                allow_private_hosts: Some(" Radicale , 127.0.0.1 ".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (base, hosts): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT base_url, allow_private_hosts FROM auth_config WHERE id = 'singleton'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(base.as_deref(), Some("https://cal.example.com"));
+        assert_eq!(hosts.as_deref(), Some("radicale,127.0.0.1"));
+
+        // Empty strings clear the stored values.
+        run(
+            &pool,
+            &key,
+            ConfigCommands::General {
+                base_url: Some(String::new()),
+                allow_private_hosts: Some(String::new()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (base, hosts): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT base_url, allow_private_hosts FROM auth_config WHERE id = 'singleton'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(base.is_none());
+        assert!(hosts.is_none());
+    }
+
+    #[tokio::test]
+    async fn config_dump_includes_general_settings() {
+        let pool = setup_db().await;
+        sqlx::query(
+            "UPDATE auth_config SET base_url = 'https://cal.example.com', \
+             allow_private_hosts = 'radicale' WHERE id = 'singleton'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let output = build_dump_output(&pool).await.unwrap();
+        assert_eq!(output["auth"]["base_url"], "https://cal.example.com");
+        assert_eq!(output["auth"]["allow_private_hosts"], "radicale");
     }
 
     #[tokio::test]

--- a/src/commands/source.rs
+++ b/src/commands/source.rs
@@ -90,6 +90,10 @@ struct SourceRow {
 }
 
 pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: SourceCommands) -> Result<()> {
+    // Honour the DB-stored private-host allowlist during URL validation (the
+    // env var, if set, still takes precedence — see `crate::settings`).
+    crate::settings::load_from_db(pool).await;
+
     match cmd {
         SourceCommands::Add {
             url,

--- a/src/db.rs
+++ b/src/db.rs
@@ -240,6 +240,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "056_meeting_links",
             include_str!("../migrations/056_meeting_links.sql"),
         ),
+        (
+            "057_runtime_settings",
+            include_str!("../migrations/057_runtime_settings.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -847,7 +851,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 56, "All 56 migrations should be tracked");
+        assert_eq!(count.0, 57, "All 57 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -861,7 +865,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 56, "Still 56 migrations after second run");
+        assert_eq!(count.0, 57, "Still 57 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod models;
 mod oauth2_caldav;
 mod providers;
 mod rrule;
+mod settings;
 mod utils;
 mod web;
 
@@ -137,12 +138,17 @@ async fn main() -> Result<()> {
         Commands::User { command } => commands::user::run(&pool, &data_dir, command).await?,
         Commands::Config { command } => commands::config::run(&pool, &secret_key, command).await?,
         Commands::Serve { port, host } => {
+            // Load DB-backed runtime settings (base URL, private-host allowlist)
+            // into the process-global cache before anything reads them.
+            settings::load_from_db(&pool).await;
+
             let private_hosts = caldav::private_host_allowlist();
             if !private_hosts.is_empty() {
                 tracing::warn!(
                     allowed_hosts = ?private_hosts,
-                    "CALRS_ALLOW_PRIVATE_HOSTS is set: listed hostnames bypass the \
-                     SSRF private-IP guard for CalDAV/EWS URLs"
+                    from_env = settings::allow_private_hosts_from_env(),
+                    "private-host allowlist is set (env or DB): listed hostnames \
+                     bypass the SSRF private-IP guard for CalDAV/EWS URLs"
                 );
             }
             // Spawn background reminder task

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,156 @@
+//! Runtime settings that can be configured either via an environment variable
+//! or persisted in the DB (`auth_config` singleton) through the admin UI /
+//! `calrs config general`.
+//!
+//! ## Precedence
+//!
+//! The **environment variable wins** when it is set and non-empty. The DB value
+//! is only used as a fallback. This keeps ops overrides authoritative: a value
+//! forced via the environment can never be silently changed from the web UI.
+//! The admin panel surfaces an "set by environment" badge in that case.
+//!
+//! ## Why a process-global cache
+//!
+//! `private_host_allowlist()` is called from deep, synchronous code paths
+//! (`validate_caldav_url`, the provider factory, EWS autodiscovery) and from the
+//! CLI — none of which carry a `SqlitePool`. Rather than thread the pool (or an
+//! allowlist argument) through every signature, the DB-backed values are loaded
+//! once into a process-global cache at startup (`load_from_db`) and refreshed
+//! whenever the admin saves changes. Reads stay synchronous and allocation-light.
+//!
+//! `base_url()` uses the same cache so that per-email / per-link reads don't hit
+//! the DB.
+
+use sqlx::SqlitePool;
+use std::sync::RwLock;
+
+/// DB-stored `CALRS_BASE_URL` fallback. `None` until `load_from_db` runs.
+static BASE_URL_DB: RwLock<Option<String>> = RwLock::new(None);
+/// DB-stored `CALRS_ALLOW_PRIVATE_HOSTS` fallback (already parsed/normalised).
+static ALLOW_PRIVATE_HOSTS_DB: RwLock<Option<Vec<String>>> = RwLock::new(None);
+
+/// Read `CALRS_BASE_URL` from the environment, trimmed; `None` when unset/empty.
+fn base_url_env() -> Option<String> {
+    std::env::var("CALRS_BASE_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Whether `CALRS_BASE_URL` is forcing the value (env precedence is in effect).
+pub fn base_url_from_env() -> bool {
+    base_url_env().is_some()
+}
+
+/// The effective public base URL: env var if set, else the DB-stored value.
+/// `None` when neither is configured (callers fall back to their own default).
+pub fn base_url() -> Option<String> {
+    if let Some(env) = base_url_env() {
+        return Some(env);
+    }
+    BASE_URL_DB.read().ok().and_then(|g| g.clone())
+}
+
+/// The DB-stored base URL, ignoring the environment override. Used by the admin
+/// UI / `config show` to display what is persisted even when env wins.
+pub fn base_url_db() -> Option<String> {
+    BASE_URL_DB.read().ok().and_then(|g| g.clone())
+}
+
+/// Parse a comma-separated host list into normalised entries (trimmed,
+/// lowercased, empties dropped).
+pub fn parse_host_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|h| h.trim().to_ascii_lowercase())
+        .filter(|h| !h.is_empty())
+        .collect()
+}
+
+/// Read `CALRS_ALLOW_PRIVATE_HOSTS` from the environment, parsed; `None` when
+/// the variable is unset or contains no non-empty entries.
+fn allow_private_hosts_env() -> Option<Vec<String>> {
+    let raw = std::env::var("CALRS_ALLOW_PRIVATE_HOSTS").ok()?;
+    let list = parse_host_list(&raw);
+    if list.is_empty() {
+        None
+    } else {
+        Some(list)
+    }
+}
+
+/// Whether `CALRS_ALLOW_PRIVATE_HOSTS` is forcing the value.
+pub fn allow_private_hosts_from_env() -> bool {
+    allow_private_hosts_env().is_some()
+}
+
+/// The effective private-host SSRF allowlist: env var if set, else the
+/// DB-stored value, else empty.
+pub fn private_host_allowlist() -> Vec<String> {
+    if let Some(env) = allow_private_hosts_env() {
+        return env;
+    }
+    ALLOW_PRIVATE_HOSTS_DB
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_default()
+}
+
+/// The DB-stored allowlist, ignoring the environment override (for display).
+pub fn private_host_allowlist_db() -> Vec<String> {
+    ALLOW_PRIVATE_HOSTS_DB
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_default()
+}
+
+/// Overwrite the in-memory DB-backed values. Called after `load_from_db` and
+/// whenever the admin saves changes.
+fn set_cache(base_url: Option<String>, allow_private_hosts: Option<Vec<String>>) {
+    if let Ok(mut g) = BASE_URL_DB.write() {
+        *g = base_url;
+    }
+    if let Ok(mut g) = ALLOW_PRIVATE_HOSTS_DB.write() {
+        *g = allow_private_hosts;
+    }
+}
+
+/// Load the DB-backed runtime settings from `auth_config` into the cache. Safe
+/// to call multiple times (startup, after admin save, before CLI validation).
+/// Silently leaves the cache untouched on error — the env fallback still works.
+pub async fn load_from_db(pool: &SqlitePool) {
+    let row: Option<(Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT base_url, allow_private_hosts FROM auth_config WHERE id = 'singleton'",
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten();
+
+    let (base_url, allow_raw) = row.unwrap_or((None, None));
+
+    let base_url = base_url
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    let allow_private_hosts = allow_raw
+        .map(|raw| parse_host_list(&raw))
+        .filter(|list| !list.is_empty());
+
+    set_cache(base_url, allow_private_hosts);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_host_list_trims_lowercases_and_drops_empties() {
+        assert_eq!(
+            parse_host_list(" 127.0.0.1 , Radicale ,, "),
+            vec!["127.0.0.1", "radicale"]
+        );
+        assert!(parse_host_list("").is_empty());
+        assert!(parse_host_list("  ,  ").is_empty());
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -120,14 +120,22 @@ fn set_cache(base_url: Option<String>, allow_private_hosts: Option<Vec<String>>)
 /// to call multiple times (startup, after admin save, before CLI validation).
 /// Silently leaves the cache untouched on error — the env fallback still works.
 pub async fn load_from_db(pool: &SqlitePool) {
-    let row: Option<(Option<String>, Option<String>)> = sqlx::query_as(
+    let row: Option<(Option<String>, Option<String>)> = match sqlx::query_as(
         "SELECT base_url, allow_private_hosts FROM auth_config WHERE id = 'singleton'",
     )
     .fetch_optional(pool)
     .await
-    .ok()
-    .flatten();
+    {
+        Ok(row) => row,
+        Err(e) => {
+            // A transient read error must NOT wipe previously cached values —
+            // keep what we have and let the env fallback continue to work.
+            tracing::warn!(error = %e, "failed to load runtime settings from DB; keeping cached values");
+            return;
+        }
+    };
 
+    // Ok(None) genuinely means no singleton row → reset to defaults.
     let (base_url, allow_raw) = row.unwrap_or((None, None));
 
     let base_url = base_url

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -14524,7 +14524,9 @@ async fn google_connect(
     let base_url = crate::settings::base_url().unwrap_or_default();
     if base_url.is_empty() {
         return Html(
-            "CALRS_BASE_URL environment variable must be set for OAuth2 flows.".to_string(),
+            "The public base URL is not configured. Set it via the CALRS_BASE_URL environment \
+             variable or in the admin panel under System settings before using OAuth2 flows."
+                .to_string(),
         )
         .into_response();
     }
@@ -14782,27 +14784,65 @@ async fn admin_update_general(
         return resp;
     }
 
-    // Normalise: strip a trailing slash off the base URL, re-serialise the
-    // allowlist through the canonical parser so what we store matches what
-    // `settings` will read back. Empty → NULL (clears the DB override).
-    let base_url = form
-        .base_url
-        .map(|s| s.trim().trim_end_matches('/').to_string())
-        .filter(|s| !s.is_empty());
-    let allow_private_hosts = form
-        .allow_private_hosts
-        .map(|s| crate::settings::parse_host_list(&s).join(","))
-        .filter(|s| !s.is_empty());
+    // Only persist a field that isn't currently forced by an environment
+    // variable. A forced field is read-only in the UI and submits the env
+    // value back; writing it would either clobber the stored DB value with NULL
+    // (disabled inputs) or leak the env value into the DB. The env keeps
+    // precedence regardless, so there's nothing to save for those fields.
+    if !crate::settings::base_url_from_env() {
+        // Normalise (strip trailing slash). Empty clears the override; a
+        // non-empty value must be an absolute http(s) URL with a host. We do
+        // NOT run the SSRF guard here — the public base URL is legitimately
+        // allowed to be localhost / a private host in dev.
+        let raw = form
+            .base_url
+            .as_deref()
+            .map(|s| s.trim().trim_end_matches('/'))
+            .filter(|s| !s.is_empty());
+        let base_url = match raw {
+            None => None,
+            Some(raw) => match reqwest::Url::parse(raw) {
+                Ok(u) if matches!(u.scheme(), "http" | "https") && u.host_str().is_some() => {
+                    Some(raw.to_string())
+                }
+                _ => {
+                    let msg = urlencoding::encode(
+                        "Base URL must be an absolute http(s) URL, e.g. https://cal.example.com",
+                    )
+                    .into_owned();
+                    return Redirect::to(&format!("/dashboard/admin?error={}", msg))
+                        .into_response();
+                }
+            },
+        };
+        if let Err(e) = sqlx::query(
+            "UPDATE auth_config SET base_url = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(&base_url)
+        .execute(&state.pool)
+        .await
+        {
+            return internal_error_response("save base_url", &e);
+        }
+    }
 
-    if let Err(e) = sqlx::query(
-        "UPDATE auth_config SET base_url = ?, allow_private_hosts = ?, updated_at = datetime('now') WHERE id = 'singleton'",
-    )
-    .bind(&base_url)
-    .bind(&allow_private_hosts)
-    .execute(&state.pool)
-    .await
-    {
-        tracing::error!(error = %e, "failed to save general settings");
+    if !crate::settings::allow_private_hosts_from_env() {
+        // Re-serialise through the canonical parser so what we store matches
+        // what `settings` reads back. Empty → NULL (clears the DB override).
+        let allow_private_hosts = form
+            .allow_private_hosts
+            .as_deref()
+            .map(|s| crate::settings::parse_host_list(s).join(","))
+            .filter(|s| !s.is_empty());
+        if let Err(e) = sqlx::query(
+            "UPDATE auth_config SET allow_private_hosts = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+        )
+        .bind(&allow_private_hosts)
+        .execute(&state.pool)
+        .await
+        {
+            return internal_error_response("save allow_private_hosts", &e);
+        }
     }
 
     // Refresh the process-global cache so the change takes effect immediately.
@@ -17321,7 +17361,7 @@ async fn notify_watchers(
     let base_url = match crate::settings::base_url() {
         Some(u) => u,
         None => {
-            tracing::warn!("CALRS_BASE_URL not set, skipping watcher notifications");
+            tracing::warn!("base URL not configured (CALRS_BASE_URL or admin System settings), skipping watcher notifications");
             return;
         }
     };

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -430,7 +430,7 @@ pub async fn run_reminder_loop(pool: SqlitePool, secret_key: [u8; 32]) {
         .await
         .unwrap_or_default();
 
-        let base_url = std::env::var("CALRS_BASE_URL").ok();
+        let base_url = crate::settings::base_url();
 
         if due.is_empty() {
             continue;
@@ -1193,6 +1193,10 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
     env.set_loader(minijinja::path_loader("templates"));
     crate::i18n::register(&mut env);
 
+    // Populate the process-global runtime-settings cache (base URL, private-host
+    // allowlist) so synchronous readers and email/link builders see DB values.
+    crate::settings::load_from_db(&pool).await;
+
     let initial_theme_css = build_theme_css(&pool).await;
     let initial_company_link = get_company_link(&pool).await;
     let initial_captcha = captcha::load_captcha_config(&pool, &secret_key).await;
@@ -1350,6 +1354,7 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
             post(admin_delete_user),
         )
         .route("/dashboard/admin/auth", post(admin_update_auth))
+        .route("/dashboard/admin/general", post(admin_update_general))
         .route("/dashboard/admin/accent", post(admin_update_accent))
         .route("/dashboard/admin/oidc", post(admin_update_oidc))
         .route(
@@ -4295,7 +4300,7 @@ async fn confirm_booking(
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        let base_url = std::env::var("CALRS_BASE_URL").ok();
+        let base_url = crate::settings::base_url();
         let guest_cancel_url = cancel_token.as_ref().and_then(|t| {
             base_url
                 .as_ref()
@@ -6841,7 +6846,7 @@ async fn render_invite_management(
     .await
     .unwrap_or_default();
 
-    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    let base_url = crate::settings::base_url().unwrap_or_default();
     let invites_ctx: Vec<minijinja::Value> = invites
         .iter()
         .map(
@@ -6984,7 +6989,7 @@ async fn send_invite_bulk(
         .map(str::trim)
         .filter(|s| !s.is_empty());
 
-    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    let base_url = crate::settings::base_url().unwrap_or_default();
     let et_slug: Option<String> = if !valid_recipients.is_empty() {
         sqlx::query_scalar("SELECT slug FROM event_types WHERE id = ?")
             .bind(&et_id)
@@ -7196,7 +7201,7 @@ async fn generate_quick_link(
 
     tracing::info!(event_type = %et_id, created_by = %auth_user.user.email, "quick invite link generated");
 
-    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    let base_url = crate::settings::base_url().unwrap_or_default();
     let invite_url = if let Some(ts) = &team_slug {
         format!("{}/team/{}/{}?invite={}", base_url, ts, et_slug, token)
     } else if let Some(un) = &username {
@@ -7473,10 +7478,11 @@ async fn embed_page(
     .into_response()
 }
 
-/// Absolute base URL for embed snippets: `CALRS_BASE_URL` without a trailing
-/// slash, or empty (the page then falls back to the dashboard's own origin).
+/// Absolute base URL for embed snippets: the configured base URL (env or DB)
+/// without a trailing slash, or empty (the page then falls back to the
+/// dashboard's own origin).
 fn embed_base_url() -> String {
-    std::env::var("CALRS_BASE_URL")
+    crate::settings::base_url()
         .unwrap_or_default()
         .trim_end_matches('/')
         .to_string()
@@ -9568,7 +9574,7 @@ async fn handle_group_booking(
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        let base_url = std::env::var("CALRS_BASE_URL").ok();
+        let base_url = crate::settings::base_url();
         let guest_cancel_url = base_url.as_ref().map(|base| {
             format!(
                 "{}/booking/cancel/{}",
@@ -10348,7 +10354,7 @@ async fn handle_dynamic_group_booking(
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        let base_url = std::env::var("CALRS_BASE_URL").ok();
+        let base_url = crate::settings::base_url();
         let guest_cancel_url = base_url.as_ref().map(|base| {
             format!(
                 "{}/booking/cancel/{}",
@@ -11144,7 +11150,7 @@ async fn handle_booking_for_user(
         if let Ok(Some(smtp_config)) =
             crate::email::load_smtp_config(&state.pool, &state.secret_key).await
         {
-            let base_url = std::env::var("CALRS_BASE_URL").ok();
+            let base_url = crate::settings::base_url();
             let guest_cancel_url = base_url.as_ref().map(|base| {
                 format!(
                     "{}/booking/cancel/{}",
@@ -13207,7 +13213,7 @@ async fn handle_booking(
         if let Ok(Some(smtp_config)) =
             crate::email::load_smtp_config(&state.pool, &state.secret_key).await
         {
-            let base_url = std::env::var("CALRS_BASE_URL").ok();
+            let base_url = crate::settings::base_url();
             let guest_cancel_url = base_url.as_ref().map(|base| {
                 format!(
                     "{}/booking/cancel/{}",
@@ -14133,7 +14139,12 @@ async fn admin_dashboard(
             oidc_auto_register => oidc_auto_register,
             google_oauth2_client_id => google_oauth2_client_id,
             google_oauth2_configured => google_oauth2_configured,
-            base_url => std::env::var("CALRS_BASE_URL").unwrap_or_default(),
+            base_url => crate::settings::base_url().unwrap_or_default(),
+            base_url_db => crate::settings::base_url_db().unwrap_or_default(),
+            base_url_from_env => crate::settings::base_url_from_env(),
+            allow_private_hosts => crate::settings::private_host_allowlist().join(", "),
+            allow_private_hosts_db => crate::settings::private_host_allowlist_db().join(", "),
+            allow_private_hosts_from_env => crate::settings::allow_private_hosts_from_env(),
             smtp_configured => smtp_configured,
             smtp_host => smtp_host,
             smtp_port => smtp_port,
@@ -14510,7 +14521,7 @@ async fn google_connect(
         }
     };
 
-    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    let base_url = crate::settings::base_url().unwrap_or_default();
     if base_url.is_empty() {
         return Html(
             "CALRS_BASE_URL environment variable must be set for OAuth2 flows.".to_string(),
@@ -14621,7 +14632,7 @@ async fn google_callback(
         Err(e) => return internal_error_response("decrypt google_oauth2 client_secret", &e),
     };
 
-    let base_url = std::env::var("CALRS_BASE_URL").unwrap_or_default();
+    let base_url = crate::settings::base_url().unwrap_or_default();
     let redirect_uri = format!(
         "{}/dashboard/sources/google/callback",
         base_url.trim_end_matches('/')
@@ -14750,6 +14761,55 @@ struct AdminCaptchaForm {
     captcha_site_key: Option<String>,
     captcha_secret: Option<String>,
     captcha_widget_url: Option<String>,
+}
+
+// --- General / system runtime settings (base URL, private-host allowlist) ---
+
+#[derive(Deserialize)]
+struct AdminGeneralForm {
+    _csrf: Option<String>,
+    base_url: Option<String>,
+    allow_private_hosts: Option<String>,
+}
+
+async fn admin_update_general(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminGeneralForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    // Normalise: strip a trailing slash off the base URL, re-serialise the
+    // allowlist through the canonical parser so what we store matches what
+    // `settings` will read back. Empty → NULL (clears the DB override).
+    let base_url = form
+        .base_url
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty());
+    let allow_private_hosts = form
+        .allow_private_hosts
+        .map(|s| crate::settings::parse_host_list(&s).join(","))
+        .filter(|s| !s.is_empty());
+
+    if let Err(e) = sqlx::query(
+        "UPDATE auth_config SET base_url = ?, allow_private_hosts = ?, updated_at = datetime('now') WHERE id = 'singleton'",
+    )
+    .bind(&base_url)
+    .bind(&allow_private_hosts)
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!(error = %e, "failed to save general settings");
+    }
+
+    // Refresh the process-global cache so the change takes effect immediately.
+    crate::settings::load_from_db(&state.pool).await;
+
+    tracing::info!(admin = %_admin.0.email, "admin: general settings updated");
+    Redirect::to("/dashboard/admin").into_response()
 }
 
 async fn admin_update_captcha(
@@ -15402,7 +15462,7 @@ async fn approve_booking_by_token(
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        let base_url = std::env::var("CALRS_BASE_URL").ok();
+        let base_url = crate::settings::base_url();
         let guest_cancel_url = cancel_token.as_ref().and_then(|t| {
             base_url
                 .as_ref()
@@ -16530,7 +16590,7 @@ async fn guest_reschedule_booking(
         if let Ok(Some(smtp_config)) =
             crate::email::load_smtp_config(&state.pool, &state.secret_key).await
         {
-            let base_url = std::env::var("CALRS_BASE_URL").ok();
+            let base_url = crate::settings::base_url();
 
             // Send host reschedule approval request
             let reschedule_details = crate::email::RescheduleDetails {
@@ -16632,7 +16692,7 @@ async fn guest_reschedule_booking(
         if let Ok(Some(smtp_config)) =
             crate::email::load_smtp_config(&state.pool, &state.secret_key).await
         {
-            let base_url = std::env::var("CALRS_BASE_URL").ok();
+            let base_url = crate::settings::base_url();
             let guest_cancel_url = base_url.as_ref().map(|base| {
                 format!(
                     "{}/booking/cancel/{}",
@@ -16820,7 +16880,7 @@ async fn host_reschedule_booking(
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        let base_url = std::env::var("CALRS_BASE_URL").ok();
+        let base_url = crate::settings::base_url();
         let reschedule_url = base_url.as_ref().map(|base| {
             format!(
                 "{}/booking/reschedule/{}",
@@ -17258,7 +17318,7 @@ async fn notify_watchers(
         return;
     }
 
-    let base_url = match std::env::var("CALRS_BASE_URL").ok() {
+    let base_url = match crate::settings::base_url() {
         Some(u) => u,
         None => {
             tracing::warn!("CALRS_BASE_URL not set, skipping watcher notifications");

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -294,7 +294,7 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
       <input type="url" name="base_url"
         value="{% if base_url_from_env %}{{ base_url }}{% else %}{{ base_url_db }}{% endif %}"
         placeholder="https://cal.example.com"
-        {% if base_url_from_env %}disabled style="opacity: 0.6; cursor: not-allowed;"{% endif %}>
+        {% if base_url_from_env %}readonly style="opacity: 0.6; cursor: not-allowed;"{% endif %}>
       <span style="font-size: 0.8rem; color: var(--text-muted);">
         Public URL of this instance. Used for OIDC redirects and links in emails (approve/decline, cancel, reminders).
         {% if base_url_from_env %}Unset the environment variable to edit this from here.{% endif %}
@@ -307,7 +307,7 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
       <input type="text" name="allow_private_hosts"
         value="{% if allow_private_hosts_from_env %}{{ allow_private_hosts }}{% else %}{{ allow_private_hosts_db }}{% endif %}"
         placeholder="radicale, 127.0.0.1"
-        {% if allow_private_hosts_from_env %}disabled style="opacity: 0.6; cursor: not-allowed;"{% endif %}>
+        {% if allow_private_hosts_from_env %}readonly style="opacity: 0.6; cursor: not-allowed;"{% endif %}>
       <span style="font-size: 0.8rem; color: var(--text-muted);">
         Comma-separated hostnames allowed to resolve to private/reserved IPs for CalDAV/EWS sources (SSRF guard opt-out).
         Only add hosts you control (e.g. a calendar server on the same Docker network). Leave empty to keep the guard active for all hosts.

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -278,6 +278,46 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
   </form>
 </div>
 
+<!-- System settings (base URL, SSRF private-host allowlist) -->
+<div class="card">
+  <h2>System settings</h2>
+  <p style="color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1rem;">
+    Public URL and network-security settings. These can also be set with the environment variables
+    <code>CALRS_BASE_URL</code> and <code>CALRS_ALLOW_PRIVATE_HOSTS</code>. When an environment variable is set it
+    <strong>takes precedence</strong> over the value below.
+  </p>
+  <form method="post" action="/dashboard/admin/general">
+    <div class="form-group">
+      <label>Base URL
+        {% if base_url_from_env %}<span class="hint" style="color: var(--warning-text, #b45309);">— set by environment (CALRS_BASE_URL), overriding the stored value</span>{% endif %}
+      </label>
+      <input type="url" name="base_url"
+        value="{% if base_url_from_env %}{{ base_url }}{% else %}{{ base_url_db }}{% endif %}"
+        placeholder="https://cal.example.com"
+        {% if base_url_from_env %}disabled style="opacity: 0.6; cursor: not-allowed;"{% endif %}>
+      <span style="font-size: 0.8rem; color: var(--text-muted);">
+        Public URL of this instance. Used for OIDC redirects and links in emails (approve/decline, cancel, reminders).
+        {% if base_url_from_env %}Unset the environment variable to edit this from here.{% endif %}
+      </span>
+    </div>
+    <div class="form-group">
+      <label>Private-host allowlist
+        {% if allow_private_hosts_from_env %}<span class="hint" style="color: var(--warning-text, #b45309);">— set by environment (CALRS_ALLOW_PRIVATE_HOSTS), overriding the stored value</span>{% endif %}
+      </label>
+      <input type="text" name="allow_private_hosts"
+        value="{% if allow_private_hosts_from_env %}{{ allow_private_hosts }}{% else %}{{ allow_private_hosts_db }}{% endif %}"
+        placeholder="radicale, 127.0.0.1"
+        {% if allow_private_hosts_from_env %}disabled style="opacity: 0.6; cursor: not-allowed;"{% endif %}>
+      <span style="font-size: 0.8rem; color: var(--text-muted);">
+        Comma-separated hostnames allowed to resolve to private/reserved IPs for CalDAV/EWS sources (SSRF guard opt-out).
+        Only add hosts you control (e.g. a calendar server on the same Docker network). Leave empty to keep the guard active for all hosts.
+        {% if allow_private_hosts_from_env %}Unset the environment variable to edit this from here.{% endif %}
+      </span>
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save system settings</button>
+  </form>
+</div>
+
 <!-- OIDC settings -->
 <div class="card">
   <h2>OIDC settings</h2>


### PR DESCRIPTION
feat(config): make base URL and private-host allowlist DB/UI configurable CALRS_BASE_URL and CALRS_ALLOW_PRIVATE_HOSTS can now be set from the admin panel (System settings) and the CLI (`calrs config general`) and are persisted on the auth_config singleton.
The environment variable still takes precedence at runtime when set; the admin UI shows the effective value in a disabled field with a "set by environment" badge in that case.

New `settings` module resolves env-over-DB precedence through a process-global cache (loaded at startup, refreshed on admin save) so deep synchronous callers (validate_caldav_url, provider factory, EWS, CLI) and per-email/link readers need no pool threading. caldav::private_host_allowlist() now delegates to it, and all CALRS_BASE_URL reads route through settings::base_url().

- migration 057_runtime_settings: base_url + allow_private_hosts on auth_config
- admin handler/route + System settings card; `config general` + dump fields
- docs (security, deployment) and CLAUDE.md updated
- tests: config general set/clear, dump fields, allowlist parsing; migration
  count assertions bumped to 57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **System settings** panel to the admin dashboard for **Base URL** and **private-host allowlist**.
  * Introduced `calrs config general` to view/update/clear these settings from the command line.
  * Runtime configuration is now stored in the database, while environment variables still override at runtime.
  * Updated app links and OAuth/OIDC redirect behavior to use the configured Base URL.
* **Documentation**
  * Expanded deployment and security docs for the new settings, supported formats, and precedence rules.
* **Tests / Chores**
  * Updated migrations tracking and added coverage for the new config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->