### PR TITLE
fix(embed): pin color-scheme when the embed theme is pinned

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% set _et = embed_theme | default("") %}
+  {% if embed | default(false) and (_et == "light" or _et == "dark") %}
+  <meta name="color-scheme" content="{{ _et }}">
+  {% else %}
   <meta name="color-scheme" content="light dark">
+  {% endif %}
   <title>{% block title %}calrs{% endblock %}</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦀</text></svg>">
   <script>


### PR DESCRIPTION
## The problem

An inline embed requested with `?embed=1&theme=light` shows light content inside a **black frame** for any visitor whose OS is in dark mode. (`theme=dark` on a light-mode visitor is the mirror case.)

The embedded booking page leaves `html` and `body` transparent and paints `--bg` on an inner wrapper only, so `body`'s `16px 12px` padding ring shows the iframe canvas. The canvas colour is resolved from the document's `color-scheme`, and `templates/base.html` hardcoded:

```html
<meta name="color-scheme" content="light dark">
```

So the UA picks the canvas from the visitor's OS even though the parent explicitly pinned a theme via `?theme=`.

## Standalone reproduction

Visitor in dark mode. Parent with `background:#f7f5f0` holding an iframe of a child shaped like the embedded page:

```html
<html><head>
  <meta name="color-scheme" content="light dark">
  <style>body{margin:0;padding:16px 12px}
         .card{background:#fbfaf6;padding:18px;border-radius:12px}</style>
</head><body><div class="card">booking card</div></body></html>
```

`light dark` reproduces the black frame; `light` removes it.

## The fix

Make the `color-scheme` meta follow `?theme=`, exactly as the anti-flash `<script>` a few lines below it in the same file already does (`embed` / `embed_theme` are already in the render context of every embeddable route). Non-embed pages, and embeds with no explicit theme, are unchanged.

| condition | output |
| --- | --- |
| `embed` and `theme=light` | `content="light"` |
| `embed` and `theme=dark` | `content="dark"` |
| `embed`, theme absent or `auto` | `content="light dark"` (unchanged) |
| not embedded | `content="light dark"` (unchanged) |
| variables absent from context | `content="light dark"` (must not error) |

## Note on iframe-element workarounds

These were tried and do **not** fix it — the fix has to be in the document calrs serves:

- `color-scheme: light` on the parent's `<iframe>` element does **not** fix it.
- A `background` on the `<iframe>` element does **not** fix it.

## What was and wasn't verified

- **Verified:** the six rows above by manually evaluating the template logic (`{% set %}`, `| default(...)`, `and`, string `==`), and the standalone reproduction above in a browser — `light dark` shows the black frame, `light` removes it.
- **Not verified:** this was **not compiled or rendered** through minijinja. No Rust toolchain was available in the environment where the change was made, so `cargo build` / `cargo test` were not run. The template constructs used here are all already present elsewhere in the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color-scheme handling for embedded content with valid light or dark themes.
  * Preserved automatic light/dark theme support when no valid embedded theme is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->