### PR TITLE
resources: per-resource team allowlist + CLI parity

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Event Types](./event-types.md)
 - [Booking Flow](./booking-flow.md)
 - [Teams](./teams.md)
+- [Shared Resources](./resources.md)
 - [Authentication](./authentication.md)
 
 # Administration

--- a/docs/src/admin.md
+++ b/docs/src/admin.md
@@ -53,6 +53,10 @@ For each event type, the dashboard offers a **Troubleshoot** link that opens a v
 - **Client secret** — update the secret (current value is never displayed)
 - **Auto-register** — automatically create users on first OIDC login
 
+## Resources
+
+The **Resources** card manages [shared bookable resources](./resources.md) (demo lab, meeting rooms): add a resource from its ICS feed URL, edit its optional CalDAV write-back settings and team allowlist, force a sync with **Sync now**, and verify write access with **Test write**. A failed feed sync is flagged here with the last error. See [Shared Resources](./resources.md) for details.
+
 ## SMTP status
 
 Shows whether SMTP is configured and the current sender address. SMTP is configured via CLI (`calrs config smtp`) or by editing the database directly.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -64,6 +64,8 @@ calrs event-type slots <SLUG> [OPTIONS]
     --days <DAYS>    Number of days to show (default: 7)
 ```
 
+`slots` consults any [shared resources](./resources.md) attached to the event type: slots where a required resource is busy are not printed, matching the web booking page.
+
 ### `calrs booking`
 
 Manage bookings.
@@ -82,6 +84,8 @@ calrs booking list [OPTIONS]
 
 calrs booking cancel <ID>    Cancel a booking (ID prefix match)
 ```
+
+`cancel` marks the booking cancelled, sends the cancellation emails, deletes the event from the host's CalDAV write-back calendar, and releases any [shared resource](./resources.md) reservation from the resource's CalDAV calendar(s).
 
 ### `calrs config`
 
@@ -110,6 +114,19 @@ calrs config oidc [OPTIONS]
     --enabled <BOOL>          Enable/disable OIDC
     --auto-register <BOOL>    Auto-create users on first login
 ```
+
+### `calrs resource`
+
+Probe resource calendar URLs before adding them as [shared resources](./resources.md).
+
+```
+calrs resource probe [OPTIONS]
+    --url <URL>           Resource calendar URL (ICS publish feed or CalDAV collection)
+    --username <USERNAME> Username for authenticated CalDAV access (password prompted)
+    --write-test          Write test: PUT a temporary event, verify it exists, then delete it
+```
+
+For CalDAV URLs the probe runs the full RFC 4791 discovery fallback. The write test confirms that reservation write-back will work with the given credentials.
 
 ### `calrs user`
 

--- a/docs/src/event-types.md
+++ b/docs/src/event-types.md
@@ -62,6 +62,12 @@ From the dashboard form, select the calendars under the **Calendars** section. O
 
 **Default behavior:** If no calendars are selected, all busy calendars are checked — same as before. This is fully backward-compatible.
 
+## Required resources
+
+Event types can require [shared resources](./resources.md) (a demo lab, a meeting room). A busy resource blocks booking slots, and confirmed bookings can reserve the resource in its own CalDAV calendar.
+
+The **Required resources** section of the event type form is visible to global admins, and to team admins on team event types when their team is allowlisted for a resource. See [Shared Resources](./resources.md) for the full behavior, including the "all" vs "round-robin" scheduling modes.
+
 ## Availability schedule
 
 Each event type has its own availability rules. By default: Monday–Friday, 09:00–17:00.
@@ -119,9 +125,10 @@ Available slots are computed by:
 1. Generating candidate slots from availability rules (day of week + time range)
 2. Filtering out slots that overlap with calendar events (from CalDAV sync)
 3. Filtering out slots that overlap with confirmed bookings
-4. Applying buffer times (before and after each slot)
-5. Removing slots that violate minimum notice (too close to now)
-6. If "one slot per day" is enabled, keeping only the earliest slot per day
+4. Filtering out slots where a required [shared resource](./resources.md) is busy
+5. Applying buffer times (before and after each slot)
+6. Removing slots that violate minimum notice (too close to now)
+7. If "one slot per day" is enabled, keeping only the earliest slot per day
 
 ```bash
 # View available slots for the next 7 days

--- a/docs/src/event-types.md
+++ b/docs/src/event-types.md
@@ -66,6 +66,8 @@ From the dashboard form, select the calendars under the **Calendars** section. O
 
 Event types can require [shared resources](./resources.md) (a demo lab, a meeting room). A busy resource blocks booking slots, and confirmed bookings can reserve the resource in its own CalDAV calendar.
 
+Whether a busy resource blocks a slot depends on the resource scheduling mode: in **all** mode every attached resource must be free, while in **round-robin** mode the slot survives as long as at least one attached resource is free.
+
 The **Required resources** section of the event type form is visible to global admins, and to team admins on team event types when their team is allowlisted for a resource. See [Shared Resources](./resources.md) for the full behavior, including the "all" vs "round-robin" scheduling modes.
 
 ## Availability schedule
@@ -125,7 +127,7 @@ Available slots are computed by:
 1. Generating candidate slots from availability rules (day of week + time range)
 2. Filtering out slots that overlap with calendar events (from CalDAV sync)
 3. Filtering out slots that overlap with confirmed bookings
-4. Filtering out slots where a required [shared resource](./resources.md) is busy
+4. Filtering out slots blocked by required [shared resources](./resources.md) (all mode: any busy resource blocks; round-robin mode: blocked only when every resource is busy)
 5. Applying buffer times (before and after each slot)
 6. Removing slots that violate minimum notice (too close to now)
 7. If "one slot per day" is enabled, keeping only the earliest slot per day

--- a/docs/src/resources.md
+++ b/docs/src/resources.md
@@ -1,0 +1,112 @@
+# Shared Resources
+
+Shared resources are instance-level bookable assets: a demo lab, a meeting room, a shared piece of equipment. Each resource is backed by a read-only ICS publish feed (a BlueMind "calendar address", a Nextcloud public link, or any URL serving an iCalendar file). Once a resource is attached to an event type, a busy resource blocks booking slots the same way a busy calendar does.
+
+The feature is opt-in. With no resources configured, nothing changes anywhere in the booking flow.
+
+## How it fits together
+
+1. A global admin adds a resource in the admin panel, pointing at its ICS feed.
+2. The resource is attached to one or more event types ("Required resources" on the event type form).
+3. When guests view the slot picker, times where the resource is busy are hidden.
+4. When a booking is confirmed, calrs can write a reservation event into the resource's own CalDAV calendar, so other tools (and other calrs event types) see it as busy too.
+5. When the booking is cancelled or rescheduled, the reservation is released.
+
+Even without CalDAV write-back, two event types sharing a resource cannot double-book it: calrs merges the feed events with its own confirmed bookings when computing busy times.
+
+## Adding a resource
+
+Go to **Dashboard > Admin > Resources** and click **Add resource**:
+
+- **Feed URL** (required) is the read-only ICS publish URL. It is validated and synced immediately on create, and the resource name is auto-filled from the feed's `X-WR-CALNAME` if present.
+- **CalDAV URL** (optional) is the writable CalDAV collection for reservation write-back. For BlueMind publish URLs, calrs can derive it automatically, so you can usually leave it blank.
+- **Service account** (optional) is a username and password with write access to the CalDAV collection. The password is encrypted at rest (AES-256-GCM, same as other stored credentials). When editing, leaving the password field empty keeps the current value.
+
+Per-resource actions:
+
+- **Sync now** forces an immediate feed re-sync.
+- **Test write** verifies write-back end to end: it PUTs a temporary event 24 hours out, checks it exists, then deletes it.
+- **Edit** and **Delete** work as expected. Deleting a resource detaches it from all event types.
+
+### Feed sync and failures
+
+Feeds are cached and re-synced automatically when older than 5 minutes, on demand as slots are computed. The feed is authoritative: events that disappear from the feed are removed from the cache.
+
+If a feed fetch fails, the admin panel shows a sync failure indicator with the last error. Failed fetches still update the sync timestamp so dead feeds back off instead of being retried on every request. A successful sync clears the error.
+
+## Attaching resources to event types
+
+The event type form gains a **Required resources** section listing the resources you may attach, plus a scheduling mode selector.
+
+- **Personal event types:** only global admins see and edit the section.
+- **Team event types:** global admins always can. Team admins can too, if their team is on the resource's allowlist (see [Team allowlist](#team-allowlist) below).
+
+## Scheduling modes
+
+When an event type has more than one required resource, the **Resource scheduling** mode controls how they combine:
+
+| Mode | Slot is available when | At booking time |
+|---|---|---|
+| **All** (default) | Every attached resource is free | The booking blocks all attached resources |
+| **Round-robin** | At least one attached resource is free | The least-loaded free resource is picked and assigned to the booking |
+
+Use **all** when a meeting genuinely needs every resource (a room and a projector). Use **round-robin** when any one of several interchangeable resources will do (three identical demo labs). In round-robin mode, the assigned resource is stored on the booking and shown on the host's bookings dashboard and in host-facing emails. Guests never see resource names.
+
+## How busy resources block slots
+
+For each candidate slot, calrs merges, per resource:
+
+- Feed events, including expanded recurring events, skipping cancelled and transparent (free) ones
+- calrs' own confirmed bookings that hold that resource
+
+In **all** mode, the union of busy intervals blocks the slot. In **round-robin** mode, only the intersection blocks it (the slot survives as long as one resource is free). Pending bookings do not block resources; both approval paths re-check resource availability before confirming, so an approval fails cleanly if the resource was taken in the meantime.
+
+The **Troubleshoot** view shows resource conflicts as `resource_busy` intervals, alongside calendar events and bookings.
+
+## Reservation write-back
+
+When a booking is confirmed, calrs PUTs a reservation event into the resource's CalDAV collection under the booking's own UID:
+
+- In **all** mode, into every attached resource.
+- In **round-robin** mode, only into the assigned resource.
+
+When a confirmed booking is cancelled or rescheduled, the reservation is deleted. The targets are derived from the stored assignment, so a resource that was detached from the event type after booking still gets released. Declined pending bookings need no cleanup, since reservations are only pushed on confirmation.
+
+Write failure is never fatal: the booking still succeeds, the DB-side busy check keeps blocking the resource, and the failure is logged.
+
+### Credentials for write-back
+
+calrs tries credentials in trust order:
+
+1. The resource's **service account**, if configured. This is always preferred.
+2. Members who opted in to **credential lending** and have a CalDAV source on the same scheme, host, and port as the resource's CalDAV URL. The booking's assigned host is preferred among them.
+
+Members opt in from **Profile & Settings**. Note that lending grants writes to any collection on that origin that the member's own server-side ACL allows, so a dedicated service account is the safer setup.
+
+## Team allowlist
+
+By default, only global admins can attach resources to event types. To delegate this to team admins, configure the allowlist on each resource:
+
+1. In **Dashboard > Admin > Resources**, edit a resource and set **Teams allowed to use this resource**.
+2. Team admins of an allowlisted team then see the **Required resources** section on their team event type forms, restricted to the resources allowlisted for their team, and can attach or detach them.
+
+Attachment is validated server-side against the allowlist, not just hidden in the UI. An empty allowlist keeps the old behavior (global admins only). Personal event types remain global-admin only regardless of allowlists.
+
+The allowlist controls **attachment only**. Availability evaluation is unchanged: once a resource is attached, it blocks slots for everyone booking that event type.
+
+## CLI
+
+Probe a resource URL before adding it, to check what calrs can do with it:
+
+```bash
+# Probe an ICS publish feed or CalDAV collection
+calrs resource probe --url https://mail.example.com/api/calendars/publish/...
+
+# Authenticated CalDAV probe (password prompted)
+calrs resource probe --url https://mail.example.com/dav/... --username svc-resources
+
+# Also run a write test (PUT a temporary event, verify, delete)
+calrs resource probe --url https://... --username svc-resources --write-test
+```
+
+`calrs event-type slots` consults attached resources, so the printed slots match the web booking page. `calrs booking cancel` releases the booking's resource reservation on cancellation. See the [CLI Reference](./cli-reference.md) for details.

--- a/migrations/060_resource_teams.sql
+++ b/migrations/060_resource_teams.sql
@@ -1,0 +1,8 @@
+-- Per-resource team allowlist: team admins of an allowlisted team may attach
+-- the resource to that team's event types. An empty allowlist keeps the
+-- resource manageable by global admins only (previous behavior).
+CREATE TABLE resource_teams (
+    resource_id TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    PRIMARY KEY (resource_id, team_id)
+);

--- a/src/commands/booking.rs
+++ b/src/commands/booking.rs
@@ -400,6 +400,24 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                         .await?;
                     println!("{} Booking {} cancelled.", "✓".green(), &full_id[..8]);
 
+                    // Remote cleanup, same order as the web cancel paths:
+                    // host calendar first, then resource reservations.
+                    // Failures are non-fatal, the cancelled-uid exclusions
+                    // keep availability correct either way.
+                    let host_user_id: Option<Option<String>> = sqlx::query_scalar(
+                        "SELECT a.user_id FROM accounts a
+                         JOIN event_types et ON et.account_id = a.id
+                         JOIN bookings b ON b.event_type_id = et.id
+                         WHERE b.id = ?",
+                    )
+                    .bind(&full_id)
+                    .fetch_optional(pool)
+                    .await?;
+                    if let Some(Some(user_id)) = &host_user_id {
+                        crate::web::caldav_delete_booking(pool, key, user_id, &uid).await;
+                    }
+                    crate::web::resource_delete_booking(pool, key, &uid).await;
+
                     // Send cancellation emails
                     if let Some(smtp_config) = crate::email::load_smtp_config(pool, key).await? {
                         let host: Option<(String, String, Option<String>)> = sqlx::query_as(

--- a/src/commands/booking.rs
+++ b/src/commands/booking.rs
@@ -401,10 +401,12 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                     println!("{} Booking {} cancelled.", "✓".green(), &full_id[..8]);
 
                     // Remote cleanup, same order as the web cancel paths:
-                    // host calendar first, then resource reservations.
-                    // Failures are non-fatal, the cancelled-uid exclusions
+                    // host calendar first, then resource reservations. All
+                    // best-effort: the booking is already cancelled, so a
+                    // failed lookup or delete must not abort the remaining
+                    // cleanup or the emails; the cancelled-uid exclusions
                     // keep availability correct either way.
-                    let host_user_id: Option<Option<String>> = sqlx::query_scalar(
+                    let host_user_id: Option<String> = sqlx::query_scalar(
                         "SELECT a.user_id FROM accounts a
                          JOIN event_types et ON et.account_id = a.id
                          JOIN bookings b ON b.event_type_id = et.id
@@ -412,8 +414,13 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: BookingCommands) -> Res
                     )
                     .bind(&full_id)
                     .fetch_optional(pool)
-                    .await?;
-                    if let Some(Some(user_id)) = &host_user_id {
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(booking_id = %full_id, error = %e, "host lookup failed, skipping host calendar cleanup");
+                        None
+                    })
+                    .flatten();
+                    if let Some(user_id) = &host_user_id {
                         crate::web::caldav_delete_booking(pool, key, user_id, &uid).await;
                     }
                     crate::web::resource_delete_booking(pool, key, &uid).await;

--- a/src/commands/event_type.rs
+++ b/src/commands/event_type.rs
@@ -305,6 +305,24 @@ pub async fn run(pool: &SqlitePool, cmd: EventTypeCommands) -> Result<()> {
                 }
             }
 
+            // Required shared resources: same blocking intervals as the web
+            // slot pages (syncs stale feeds, merges per the scheduling mode).
+            let resource_busy = crate::resources::blocking_intervals_for_event_type(
+                pool,
+                &et_id,
+                now,
+                window_end_dt,
+                host_tz,
+                None,
+            )
+            .await;
+            for (s, e) in resource_busy {
+                busy_events.push((
+                    s.format("%Y-%m-%dT%H:%M:%S").to_string(),
+                    e.format("%Y-%m-%dT%H:%M:%S").to_string(),
+                ));
+            }
+
             println!("Available slots for {} ({}min):\n", slug.bold(), duration);
 
             let slot_duration = Duration::minutes(duration as i64);

--- a/src/db.rs
+++ b/src/db.rs
@@ -252,6 +252,10 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "059_resource_sync_error",
             include_str!("../migrations/059_resource_sync_error.sql"),
         ),
+        (
+            "060_resource_teams",
+            include_str!("../migrations/060_resource_teams.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;
@@ -859,7 +863,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 59, "All 59 migrations should be tracked");
+        assert_eq!(count.0, 60, "All 60 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -873,7 +877,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 59, "Still 59 migrations after second run");
+        assert_eq!(count.0, 60, "Still 60 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4529,25 +4529,67 @@ struct EventTypeForm {
 
 /// Template context for the "Required resources" section of the event type
 /// form: (all resources, comma-joined selected ids, scheduling mode).
+/// Resources the user may attach to an event type belonging to `team_id`.
+/// Global admins: every resource. Team admins of `team_id`: that team's
+/// allowlist (`resource_teams`). Anyone else, including personal event
+/// types, gets none: attachment stays global-admin only there (a plain
+/// user could otherwise read a resource's schedule through public slot
+/// availability, or spam reservations into its calendar).
+async fn attachable_resources(
+    pool: &SqlitePool,
+    user_id: &str,
+    is_admin: bool,
+    team_id: Option<&str>,
+) -> Vec<(String, String)> {
+    if is_admin {
+        return sqlx::query_as("SELECT id, name FROM resources ORDER BY name")
+            .fetch_all(pool)
+            .await
+            .unwrap_or_default();
+    }
+    let Some(team_id) = team_id else {
+        return Vec::new();
+    };
+    sqlx::query_as(
+        "SELECT r.id, r.name FROM resources r
+         JOIN resource_teams rt ON rt.resource_id = r.id
+         JOIN team_members tm ON tm.team_id = rt.team_id
+         WHERE rt.team_id = ? AND tm.user_id = ? AND tm.role = 'admin'
+         ORDER BY r.name",
+    )
+    .bind(team_id)
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+}
+
+/// Union of the allowlists of every team the user administers, for create
+/// forms where the team is picked in the form itself. The save path
+/// re-validates against the team actually submitted.
+async fn attachable_resources_any_team(pool: &SqlitePool, user_id: &str) -> Vec<(String, String)> {
+    sqlx::query_as(
+        "SELECT DISTINCT r.id, r.name FROM resources r
+         JOIN resource_teams rt ON rt.resource_id = r.id
+         JOIN team_members tm ON tm.team_id = rt.team_id
+         WHERE tm.user_id = ? AND tm.role = 'admin'
+         ORDER BY r.name",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+}
+
 async fn resources_form_ctx(
     pool: &SqlitePool,
     et_id: Option<&str>,
-    is_admin: bool,
+    available: &[(String, String)],
 ) -> (Vec<minijinja::Value>, String, String) {
-    // Resources are instance-global; only admins may attach them (a plain
-    // user could otherwise read a resource's schedule through public slot
-    // availability, or spam reservations into its calendar). Non-admins
-    // get an empty list, which hides the form section entirely, and their
-    // saves are skipped so existing attachments survive edits untouched.
-    let all: Vec<(String, String)> = if is_admin {
-        sqlx::query_as("SELECT id, name FROM resources ORDER BY name")
-            .fetch_all(pool)
-            .await
-            .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-    let resources_all: Vec<minijinja::Value> = all
+    // An empty `available` hides the form section entirely, and the
+    // matching save is skipped so existing attachments survive edits
+    // untouched.
+    let resources_all: Vec<minijinja::Value> = available
         .iter()
         .map(|(id, name)| context! { id => id, name => name })
         .collect();
@@ -4614,6 +4656,51 @@ async fn save_event_type_resources(
         .bind(et_id)
         .execute(pool)
         .await;
+}
+
+/// Authorization wrapper around [`save_event_type_resources`]. Global
+/// admins save as-is. Team admins are restricted to `team_id`'s allowlist:
+/// submitted ids outside it are dropped, and existing attachments outside
+/// it are preserved (the form never showed them, so a team admin's save
+/// must not detach what a global admin attached). Users with no allowlist
+/// skip the save entirely, scheduling mode included.
+async fn save_event_type_resources_authorized(
+    pool: &SqlitePool,
+    et_id: &str,
+    user_id: &str,
+    is_admin: bool,
+    team_id: Option<&str>,
+    resource_ids: &Option<String>,
+    mode: &Option<String>,
+) {
+    if is_admin {
+        save_event_type_resources(pool, et_id, resource_ids, mode).await;
+        return;
+    }
+    let allowed = attachable_resources(pool, user_id, false, team_id).await;
+    if allowed.is_empty() {
+        return;
+    }
+    let allowed_ids: std::collections::HashSet<&str> =
+        allowed.iter().map(|(id, _)| id.as_str()).collect();
+    let existing: Vec<(String,)> =
+        sqlx::query_as("SELECT resource_id FROM event_type_resources WHERE event_type_id = ?")
+            .bind(et_id)
+            .fetch_all(pool)
+            .await
+            .unwrap_or_default();
+    let kept = existing
+        .iter()
+        .map(|(id,)| id.as_str())
+        .filter(|id| !allowed_ids.contains(*id));
+    let submitted = resource_ids
+        .as_deref()
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && allowed_ids.contains(*s));
+    let merged = kept.chain(submitted).collect::<Vec<_>>().join(",");
+    save_event_type_resources(pool, et_id, &Some(merged), mode).await;
 }
 
 async fn new_event_type_form(
@@ -4699,8 +4786,13 @@ async fn new_event_type_form(
         Err(e) => return internal_error_html("template render", &e),
     };
 
+    let attachable = if user.role == "admin" {
+        attachable_resources(&state.pool, &user.id, true, None).await
+    } else {
+        attachable_resources_any_team(&state.pool, &user.id).await
+    };
     let (resources_all, selected_resource_ids, resource_scheduling_mode) =
-        resources_form_ctx(&state.pool, None, auth_user.user.role == "admin").await;
+        resources_form_ctx(&state.pool, None, &attachable).await;
     let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
     Html(
         tmpl.render(context! {
@@ -5029,15 +5121,16 @@ async fn create_event_type(
     // Save booking frequency limits
     save_frequency_limits(&state.pool, &et_id, &form.frequency_limits).await;
 
-    if auth_user.user.role == "admin" {
-        save_event_type_resources(
-            &state.pool,
-            &et_id,
-            &form.resource_ids,
-            &form.resource_scheduling_mode,
-        )
-        .await;
-    }
+    save_event_type_resources_authorized(
+        &state.pool,
+        &et_id,
+        &auth_user.user.id,
+        auth_user.user.role == "admin",
+        team_id,
+        &form.resource_ids,
+        &form.resource_scheduling_mode,
+    )
+    .await;
 
     Redirect::to("/dashboard/event-types").into_response()
 }
@@ -5318,8 +5411,17 @@ async fn edit_event_type_form(
         })
         .collect();
 
+    // Personal event types (this handler is scoped team_id IS NULL) stay
+    // global-admin only for resource attachment.
+    let attachable = attachable_resources(
+        &state.pool,
+        &auth_user.user.id,
+        auth_user.user.role == "admin",
+        None,
+    )
+    .await;
     let (resources_all, selected_resource_ids2, resource_scheduling_mode) =
-        resources_form_ctx(&state.pool, Some(&et_id), auth_user.user.role == "admin").await;
+        resources_form_ctx(&state.pool, Some(&et_id), &attachable).await;
     Html(
         tmpl.render(context! {
             editing => true,
@@ -5577,15 +5679,16 @@ async fn update_event_type(
         .await;
     save_frequency_limits(&state.pool, &et_id, &form.frequency_limits).await;
 
-    if auth_user.user.role == "admin" {
-        save_event_type_resources(
-            &state.pool,
-            &et_id,
-            &form.resource_ids,
-            &form.resource_scheduling_mode,
-        )
-        .await;
-    }
+    save_event_type_resources_authorized(
+        &state.pool,
+        &et_id,
+        &auth_user.user.id,
+        auth_user.user.role == "admin",
+        None,
+        &form.resource_ids,
+        &form.resource_scheduling_mode,
+    )
+    .await;
 
     Redirect::to("/dashboard/event-types").into_response()
 }
@@ -6894,17 +6997,15 @@ async fn render_event_type_form_error(
     // Echo the submitted resource selection back. Omitting resources_all
     // would hide the section entirely and a resubmit after a validation
     // error would then silently detach every resource.
-    let resources_all: Vec<minijinja::Value> = if auth_user.user.role == "admin" {
-        sqlx::query_as::<_, (String, String)>("SELECT id, name FROM resources ORDER BY name")
-            .fetch_all(&state.pool)
-            .await
-            .unwrap_or_default()
-            .iter()
-            .map(|(id, name)| context! { id => id, name => name })
-            .collect()
+    let attachable = if auth_user.user.role == "admin" {
+        attachable_resources(&state.pool, &auth_user.user.id, true, None).await
     } else {
-        Vec::new()
+        attachable_resources_any_team(&state.pool, &auth_user.user.id).await
     };
+    let resources_all: Vec<minijinja::Value> = attachable
+        .iter()
+        .map(|(id, name)| context! { id => id, name => name })
+        .collect();
 
     let (impersonating, impersonating_name, _) = impersonation_ctx(auth_user);
     Html(
@@ -7895,8 +7996,13 @@ async fn new_group_event_type_form(
     };
 
     let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
+    let attachable = if auth_user.user.role == "admin" {
+        attachable_resources(&state.pool, &auth_user.user.id, true, None).await
+    } else {
+        attachable_resources_any_team(&state.pool, &auth_user.user.id).await
+    };
     let (resources_all, selected_resource_ids, resource_scheduling_mode) =
-        resources_form_ctx(&state.pool, None, auth_user.user.role == "admin").await;
+        resources_form_ctx(&state.pool, None, &attachable).await;
     Html(
         tmpl.render(context! {
             editing => false,
@@ -8133,15 +8239,16 @@ async fn create_group_event_type(
     // Save booking frequency limits
     save_frequency_limits(&state.pool, &et_id, &form.frequency_limits).await;
 
-    if auth_user.user.role == "admin" {
-        save_event_type_resources(
-            &state.pool,
-            &et_id,
-            &form.resource_ids,
-            &form.resource_scheduling_mode,
-        )
-        .await;
-    }
+    save_event_type_resources_authorized(
+        &state.pool,
+        &et_id,
+        &auth_user.user.id,
+        auth_user.user.role == "admin",
+        Some(&team_id),
+        &form.resource_ids,
+        &form.resource_scheduling_mode,
+    )
+    .await;
 
     Redirect::to("/dashboard/event-types").into_response()
 }
@@ -8425,8 +8532,15 @@ async fn edit_group_event_type_form(
         Err(e) => return internal_error_html("template render", &e),
     };
 
+    let attachable = attachable_resources(
+        &state.pool,
+        &auth_user.user.id,
+        auth_user.user.role == "admin",
+        Some(&team_id),
+    )
+    .await;
     let (resources_all, selected_resource_ids, resource_scheduling_mode) =
-        resources_form_ctx(&state.pool, Some(&et_id), auth_user.user.role == "admin").await;
+        resources_form_ctx(&state.pool, Some(&et_id), &attachable).await;
     let (impersonating, impersonating_name, _) = impersonation_ctx(&auth_user);
     Html(
         tmpl.render(context! {
@@ -8697,15 +8811,16 @@ async fn update_group_event_type(
         .await;
     save_frequency_limits(&state.pool, &et_id, &form.frequency_limits).await;
 
-    if auth_user.user.role == "admin" {
-        save_event_type_resources(
-            &state.pool,
-            &et_id,
-            &form.resource_ids,
-            &form.resource_scheduling_mode,
-        )
-        .await;
-    }
+    save_event_type_resources_authorized(
+        &state.pool,
+        &et_id,
+        &auth_user.user.id,
+        auth_user.user.role == "admin",
+        Some(&team_id),
+        &form.resource_ids,
+        &form.resource_scheduling_mode,
+    )
+    .await;
 
     Redirect::to("/dashboard/event-types").into_response()
 }
@@ -14468,6 +14583,16 @@ async fn admin_dashboard(
     .fetch_all(&state.pool)
     .await
     .unwrap_or_default();
+    // All teams, for the per-resource "Teams allowed" checkboxes.
+    let resource_teams_all: Vec<(String, String)> =
+        sqlx::query_as("SELECT id, name FROM teams ORDER BY name")
+            .fetch_all(&state.pool)
+            .await
+            .unwrap_or_default();
+    let resource_teams_ctx: Vec<minijinja::Value> = resource_teams_all
+        .iter()
+        .map(|(id, name)| context! { id => id, name => name })
+        .collect();
     let mut resources_ctx: Vec<minijinja::Value> = Vec::new();
     for (
         rid,
@@ -14480,6 +14605,25 @@ async fn admin_dashboard(
         last_sync_error,
     ) in &resource_rows
     {
+        let allowed_teams: Vec<(String, String)> = sqlx::query_as(
+            "SELECT t.id, t.name FROM teams t
+             JOIN resource_teams rt ON rt.team_id = t.id
+             WHERE rt.resource_id = ? ORDER BY t.name",
+        )
+        .bind(rid)
+        .fetch_all(&state.pool)
+        .await
+        .unwrap_or_default();
+        let allowed_team_ids = allowed_teams
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        let allowed_team_names = allowed_teams
+            .iter()
+            .map(|(_, name)| name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
         let event_count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM resource_events WHERE resource_id = ?")
                 .bind(rid)
@@ -14532,6 +14676,8 @@ async fn admin_dashboard(
             last_sync_error => last_sync_error.clone().unwrap_or_default(),
             event_count => event_count,
             attached_count => attached_count,
+            allowed_team_ids => allowed_team_ids,
+            allowed_team_names => allowed_team_names,
         });
     }
 
@@ -14840,6 +14986,7 @@ async fn admin_dashboard(
             impersonating_name => "",
             error_message => error_message,
             resources => resources_ctx,
+            resource_teams_all => resource_teams_ctx,
             resource_notice => resource_notice,
             resource_error => resource_error,
         })
@@ -14855,6 +15002,31 @@ struct AdminResourceForm {
     caldav_url: Option<String>,
     caldav_username: Option<String>,
     caldav_password: Option<String>,
+    /// Comma-joined team ids allowed to use this resource (hidden field
+    /// kept in sync with the checkboxes, same pattern as `resource_ids`
+    /// on the event type form).
+    team_ids: Option<String>,
+}
+
+/// Persist a resource's team allowlist (delete-then-insert). Unknown team
+/// ids are dropped by inserting through a SELECT on `teams`.
+async fn save_resource_teams(pool: &SqlitePool, resource_id: &str, team_ids: &Option<String>) {
+    let _ = sqlx::query("DELETE FROM resource_teams WHERE resource_id = ?")
+        .bind(resource_id)
+        .execute(pool)
+        .await;
+    if let Some(ids) = team_ids {
+        for tid in ids.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let _ = sqlx::query(
+                "INSERT OR IGNORE INTO resource_teams (resource_id, team_id)
+                 SELECT ?, id FROM teams WHERE id = ?",
+            )
+            .bind(resource_id)
+            .bind(tid)
+            .execute(pool)
+            .await;
+        }
+    }
 }
 
 fn admin_resources_redirect(notice: &str) -> Response {
@@ -14943,6 +15115,7 @@ async fn admin_create_resource(
     .bind(&caldav_password_enc)
     .execute(&state.pool)
     .await;
+    save_resource_teams(&state.pool, &id, &form.team_ids).await;
 
     let cached = crate::resources::sync_resource(&state.pool, &id, &feed_url)
         .await
@@ -15028,6 +15201,7 @@ async fn admin_update_resource(
                 .await;
         }
     }
+    save_resource_teams(&state.pool, &resource_id, &form.team_ids).await;
     let cached = crate::resources::sync_resource(&state.pool, &resource_id, &feed_url)
         .await
         .unwrap_or(0);
@@ -18566,7 +18740,7 @@ async fn caldav_delete_for_user(
 }
 
 /// Delete a booking from the host's CalDAV calendar.
-async fn caldav_delete_booking(
+pub(crate) async fn caldav_delete_booking(
     pool: &SqlitePool,
     key: &[u8; 32],
     user_id: &str,
@@ -18996,7 +19170,7 @@ async fn release_reservation_target(
         .await;
 }
 
-async fn resource_delete_booking(pool: &SqlitePool, key: &[u8; 32], booking_uid: &str) {
+pub(crate) async fn resource_delete_booking(pool: &SqlitePool, key: &[u8; 32], booking_uid: &str) {
     let targets = booking_resources_to_reserve(pool, booking_uid, true).await;
     for (resource_id, caldav_url, service_user, service_pw) in &targets {
         release_reservation_target(
@@ -21628,6 +21802,195 @@ mod tests {
             },
             "round_robin must pick the free resource"
         );
+    }
+
+    // --- Per-resource team allowlist (#153) ---
+
+    async fn seed_team_with_admin(pool: &SqlitePool, slug: &str, admin_user_id: &str) -> String {
+        let team_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO teams (id, name, slug, visibility) VALUES (?, ?, ?, 'public')")
+            .bind(&team_id)
+            .bind(slug)
+            .bind(slug)
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO team_members (team_id, user_id, role, source) VALUES (?, ?, 'admin', 'direct')",
+        )
+        .bind(&team_id)
+        .bind(admin_user_id)
+        .execute(pool)
+        .await
+        .unwrap();
+        team_id
+    }
+
+    async fn allow_resource_for_team(pool: &SqlitePool, resource_id: &str, team_id: &str) {
+        sqlx::query("INSERT INTO resource_teams (resource_id, team_id) VALUES (?, ?)")
+            .bind(resource_id)
+            .bind(team_id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn attachable_resources_respects_allowlist_and_roles() {
+        let pool = setup_test_db().await;
+        let admin = insert_role_user(&pool, "admin@allow.test", "admin").await;
+        let team_admin = insert_role_user(&pool, "ta@allow.test", "user").await;
+        let member = insert_role_user(&pool, "member@allow.test", "user").await;
+        let team_id = seed_team_with_admin(&pool, "allow-sales", &team_admin).await;
+        sqlx::query(
+            "INSERT INTO team_members (team_id, user_id, role, source) VALUES (?, ?, 'member', 'direct')",
+        )
+        .bind(&team_id)
+        .bind(&member)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let allowed = insert_resource(&pool, "Lab A").await;
+        let _other = insert_resource(&pool, "Lab B").await;
+        allow_resource_for_team(&pool, &allowed, &team_id).await;
+
+        let all = attachable_resources(&pool, &admin, true, None).await;
+        assert_eq!(all.len(), 2, "global admin sees every resource");
+
+        let ta = attachable_resources(&pool, &team_admin, false, Some(&team_id)).await;
+        assert_eq!(
+            ta.iter().map(|(id, _)| id.as_str()).collect::<Vec<_>>(),
+            vec![allowed.as_str()],
+            "team admin sees only the team's allowlist"
+        );
+
+        assert!(
+            attachable_resources(&pool, &member, false, Some(&team_id))
+                .await
+                .is_empty(),
+            "plain team member may not attach even allowlisted resources"
+        );
+        assert!(
+            attachable_resources(&pool, &team_admin, false, None)
+                .await
+                .is_empty(),
+            "personal event types stay global-admin only"
+        );
+
+        let any = attachable_resources_any_team(&pool, &team_admin).await;
+        assert_eq!(any.len(), 1, "union helper covers the create forms");
+        assert!(attachable_resources_any_team(&pool, &member)
+            .await
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn save_resources_authorized_filters_and_preserves() {
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+        let team_admin = insert_role_user(&pool, "ta2@allow.test", "user").await;
+        let team_id = seed_team_with_admin(&pool, "allow-support", &team_admin).await;
+        let allowed = insert_resource(&pool, "Allowed Lab").await;
+        let preexisting = insert_resource(&pool, "Admin-only Lab").await;
+        let smuggled = insert_resource(&pool, "Smuggled Lab").await;
+        allow_resource_for_team(&pool, &allowed, &team_id).await;
+        // A global admin attached a non-allowlisted resource earlier.
+        attach_resource(&pool, &et_id, &preexisting).await;
+
+        // Team admin submits an allowlisted id plus a smuggled one.
+        save_event_type_resources_authorized(
+            &pool,
+            &et_id,
+            &team_admin,
+            false,
+            Some(&team_id),
+            &Some(format!("{},{}", allowed, smuggled)),
+            &Some("round_robin".to_string()),
+        )
+        .await;
+
+        let mut attached: Vec<String> = sqlx::query_as::<_, (String,)>(
+            "SELECT resource_id FROM event_type_resources WHERE event_type_id = ?",
+        )
+        .bind(&et_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(id,)| id)
+        .collect();
+        attached.sort();
+        let mut expected = vec![allowed.clone(), preexisting.clone()];
+        expected.sort();
+        assert_eq!(
+            attached, expected,
+            "smuggled id dropped, invisible attachment preserved"
+        );
+        let mode: String =
+            sqlx::query_scalar("SELECT resource_scheduling_mode FROM event_types WHERE id = ?")
+                .bind(&et_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(mode, "round_robin");
+
+        // Deselecting everything detaches the allowlisted resource but
+        // still preserves the one outside the allowlist.
+        save_event_type_resources_authorized(
+            &pool,
+            &et_id,
+            &team_admin,
+            false,
+            Some(&team_id),
+            &Some(String::new()),
+            &Some("all".to_string()),
+        )
+        .await;
+        let attached: Vec<(String,)> =
+            sqlx::query_as("SELECT resource_id FROM event_type_resources WHERE event_type_id = ?")
+                .bind(&et_id)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(attached, vec![(preexisting.clone(),)]);
+    }
+
+    #[tokio::test]
+    async fn save_resources_authorized_noop_without_allowlist() {
+        let pool = setup_test_db().await;
+        let (_, _, et_id) = seed_test_data(&pool).await;
+        let team_admin = insert_role_user(&pool, "ta3@allow.test", "user").await;
+        let team_id = seed_team_with_admin(&pool, "allow-empty", &team_admin).await;
+        let resource = insert_resource(&pool, "Locked Lab").await;
+        attach_resource(&pool, &et_id, &resource).await;
+
+        // No allowlist for the team: the save is skipped entirely, mode
+        // included, exactly like before the allowlist existed.
+        save_event_type_resources_authorized(
+            &pool,
+            &et_id,
+            &team_admin,
+            false,
+            Some(&team_id),
+            &Some(String::new()),
+            &Some("round_robin".to_string()),
+        )
+        .await;
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM event_type_resources WHERE event_type_id = ?")
+                .bind(&et_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 1, "attachments untouched");
+        let mode: String =
+            sqlx::query_scalar("SELECT resource_scheduling_mode FROM event_types WHERE id = ?")
+                .bind(&et_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(mode, "all", "mode untouched");
     }
 
     #[tokio::test]

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -437,6 +437,9 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
       <div style="font-size: 0.825rem; margin-top: 0.25rem;">
         {% if r.write_configured %}<span style="color: var(--success);">Write-back: enabled ({{ r.write_via }})</span>{% else %}<span style="color: var(--text-muted);">Write-back: read-only</span>{% endif %}
       </div>
+      <div style="font-size: 0.825rem; margin-top: 0.25rem; color: var(--text-secondary);">
+        Teams allowed: {% if r.allowed_team_names %}{{ r.allowed_team_names }}{% else %}<span style="color: var(--text-muted);">none (global admins only)</span>{% endif %}
+      </div>
       <div style="margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.375rem;">
         <form method="post" action="/dashboard/admin/resources/{{ r.id }}/sync" style="margin: 0;">
           <button type="submit" class="slot-btn" style="font-size: 0.8rem; cursor: pointer;">Sync now</button>
@@ -474,6 +477,24 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
             <label>CalDAV password</label>
             <input type="password" name="caldav_password" value="" placeholder="Leave empty to keep unchanged">
           </div>
+          <div class="form-group">
+            <label>Teams allowed to use this resource</label>
+            {% if resource_teams_all %}
+            {% set allowed_padded = "," ~ r.allowed_team_ids ~ "," %}
+            <div style="display: flex; flex-wrap: wrap; gap: 0.5rem 1rem;">
+              {% for t in resource_teams_all %}
+              <label style="display: flex; align-items: center; gap: 0.375rem; font-weight: 400; font-size: 0.875rem;">
+                <input type="checkbox" class="res-team-check" value="{{ t.id }}" {% if ("," ~ t.id ~ ",") in allowed_padded %}checked{% endif %}>
+                {{ t.name }}
+              </label>
+              {% endfor %}
+            </div>
+            <span style="font-size: 0.8rem; color: var(--text-muted);">Team admins of these teams can attach this resource to their team event types. Empty: global admins only.</span>
+            {% else %}
+            <span style="font-size: 0.8rem; color: var(--text-muted);">No teams yet.</span>
+            {% endif %}
+            <input type="hidden" name="team_ids" value="{{ r.allowed_team_ids }}">
+          </div>
           <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save resource</button>
         </form>
       </details>
@@ -507,8 +528,37 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
       <label>CalDAV password</label>
       <input type="password" name="caldav_password" value="">
     </div>
+    <div class="form-group">
+      <label>Teams allowed to use this resource</label>
+      {% if resource_teams_all %}
+      <div style="display: flex; flex-wrap: wrap; gap: 0.5rem 1rem;">
+        {% for t in resource_teams_all %}
+        <label style="display: flex; align-items: center; gap: 0.375rem; font-weight: 400; font-size: 0.875rem;">
+          <input type="checkbox" class="res-team-check" value="{{ t.id }}">
+          {{ t.name }}
+        </label>
+        {% endfor %}
+      </div>
+      <span style="font-size: 0.8rem; color: var(--text-muted);">Team admins of these teams can attach this resource to their team event types. Empty: global admins only.</span>
+      {% else %}
+      <span style="font-size: 0.8rem; color: var(--text-muted);">No teams yet.</span>
+      {% endif %}
+      <input type="hidden" name="team_ids" value="">
+    </div>
     <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Add resource</button>
   </form>
+  <script>
+    document.querySelectorAll('.res-team-check').forEach(function (cb) {
+      cb.addEventListener('change', function () {
+        var form = cb.closest('form');
+        var ids = Array.prototype.filter.call(
+          form.querySelectorAll('.res-team-check'),
+          function (c) { return c.checked; }
+        ).map(function (c) { return c.value; }).join(',');
+        form.querySelector('input[name="team_ids"]').value = ids;
+      });
+    });
+  </script>
 </div>
 
 <!-- Jitsi auto-generated meeting links -->


### PR DESCRIPTION
Closes #153, closes #150. Follow-ups to #149.

## Per-resource team allowlist (#153)

- New `resource_teams` junction (migration 060, registered in `db.rs`).
- Admin panel resource card gains a "Teams allowed to use this resource" checkbox list (edit + add forms), with the allowlisted team names shown on the resource summary.
- Team admins of an allowlisted team now see the "Required resources" section on their team event type forms, restricted to their team's allowlist. Create forms (where the team is picked in the form) show the union of the allowlists of the teams the user administers; the save path re-validates against the team actually submitted.
- `save_event_type_resources_authorized` enforces the allowlist server-side: submitted ids outside it are dropped, and existing attachments outside it are preserved so a team admin's save cannot detach a resource a global admin attached. Users with no allowlist skip the save entirely (mode included), which keeps today's behavior for an empty allowlist.
- Availability evaluation is untouched: authorization applies to attachment only. Personal event types stay global-admin only.

## CLI parity (#150)

- `calrs event-type slots` merges `resources::blocking_intervals_for_event_type()` into its busy set, so it no longer prints times the web booking page would refuse.
- `calrs booking cancel` now mirrors the web cancel sequence after the status update: host-calendar CalDAV delete, then resource reservation release. The web helpers (`caldav_delete_booking`, `resource_delete_booking`) had no AppState coupling and are simply `pub(crate)` now. Failures stay non-fatal; the cancelled-uid exclusions keep availability correct either way.

## Docs

New `docs/src/resources.md` (feeds, modes, write-back, credential lending, team allowlist) plus CLI reference updates; registered in SUMMARY, cross-linked from event-types and admin pages. `mdbook build docs` passes.

## Tests

- `attachable_resources_respects_allowlist_and_roles`
- `save_resources_authorized_filters_and_preserves` (smuggled id dropped, invisible attachment preserved, deselect keeps preserved rows)
- `save_resources_authorized_noop_without_allowlist`
- Migration-count assertions bumped to 60.

`cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`: 790 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added team allowlists for shared bookable resources, with admin UI support and enforced attachment permissions for event types.
  - Introduced “required resources” behavior: required resources can block slot availability, with All vs round-robin scheduling modes.
  - Improved booking cancellation with best-effort remote cleanup of booking and related resource reservations before sending emails.
- **Documentation**
  - Expanded Shared Resources documentation, including admin actions (sync/test write), slot-computation rules, and CLI command details (slot filtering, resource probing, and cancellation side effects).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->