### PR TITLE
fix(sources): gate Edit flow to basic-auth sources (#121)

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -5528,8 +5528,8 @@ async fn edit_source_form(
 ) -> impl IntoResponse {
     let user = &auth_user.user;
     // Verify ownership and load current values.
-    let source: Option<(String, String, String)> = sqlx::query_as(
-        "SELECT cs.name, cs.url, cs.username
+    let source: Option<(String, String, String, Option<String>)> = sqlx::query_as(
+        "SELECT cs.name, cs.url, cs.username, cs.auth_type
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE cs.id = ? AND a.user_id = ?",
@@ -5540,10 +5540,16 @@ async fn edit_source_form(
     .await
     .unwrap_or(None);
 
-    let (name, url, username) = match source {
+    let (name, url, username, auth_type) = match source {
         Some(s) => s,
         None => return Redirect::to("/dashboard/sources").into_response(),
     };
+
+    // OAuth2 sources can't be edited via the basic-auth form; the only
+    // useful "edit" is re-running the consent flow.
+    if auth_type.as_deref() == Some("oauth2") {
+        return Redirect::to("/dashboard/sources").into_response();
+    }
 
     render_source_edit_form(&state, &auth_user, &source_id, &name, &url, &username, "")
         .into_response()
@@ -5563,8 +5569,8 @@ async fn update_source(
 
     // Confirm the source belongs to this user and grab the existing
     // password (used as fallback when the form leaves it blank).
-    let existing: Option<(String,)> = sqlx::query_as(
-        "SELECT cs.password_enc
+    let existing: Option<(String, Option<String>)> = sqlx::query_as(
+        "SELECT cs.password_enc, cs.auth_type
          FROM caldav_sources cs
          JOIN accounts a ON a.id = cs.account_id
          WHERE cs.id = ? AND a.user_id = ?",
@@ -5575,10 +5581,16 @@ async fn update_source(
     .await
     .unwrap_or(None);
 
-    let existing_password_enc = match existing {
-        Some((enc,)) => enc,
+    let (existing_password_enc, auth_type) = match existing {
+        Some((enc, at)) => (enc, at),
         None => return Redirect::to("/dashboard/sources").into_response(),
     };
+
+    // OAuth2 sources don't have a password to decrypt and can't be reached
+    // with basic auth — reject the update outright.
+    if auth_type.as_deref() == Some("oauth2") {
+        return Redirect::to("/dashboard/sources").into_response();
+    }
 
     let url = form.url.trim().to_string();
     let username = form.username.trim().to_string();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -14735,23 +14735,54 @@ async fn google_callback(
     };
     let expires_at = chrono::Utc::now() + chrono::Duration::seconds(expires_in);
 
-    // Create the CalDAV source
-    let source_id = uuid::Uuid::new_v4().to_string();
-    let _ = sqlx::query(
-        "INSERT INTO caldav_sources (id, account_id, name, url, username, auth_type, oauth2_provider, access_token_enc, refresh_token_enc, token_expires_at)
-         VALUES (?, ?, 'Google Calendar', ?, ?, 'oauth2', 'google', ?, ?, ?)",
+    // Reconnecting to a Google account that is already linked must refresh the
+    // existing source's tokens, not create a duplicate. A Google CalDAV source
+    // is uniquely identified by (account, google account email) — encoded in the
+    // per-user caldav_url — so match on that before deciding insert vs. update.
+    let existing_source: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM caldav_sources WHERE account_id = ? AND auth_type = 'oauth2' AND oauth2_provider = 'google' AND url = ? LIMIT 1",
     )
-    .bind(&source_id)
     .bind(&account_id)
     .bind(&caldav_url)
-    .bind(&google_email)
-    .bind(&access_token_enc)
-    .bind(&refresh_token_enc)
-    .bind(expires_at.to_rfc3339())
-    .execute(&state.pool)
-    .await;
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None);
 
-    tracing::info!(user = %auth_user.user.email, google_email = %google_email, "Google Calendar source added via OAuth2");
+    let source_id = match existing_source {
+        Some((id,)) => {
+            // Reconnect: refresh the stored tokens on the existing source.
+            let _ = sqlx::query(
+                "UPDATE caldav_sources SET access_token_enc = ?, refresh_token_enc = ?, token_expires_at = ? WHERE id = ?",
+            )
+            .bind(&access_token_enc)
+            .bind(&refresh_token_enc)
+            .bind(expires_at.to_rfc3339())
+            .bind(&id)
+            .execute(&state.pool)
+            .await;
+            tracing::info!(user = %auth_user.user.email, google_email = %google_email, "Google Calendar source reconnected via OAuth2");
+            id
+        }
+        None => {
+            // First-time connect: create the CalDAV source.
+            let source_id = uuid::Uuid::new_v4().to_string();
+            let _ = sqlx::query(
+                "INSERT INTO caldav_sources (id, account_id, name, url, username, auth_type, oauth2_provider, access_token_enc, refresh_token_enc, token_expires_at)
+                 VALUES (?, ?, 'Google Calendar', ?, ?, 'oauth2', 'google', ?, ?, ?)",
+            )
+            .bind(&source_id)
+            .bind(&account_id)
+            .bind(&caldav_url)
+            .bind(&google_email)
+            .bind(&access_token_enc)
+            .bind(&refresh_token_enc)
+            .bind(expires_at.to_rfc3339())
+            .execute(&state.pool)
+            .await;
+            tracing::info!(user = %auth_user.user.email, google_email = %google_email, "Google Calendar source added via OAuth2");
+            source_id
+        }
+    };
 
     // Auto-sync
     let (_, calendar_count) = run_sync_for_source(

--- a/templates/dashboard_sources.html
+++ b/templates/dashboard_sources.html
@@ -28,7 +28,11 @@
           <form method="post" action="/dashboard/sources/{{ s.id }}/test" style="margin: 0;">
             <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">Test</button>
           </form>
+          {% if s.auth_type == "oauth2" %}
+          <a href="/dashboard/sources/google/connect" class="slot-btn" style="font-size: 0.8rem; cursor: pointer; text-decoration: none;" title="Re-run the Google consent flow">Reconnect</a>
+          {% else %}
           <a href="/dashboard/sources/{{ s.id }}/edit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer; text-decoration: none;">Edit</a>
+          {% endif %}
           <button type="button" class="slot-btn" style="font-size: 0.8rem; color: var(--error-text); cursor: pointer;" data-confirm="Remove source '{{ s.name }}'? This will delete all synced events from this source." onclick="if(confirm(this.dataset.confirm)) this.closest('div').querySelector('.remove-form').submit();">Remove</button>
           <form method="post" action="/dashboard/sources/{{ s.id }}/remove" class="remove-form" style="display: none;"></form>
         </div>


### PR DESCRIPTION
Hides the Edit button on OAuth2 calendar sources (replaces it with a Reconnect link to the Google consent flow) and early-returns fromedit_source_form / update_source when auth_type is "oauth2". Without this, clicking Edit on a Google source rendered an empty basic-auth form whose submit crashed in decrypt_password on the empty/NULL password_enc.

Here's what the new Edit flow looks like with this fix: <img width="923" height="364" alt="image" src="https://github.com/user-attachments/assets/c5aeffe7-be4f-47a6-855f-68e8be3bb17d" />

I also tested that the `Reconnect` button flow works as expected: it takes you through authorizing calrs access to your calendar again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2-backed sources now display a "Reconnect" button instead of "Edit" for managing authentication.

* **Bug Fixes**
  * Google CalDAV OAuth2 reconnections now update existing sources instead of creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->