### PR TITLE
fix(email): neutral subjects on guest emails carrying a REQUEST ICS

### DIFF
--- a/i18n/de/main.ftl
+++ b/i18n/de/main.ftl
@@ -211,7 +211,7 @@ email-action-cancel-booking = Buchung stornieren
 
 # Email: guest booking confirmation
 
-email-confirm-subject = Bestätigt: { $event } — { $date }
+email-confirm-subject = { $event } — { $date }
 email-confirm-greeting = Hallo { $name },
 email-confirm-headline = Deine Buchung wurde bestätigt!
 email-confirm-ics-attached-plain = Eine Kalendereinladung ist beigefügt.

--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -216,7 +216,9 @@ email-action-cancel-booking = Cancel booking
 
 # Email: guest booking confirmation
 
-email-confirm-subject = Confirmed: { $event } — { $date }
+# Kept to "event — date": Exchange titles the guest appointment after the
+# email Subject header, not the ICS SUMMARY (#157).
+email-confirm-subject = { $event } — { $date }
 email-confirm-greeting = Hi { $name },
 email-confirm-headline = Your booking has been confirmed!
 email-confirm-ics-attached-plain = A calendar invite is attached.

--- a/i18n/es/main.ftl
+++ b/i18n/es/main.ftl
@@ -210,7 +210,7 @@ email-action-cancel-booking = Cancelar reserva
 
 # Email: guest booking confirmation
 
-email-confirm-subject = Confirmada: { $event } — { $date }
+email-confirm-subject = { $event } — { $date }
 email-confirm-greeting = Hola { $name },
 email-confirm-headline = ¡Tu reserva se ha confirmado!
 email-confirm-ics-attached-plain = Se adjunta una invitación de calendario.

--- a/i18n/fr/main.ftl
+++ b/i18n/fr/main.ftl
@@ -211,7 +211,7 @@ email-action-cancel-booking = Annuler la réservation
 
 # Email: guest booking confirmation
 
-email-confirm-subject = Réservation confirmée : { $event } — { $date }
+email-confirm-subject = { $event } — { $date }
 email-confirm-greeting = Bonjour { $name },
 email-confirm-headline = Votre réservation est confirmée !
 email-confirm-ics-attached-plain = Une invitation est jointe à cet e-mail.

--- a/i18n/it/main.ftl
+++ b/i18n/it/main.ftl
@@ -211,7 +211,7 @@ email-action-cancel-booking = Annulla prenotazione
 
 # Email: guest booking confirmation
 
-email-confirm-subject = Confermata: { $event } — { $date }
+email-confirm-subject = { $event } — { $date }
 email-confirm-greeting = Ciao { $name },
 email-confirm-headline = La tua prenotazione è confermata!
 email-confirm-ics-attached-plain = Un invito al calendario è in allegato.

--- a/i18n/pl/main.ftl
+++ b/i18n/pl/main.ftl
@@ -213,7 +213,7 @@ email-action-cancel-booking = Anuluj rezerwację
 
 # Email: guest booking confirmation
 
-email-confirm-subject = Potwierdzono: { $event } — { $date }
+email-confirm-subject = { $event } — { $date }
 email-confirm-greeting = Cześć { $name },
 email-confirm-headline = Twoja rezerwacja została potwierdzona!
 email-confirm-ics-attached-plain = Zaproszenie do kalendarza w załączniku.

--- a/src/email.rs
+++ b/src/email.rs
@@ -816,10 +816,10 @@ pub async fn send_guest_confirmation_ex(
         let email2 = Message::builder()
             .from(from.clone())
             .to(to2)
-            .subject(format!(
-                "Invite: {} \u{2014} {}",
-                details.event_title, details.date
-            ))
+            // Exchange titles the guest's appointment after the Subject
+            // header, not the ICS SUMMARY, so REQUEST emails keep a neutral
+            // "event, date" subject (#157).
+            .subject(format!("{} \u{2014} {}", details.event_title, details.date))
             .multipart(MultiPart::mixed().multipart(body2).singlepart(att2))?;
         if let Err(e) = send_email(config, email2).await {
             tracing::warn!(attendee = %attendee_email, error = %e, "failed to send attendee confirmation");
@@ -2292,8 +2292,9 @@ pub async fn send_guest_reschedule_notification(
     let email = Message::builder()
         .from(config.mailbox_from()?)
         .to(to)
+        // Neutral subject: Exchange uses it as the appointment title (#157).
         .subject(format!(
-            "Rescheduled: {} \u{2014} {}",
+            "{} \u{2014} {}",
             details.event_title, details.new_date
         ))
         .multipart(


### PR DESCRIPTION
Workaround for #157.

## What

Exchange iMIP processing titles the guest's calendar appointment after the email Subject header instead of the ICS SUMMARY, so prefixed subjects become the event title on the guest side and bounce back in accept/decline replies (see #157 for the full chain, including the JSON rendering on the receiving webmail).

This drops the prefix on the three guest-facing emails that attach a METHOD:REQUEST ICS, keeping just "event, date" as subject:

- `email-confirm-subject` in all six locales (value is now identical everywhere, nothing new for Weblate to translate)
- additional attendee invite, was hardcoded "Invite: ..."
- guest reschedule notification, was hardcoded "Rescheduled: ..."

The confirmed/rescheduled wording stays in the email body. Host-facing notifications are unchanged on purpose: hosts get the properly titled event via CalDAV write-back and the "New booking:" prefix has inbox value.

## Why base `i18n`

Touches translatable strings, so it lands on `i18n` first per the workflow, and reaches `main` with the next `i18n` merge.

## Testing

`cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (745 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated guest booking confirmation email subjects across supported languages to display the event name and date consistently.
  - Standardized confirmation and rescheduling email subjects to avoid duplicated appointment titles in Exchange and calendar clients.
  - Removed introductory prefixes such as “Confirmed,” “Invite,” and “Rescheduled” for a cleaner, more consistent email experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->