### PR TITLE
fix(caldav): SCHEDULE-AGENT=CLIENT on write-back attendees

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -432,6 +432,24 @@ fn first_name(full_name: &str) -> &str {
 }
 
 pub fn generate_ics(details: &BookingDetails, method: &str) -> String {
+    generate_ics_impl(details, method, false)
+}
+
+/// ICS for CalDAV write-back (RFC 4791: no METHOD). ATTENDEE lines carry
+/// SCHEDULE-AGENT=CLIENT (RFC 6638 §7.1) so the CalDAV server does not
+/// run its own scheduling: calrs already sends the invitations over SMTP,
+/// and servers like Fastmail would otherwise send a duplicate iMIP invite
+/// (in UTC) for every written booking. Email .ics attachments keep plain
+/// ATTENDEE;RSVP=TRUE so mail clients still offer "Add to calendar".
+pub fn generate_ics_caldav(details: &BookingDetails) -> String {
+    generate_ics_impl(details, "", true)
+}
+
+fn generate_ics_impl(
+    details: &BookingDetails,
+    method: &str,
+    schedule_agent_client: bool,
+) -> String {
     let guest_first = first_name(&details.guest_name);
     let host_first = first_name(&details.host_name);
     let summary = sanitize_ics(&format!(
@@ -466,10 +484,15 @@ pub fn generate_ics(details: &BookingDetails, method: &str) -> String {
             )
         })
         .unwrap_or_default();
+    let sa = if schedule_agent_client {
+        ";SCHEDULE-AGENT=CLIENT"
+    } else {
+        ""
+    };
     let additional_attendee_lines: String = details
         .additional_attendees
         .iter()
-        .map(|email| format!("ATTENDEE;RSVP=TRUE:mailto:{}\r\n", sanitize_ics(email)))
+        .map(|email| format!("ATTENDEE{sa};RSVP=TRUE:mailto:{}\r\n", sanitize_ics(email)))
         .collect();
     let dtstamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
     // Convert guest-timezone times to UTC for the ICS
@@ -493,7 +516,7 @@ pub fn generate_ics(details: &BookingDetails, method: &str) -> String {
          {description_line}\
          {location_line}\
          ORGANIZER;CN={host_name}:mailto:{host_email}\r\n\
-         ATTENDEE;CN={guest_name};RSVP=TRUE:mailto:{guest_email}\r\n\
+         ATTENDEE{sa};CN={guest_name};RSVP=TRUE:mailto:{guest_email}\r\n\
          {additional_attendee_lines}\
          STATUS:CONFIRMED\r\n\
          {valarm}\
@@ -2930,6 +2953,45 @@ mod tests {
         assert!(ics.contains("ORGANIZER;CN=Alice:mailto:alice@cal.rs"));
         assert!(ics.contains("ATTENDEE;CN=Jane Doe;RSVP=TRUE:mailto:jane@example.com"));
         assert!(ics.contains("STATUS:CONFIRMED"));
+    }
+
+    // Regression test for #141: the CalDAV write-back variant must mark
+    // every ATTENDEE with SCHEDULE-AGENT=CLIENT (RFC 6638 §7.1) so servers
+    // like Fastmail do not send their own duplicate iMIP invite, while the
+    // email variant keeps plain ATTENDEE lines for "Add to calendar".
+    #[test]
+    fn generate_ics_caldav_marks_attendees_schedule_agent_client() {
+        let details = BookingDetails {
+            event_title: "Intro Call".to_string(),
+            date: "2026-03-10".to_string(),
+            start_time: "14:00".to_string(),
+            end_time: "14:30".to_string(),
+            guest_name: "Jane Doe".to_string(),
+            guest_email: "jane@example.com".to_string(),
+            guest_timezone: "Europe/Paris".to_string(),
+            host_name: "Alice".to_string(),
+            host_email: "alice@cal.rs".to_string(),
+            uid: "test-uid-141".to_string(),
+            notes: None,
+            location: None,
+            reminder_minutes: None,
+            additional_attendees: vec!["bob@example.com".to_string()],
+            ..Default::default()
+        };
+
+        let caldav = generate_ics_caldav(&details);
+        assert!(!caldav.contains("METHOD:"), "CalDAV PUT must omit METHOD");
+        assert!(caldav.contains(
+            "ATTENDEE;SCHEDULE-AGENT=CLIENT;CN=Jane Doe;RSVP=TRUE:mailto:jane@example.com"
+        ));
+        assert!(caldav.contains("ATTENDEE;SCHEDULE-AGENT=CLIENT;RSVP=TRUE:mailto:bob@example.com"));
+
+        let email = generate_ics(&details, "REQUEST");
+        assert!(
+            !email.contains("SCHEDULE-AGENT"),
+            "email .ics must keep plain ATTENDEE lines"
+        );
+        assert!(email.contains("ATTENDEE;CN=Jane Doe;RSVP=TRUE:mailto:jane@example.com"));
     }
 
     // Regression test for #49: DTSTAMP is REQUIRED in VEVENT by RFC 5545 §3.6.1.

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -18561,7 +18561,7 @@ async fn caldav_push_booking(
         return;
     }
 
-    let ics = crate::email::generate_ics(details, "");
+    let ics = crate::email::generate_ics_caldav(details);
 
     for (
         source_id,
@@ -19009,7 +19009,7 @@ async fn resource_push_booking(
             .await
             .unwrap_or(None)
             .flatten();
-    let ics = crate::email::generate_ics(details, "");
+    let ics = crate::email::generate_ics_caldav(details);
 
     for (resource_id, caldav_url, service_user, service_pw) in &targets {
         let Some(url) = caldav_url else {


### PR DESCRIPTION
Closes #141.

The ICS written to CalDAV (host calendar and resource reservations) now marks every ATTENDEE with `SCHEDULE-AGENT=CLIENT` (RFC 6638 section 7.1), telling the server that calrs already handled invitations over SMTP. Without it, Fastmail-style servers run server-side scheduling on the PUT event and send a duplicate iMIP invite in UTC, the exact behavior Cal.com fixed the same way (calcom/cal.com#26809).

Implementation: `generate_ics` gains an internal variant; the public API adds `generate_ics_caldav(details)` used by the two CalDAV PUT sites. Email `.ics` attachments are unchanged (`METHOD:REQUEST`, plain `ATTENDEE;RSVP=TRUE`) so Gmail and friends keep showing "Add to calendar".

Not included: the issue's nice-to-have VTIMEZONE/local-time DTSTART. The write-back event stays in UTC; clients render it in their own zone. Can be a follow-up if someone still sees wrong times after this fix.

Test: `generate_ics_caldav_marks_attendees_schedule_agent_client` covers both the guest and additional-attendee lines, METHOD omission, and that the email variant stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)