### PR TITLE
feat: add SMS notifications via Twilio

### DIFF
--- a/migrations/062_sms_notifications.sql
+++ b/migrations/062_sms_notifications.sql
@@ -1,0 +1,22 @@
+-- SMS notifications via Twilio (optional, opt-in per event type).
+--
+-- Mirrors the smtp_config pattern: a system-wide singleton row, auth token
+-- encrypted at rest with AES-256-GCM (see src/crypto.rs), editable from the
+-- admin panel or CALRS_TWILIO_* environment variables.
+
+-- Guests can optionally leave a phone number on the booking form. It is only
+-- collected/shown when the event type has SMS notifications enabled.
+ALTER TABLE bookings ADD COLUMN phone_number TEXT;
+
+-- Per-event-type opt-in switch (default off, so existing event types keep
+-- working exactly as before with no SMS involved).
+ALTER TABLE event_types ADD COLUMN sms_notifications_enabled INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS twilio_config (
+    id                TEXT PRIMARY KEY,
+    account_sid       TEXT NOT NULL,
+    auth_token_enc     TEXT,
+    from_number       TEXT NOT NULL,
+    enabled           INTEGER NOT NULL DEFAULT 1,
+    created_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/migrations/063_sms_default_country_code.sql
+++ b/migrations/063_sms_default_country_code.sql
@@ -1,0 +1,2 @@
+-- Default country calling code used to normalize local guest phone numbers.
+ALTER TABLE twilio_config ADD COLUMN default_country_code TEXT NOT NULL DEFAULT '+1';

--- a/src/db.rs
+++ b/src/db.rs
@@ -841,6 +841,7 @@ mod tests {
             "sessions",
             "auth_config",
             "smtp_config",
+            "twilio_config",
             "groups",
             "user_groups",
             "event_type_calendars",
@@ -875,7 +876,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 61, "All 61 migrations should be tracked");
+        assert_eq!(count.0, 63, "All 63 migrations should be tracked");
     }
 
     #[tokio::test]
@@ -889,7 +890,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(count.0, 61, "Still 61 migrations after second run");
+        assert_eq!(count.0, 63, "Still 63 migrations after second run");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -260,6 +260,14 @@ pub async fn migrate(pool: &SqlitePool) -> Result<()> {
             "061_booking_unique_per_member",
             include_str!("../migrations/061_booking_unique_per_member.sql"),
         ),
+        (
+            "062_sms_notifications",
+            include_str!("../migrations/062_sms_notifications.sql"),
+        ),
+        (
+            "063_sms_default_country_code",
+            include_str!("../migrations/063_sms_default_country_code.sql"),
+        ),
     ];
 
     let mut applied_count = 0u32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod providers;
 mod resources;
 mod rrule;
 mod settings;
+mod sms;
 mod utils;
 mod web;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -144,6 +144,11 @@ pub struct EventType {
     /// Minimum notice (in minutes) required for a guest-initiated reschedule.
     /// `None` or `Some(0)` means no restriction.
     pub reschedule_notice_min: Option<i32>,
+    /// Opt-in: when true, the booking form shows an optional phone number
+    /// field and SMS notifications (via Twilio) are sent for this event
+    /// type's bookings, in addition to email. Defaults to false so existing
+    /// event types are unaffected.
+    pub sms_notifications_enabled: bool,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
@@ -196,6 +201,9 @@ pub struct Booking {
     pub reschedule_token: String,
     pub created_at: String,
     pub assigned_user_id: Option<String>,
+    /// Optional guest phone number in E.164 format (e.g. `+15551234567`),
+    /// collected only when the event type has SMS notifications enabled.
+    pub phone_number: Option<String>,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/src/sms.rs
+++ b/src/sms.rs
@@ -1,0 +1,494 @@
+//! SMS notifications via the Twilio REST API.
+//!
+//! Mirrors `email.rs`'s SMTP pattern on purpose: a system-wide singleton
+//! config, `CALRS_TWILIO_*` environment variables taking precedence over a
+//! DB-stored, AES-256-GCM-encrypted (`crate::crypto`) row editable from the
+//! admin panel. SMS is entirely opt-in — with no Twilio config *and* no
+//! event type enabling it, nothing changes for existing installs.
+//!
+//! Unlike SMTP, sending happens over plain HTTPS (Twilio's REST API), so we
+//! reuse the `reqwest` client already used for CalDAV instead of pulling in a
+//! Twilio SDK.
+
+use anyhow::{bail, Context, Result};
+use sqlx::SqlitePool;
+
+pub struct TwilioConfig {
+    pub account_sid: String,
+    pub auth_token: String,
+    pub from_number: String,
+}
+
+impl std::fmt::Debug for TwilioConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TwilioConfig")
+            .field("account_sid", &self.account_sid)
+            .field("auth_token", &"<redacted>")
+            .field("from_number", &self.from_number)
+            .finish()
+    }
+}
+
+pub struct TwilioStatus {
+    pub account_sid: String,
+    pub from_number: String,
+    pub enabled: bool,
+    pub from_env: bool,
+}
+
+const TWILIO_ENV_VARS: &[&str] = &[
+    "CALRS_TWILIO_ACCOUNT_SID",
+    "CALRS_TWILIO_AUTH_TOKEN",
+    "CALRS_TWILIO_FROM_NUMBER",
+];
+
+/// Read a Twilio env var, returning `Some(value)` only when set and non-empty.
+fn optional_twilio_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+/// Load Twilio config from the `CALRS_TWILIO_*` environment block. Same
+/// "full block override" semantics as `email::load_smtp_config_from_env`:
+/// a complete block wins over the database; a partial block is ignored and
+/// the caller falls back to the DB config.
+fn load_twilio_config_from_env() -> Option<TwilioConfig> {
+    if !TWILIO_ENV_VARS
+        .iter()
+        .any(|name| std::env::var_os(name).is_some())
+    {
+        return None;
+    }
+
+    match (
+        optional_twilio_env("CALRS_TWILIO_ACCOUNT_SID"),
+        optional_twilio_env("CALRS_TWILIO_AUTH_TOKEN"),
+        optional_twilio_env("CALRS_TWILIO_FROM_NUMBER"),
+    ) {
+        (Some(account_sid), Some(auth_token), Some(from_number)) => Some(TwilioConfig {
+            account_sid,
+            auth_token,
+            from_number,
+        }),
+        _ => {
+            tracing::warn!(
+                "partial CALRS_TWILIO_* environment block (missing one of ACCOUNT_SID/AUTH_TOKEN/FROM_NUMBER); falling back to database Twilio config"
+            );
+            None
+        }
+    }
+}
+
+/// Whether the `CALRS_TWILIO_*` environment block governs the config (locks
+/// the admin form, same as `email::smtp_env_active`).
+pub fn twilio_env_active() -> bool {
+    load_twilio_config_from_env().is_some()
+}
+
+/// Load Twilio config from environment or database. Returns `Ok(None)` when
+/// SMS is simply not configured — this is the normal, default state.
+pub async fn load_twilio_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Option<TwilioConfig>> {
+    if let Some(config) = load_twilio_config_from_env() {
+        return Ok(Some(config));
+    }
+
+    let row: Option<(String, Option<String>, String)> = sqlx::query_as(
+        "SELECT account_sid, auth_token_enc, from_number FROM twilio_config WHERE enabled = 1 LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some((account_sid, Some(auth_token_enc), from_number)) => {
+            let auth_token = crate::crypto::decrypt_password(key, &auth_token_enc)?;
+            Ok(Some(TwilioConfig {
+                account_sid,
+                auth_token,
+                from_number,
+            }))
+        }
+        Some((_, None, _)) | None => Ok(None),
+    }
+}
+
+/// Load non-secret Twilio status for admin display (same "show disabled rows
+/// too" behaviour as `email::load_smtp_status`).
+pub async fn load_twilio_status(pool: &SqlitePool) -> Result<Option<TwilioStatus>> {
+    if let Some(config) = load_twilio_config_from_env() {
+        return Ok(Some(TwilioStatus {
+            account_sid: config.account_sid,
+            from_number: config.from_number,
+            enabled: true,
+            from_env: true,
+        }));
+    }
+
+    let row: Option<(String, String, bool)> = sqlx::query_as(
+        "SELECT account_sid, from_number, enabled FROM twilio_config ORDER BY enabled DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|(account_sid, from_number, enabled)| TwilioStatus {
+        account_sid,
+        from_number,
+        enabled,
+        from_env: false,
+    }))
+}
+
+
+
+/// Supported/default international calling codes for the guest phone prefix selector.
+pub const COUNTRY_CODES: &[(&str, &str)] = &[
+    ("+1", "United States / Canada (+1)"),
+    ("+20", "Egypt (+20)"),
+    ("+27", "South Africa (+27)"),
+    ("+30", "Greece (+30)"),
+    ("+31", "Netherlands (+31)"),
+    ("+32", "Belgium (+32)"),
+    ("+33", "France (+33)"),
+    ("+34", "Spain (+34)"),
+    ("+36", "Hungary (+36)"),
+    ("+39", "Italy (+39)"),
+    ("+40", "Romania (+40)"),
+    ("+41", "Switzerland (+41)"),
+    ("+43", "Austria (+43)"),
+    ("+44", "United Kingdom (+44)"),
+    ("+45", "Denmark (+45)"),
+    ("+46", "Sweden (+46)"),
+    ("+47", "Norway (+47)"),
+    ("+48", "Poland (+48)"),
+    ("+49", "Germany (+49)"),
+    ("+52", "Mexico (+52)"),
+    ("+53", "Cuba (+53)"),
+    ("+54", "Argentina (+54)"),
+    ("+55", "Brazil (+55)"),
+    ("+56", "Chile (+56)"),
+    ("+57", "Colombia (+57)"),
+    ("+58", "Venezuela (+58)"),
+    ("+60", "Malaysia (+60)"),
+    ("+61", "Australia (+61)"),
+    ("+62", "Indonesia (+62)"),
+    ("+63", "Philippines (+63)"),
+    ("+64", "New Zealand (+64)"),
+    ("+65", "Singapore (+65)"),
+    ("+66", "Thailand (+66)"),
+    ("+7", "Russia / Kazakhstan (+7)"),
+    ("+81", "Japan (+81)"),
+    ("+82", "South Korea (+82)"),
+    ("+84", "Vietnam (+84)"),
+    ("+86", "China (+86)"),
+    ("+90", "Turkey (+90)"),
+    ("+91", "India (+91)"),
+    ("+92", "Pakistan (+92)"),
+    ("+93", "Afghanistan (+93)"),
+    ("+94", "Sri Lanka (+94)"),
+    ("+95", "Myanmar (+95)"),
+    ("+98", "Iran (+98)"),
+    ("+212", "Morocco (+212)"),
+    ("+213", "Algeria (+213)"),
+    ("+216", "Tunisia (+216)"),
+    ("+218", "Libya (+218)"),
+    ("+220", "Gambia (+220)"),
+    ("+221", "Senegal (+221)"),
+    ("+222", "Mauritania (+222)"),
+    ("+223", "Mali (+223)"),
+    ("+224", "Guinea (+224)"),
+    ("+225", "Côte d'Ivoire (+225)"),
+    ("+226", "Burkina Faso (+226)"),
+    ("+227", "Niger (+227)"),
+    ("+228", "Togo (+228)"),
+    ("+229", "Benin (+229)"),
+    ("+230", "Mauritius (+230)"),
+    ("+231", "Liberia (+231)"),
+    ("+232", "Sierra Leone (+232)"),
+    ("+233", "Ghana (+233)"),
+    ("+234", "Nigeria (+234)"),
+    ("+235", "Chad (+235)"),
+    ("+236", "Central African Republic (+236)"),
+    ("+237", "Cameroon (+237)"),
+    ("+238", "Cape Verde (+238)"),
+    ("+239", "São Tomé and Príncipe (+239)"),
+    ("+240", "Equatorial Guinea (+240)"),
+    ("+241", "Gabon (+241)"),
+    ("+242", "Republic of the Congo (+242)"),
+    ("+243", "DR Congo (+243)"),
+    ("+244", "Angola (+244)"),
+    ("+245", "Guinea-Bissau (+245)"),
+    ("+248", "Seychelles (+248)"),
+    ("+249", "Sudan (+249)"),
+    ("+250", "Rwanda (+250)"),
+    ("+251", "Ethiopia (+251)"),
+    ("+252", "Somalia (+252)"),
+    ("+253", "Djibouti (+253)"),
+    ("+254", "Kenya (+254)"),
+    ("+255", "Tanzania (+255)"),
+    ("+256", "Uganda (+256)"),
+    ("+257", "Burundi (+257)"),
+    ("+258", "Mozambique (+258)"),
+    ("+260", "Zambia (+260)"),
+    ("+261", "Madagascar (+261)"),
+    ("+262", "Réunion / Mayotte (+262)"),
+    ("+263", "Zimbabwe (+263)"),
+    ("+264", "Namibia (+264)"),
+    ("+265", "Malawi (+265)"),
+    ("+266", "Lesotho (+266)"),
+    ("+267", "Botswana (+267)"),
+    ("+268", "Eswatini (+268)"),
+    ("+269", "Comoros (+269)"),
+    ("+290", "Saint Helena (+290)"),
+    ("+291", "Eritrea (+291)"),
+    ("+297", "Aruba (+297)"),
+    ("+298", "Faroe Islands (+298)"),
+    ("+299", "Greenland (+299)"),
+    ("+350", "Gibraltar (+350)"),
+    ("+351", "Portugal (+351)"),
+    ("+352", "Luxembourg (+352)"),
+    ("+353", "Ireland (+353)"),
+    ("+354", "Iceland (+354)"),
+    ("+355", "Albania (+355)"),
+    ("+356", "Malta (+356)"),
+    ("+357", "Cyprus (+357)"),
+    ("+358", "Finland (+358)"),
+    ("+359", "Bulgaria (+359)"),
+    ("+370", "Lithuania (+370)"),
+    ("+371", "Latvia (+371)"),
+    ("+372", "Estonia (+372)"),
+    ("+373", "Moldova (+373)"),
+    ("+374", "Armenia (+374)"),
+    ("+375", "Belarus (+375)"),
+    ("+376", "Andorra (+376)"),
+    ("+377", "Monaco (+377)"),
+    ("+378", "San Marino (+378)"),
+    ("+380", "Ukraine (+380)"),
+    ("+381", "Serbia (+381)"),
+    ("+382", "Montenegro (+382)"),
+    ("+383", "Kosovo (+383)"),
+    ("+385", "Croatia (+385)"),
+    ("+386", "Slovenia (+386)"),
+    ("+387", "Bosnia and Herzegovina (+387)"),
+    ("+389", "North Macedonia (+389)"),
+    ("+420", "Czech Republic (+420)"),
+    ("+421", "Slovakia (+421)"),
+    ("+423", "Liechtenstein (+423)"),
+    ("+500", "Falkland Islands (+500)"),
+    ("+501", "Belize (+501)"),
+    ("+502", "Guatemala (+502)"),
+    ("+503", "El Salvador (+503)"),
+    ("+504", "Honduras (+504)"),
+    ("+505", "Nicaragua (+505)"),
+    ("+506", "Costa Rica (+506)"),
+    ("+507", "Panama (+507)"),
+    ("+508", "Saint Pierre and Miquelon (+508)"),
+    ("+509", "Haiti (+509)"),
+    ("+590", "Guadeloupe / Saint Martin (+590)"),
+    ("+591", "Bolivia (+591)"),
+    ("+592", "Guyana (+592)"),
+    ("+593", "Ecuador (+593)"),
+    ("+594", "French Guiana (+594)"),
+    ("+595", "Paraguay (+595)"),
+    ("+596", "Martinique (+596)"),
+    ("+597", "Suriname (+597)"),
+    ("+598", "Uruguay (+598)"),
+    ("+599", "Caribbean Netherlands / Curaçao (+599)"),
+    ("+670", "Timor-Leste (+670)"),
+    ("+672", "Australian External Territories (+672)"),
+    ("+673", "Brunei (+673)"),
+    ("+674", "Nauru (+674)"),
+    ("+675", "Papua New Guinea (+675)"),
+    ("+676", "Tonga (+676)"),
+    ("+677", "Solomon Islands (+677)"),
+    ("+678", "Vanuatu (+678)"),
+    ("+679", "Fiji (+679)"),
+    ("+680", "Palau (+680)"),
+    ("+681", "Wallis and Futuna (+681)"),
+    ("+682", "Cook Islands (+682)"),
+    ("+683", "Niue (+683)"),
+    ("+685", "Samoa (+685)"),
+    ("+686", "Kiribati (+686)"),
+    ("+687", "New Caledonia (+687)"),
+    ("+688", "Tuvalu (+688)"),
+    ("+689", "French Polynesia (+689)"),
+    ("+690", "Tokelau (+690)"),
+    ("+691", "Micronesia (+691)"),
+    ("+692", "Marshall Islands (+692)"),
+    ("+850", "North Korea (+850)"),
+    ("+852", "Hong Kong (+852)"),
+    ("+853", "Macau (+853)"),
+    ("+855", "Cambodia (+855)"),
+    ("+856", "Laos (+856)"),
+    ("+880", "Bangladesh (+880)"),
+    ("+886", "Taiwan (+886)"),
+    ("+960", "Maldives (+960)"),
+    ("+961", "Lebanon (+961)"),
+    ("+962", "Jordan (+962)"),
+    ("+963", "Syria (+963)"),
+    ("+964", "Iraq (+964)"),
+    ("+965", "Kuwait (+965)"),
+    ("+966", "Saudi Arabia (+966)"),
+    ("+967", "Yemen (+967)"),
+    ("+968", "Oman (+968)"),
+    ("+970", "Palestine (+970)"),
+    ("+971", "United Arab Emirates (+971)"),
+    ("+972", "Israel (+972)"),
+    ("+973", "Bahrain (+973)"),
+    ("+974", "Qatar (+974)"),
+    ("+975", "Bhutan (+975)"),
+    ("+976", "Mongolia (+976)"),
+    ("+977", "Nepal (+977)"),
+    ("+992", "Tajikistan (+992)"),
+    ("+993", "Turkmenistan (+993)"),
+    ("+994", "Azerbaijan (+994)"),
+    ("+995", "Georgia (+995)"),
+    ("+996", "Kyrgyzstan (+996)"),
+    ("+998", "Uzbekistan (+998)"),
+];
+
+pub fn is_valid_country_code(code: &str) -> bool {
+    COUNTRY_CODES.iter().any(|(value, _)| *value == code.trim())
+}
+
+/// Normalize a guest phone number using the configured default country code.
+/// Local numbers beginning with 0 are converted to +<country><number without
+/// the national trunk prefix>.  International + and 00 formats are preserved.
+pub fn normalize_guest_phone(raw: &str, default_country_code: &str) -> Option<String> {
+    let mut value: String = raw
+        .trim()
+        .chars()
+        .filter(|c| !matches!(c, ' ' | '-' | '(' | ')' | '.'))
+        .collect();
+    if value.is_empty() || !is_valid_country_code(default_country_code) {
+        return None;
+    }
+
+    if value.starts_with("00") {
+        value.replace_range(..2, "+");
+    } else if value.starts_with('+') {
+        // already international
+    } else {
+        let digits = value.trim_start_matches('0');
+        if digits.is_empty() {
+            return None;
+        }
+        value = format!("{}{}", default_country_code, digits);
+    }
+
+    if is_plausible_e164(&value) {
+        Some(value)
+    } else {
+        None
+    }
+}
+
+/// Very loose E.164 sanity check for guest-entered phone numbers: leading
+/// `+`, then 8-15 digits. Twilio itself is the source of truth on validity;
+/// this only stops obviously-wrong input server-side (the HTML field also
+/// has a `pattern` attribute as a first line of defence for the guest).
+pub fn is_plausible_e164(raw: &str) -> bool {
+    let raw = raw.trim();
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some('+') => {}
+        _ => return false,
+    }
+    let digits: String = chars.collect();
+    digits.len() >= 8 && digits.len() <= 15 && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Send a single SMS via the Twilio REST API
+/// (`POST /2010-04-01/Accounts/{Sid}/Messages.json`).
+async fn send_sms(config: &TwilioConfig, to: &str, body: &str) -> Result<()> {
+    let url = format!(
+        "https://api.twilio.com/2010-04-01/Accounts/{}/Messages.json",
+        config.account_sid
+    );
+
+    let client = reqwest::Client::new();
+    let params = [
+        ("To", to),
+        ("From", config.from_number.as_str()),
+        ("Body", body),
+    ];
+
+    let response = client
+        .post(&url)
+        .basic_auth(&config.account_sid, Some(&config.auth_token))
+        .form(&params)
+        .send()
+        .await
+        .context("Twilio request failed")?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        bail!("Twilio API error ({}): {}", status, text);
+    }
+
+    Ok(())
+}
+
+/// Send a test SMS from the admin panel.
+pub async fn send_test_sms(config: &TwilioConfig, to: &str) -> Result<()> {
+    send_sms(config, to, "This is a test SMS from calrs. Twilio is working!").await
+}
+
+/// Send a booking confirmation SMS to the guest. Keep it short — SMS is
+/// billed per segment (~160 chars for GSM-7).
+pub async fn send_booking_confirmation_sms(
+    config: &TwilioConfig,
+    to: &str,
+    event_title: &str,
+    date: &str,
+    start_time: &str,
+) -> Result<()> {
+    let body = format!(
+        "calrs: your booking \"{}\" is confirmed for {} at {}.",
+        event_title, date, start_time
+    );
+    send_sms(config, to, &body).await
+}
+
+/// Send a cancellation SMS to the guest.
+pub async fn send_cancellation_sms(
+    config: &TwilioConfig,
+    to: &str,
+    event_title: &str,
+    date: &str,
+    start_time: &str,
+) -> Result<()> {
+    let body = format!(
+        "calrs: your booking \"{}\" on {} at {} was cancelled.",
+        event_title, date, start_time
+    );
+    send_sms(config, to, &body).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_plausible_e164() {
+        assert!(is_plausible_e164("+15551234567"));
+        assert!(is_plausible_e164(" +447911123456 "));
+    }
+
+    #[test]
+    fn rejects_missing_plus_or_bad_length_or_non_digits() {
+        assert!(!is_plausible_e164("07911123456"));
+        assert!(!is_plausible_e164("+1234"));
+        assert!(!is_plausible_e164("+1555abc4567"));
+        assert!(!is_plausible_e164(""));
+    }
+
+    #[test]
+    fn env_config_requires_full_block() {
+        // No env vars set at all -> None, falls back to DB.
+        for var in TWILIO_ENV_VARS {
+            std::env::remove_var(var);
+        }
+        assert!(load_twilio_config_from_env().is_none());
+    }
+}

--- a/src/sms.rs
+++ b/src/sms.rs
@@ -138,8 +138,6 @@ pub async fn load_twilio_status(pool: &SqlitePool) -> Result<Option<TwilioStatus
     }))
 }
 
-
-
 /// Supported/default international calling codes for the guest phone prefix selector.
 pub const COUNTRY_CODES: &[(&str, &str)] = &[
     ("+1", "United States / Canada (+1)"),
@@ -405,7 +403,10 @@ async fn send_sms(config: &TwilioConfig, to: &str, body: &str) -> Result<()> {
         config.account_sid
     );
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .context("Failed to build HTTP client")?;
     let params = [
         ("To", to),
         ("From", config.from_number.as_str()),

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -9919,6 +9919,41 @@ async fn handle_group_booking(
         None
     };
 
+    // Validate and normalize phone before opening the transaction so an
+    // invalid number never holds a transaction open or acquires the resource lock.
+    let sms_default_country_pre: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+    let phone_to_store: Option<String> = if sms_notifications_enabled != 0 {
+        match form
+            .phone
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country_pre) {
+                Some(phone) => Some(phone),
+                None => {
+                    return render_booking_action_error(
+                        &state,
+                        &headers,
+                        "Invalid phone number",
+                        "Please enter a valid phone number.",
+                    );
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
+
     // Start a transaction to ensure atomicity of availability check + insert.
     let mut tx = match state.pool.begin().await {
         Ok(tx) => tx,
@@ -10049,39 +10084,6 @@ async fn handle_group_booking(
         }
         crate::resources::ResourceCheck::Free { assigned } => assigned,
         crate::resources::ResourceCheck::NoResources => None,
-    };
-
-    let sms_default_country: String = sqlx::query_scalar::<_, Option<String>>(
-        "SELECT default_country_code FROM twilio_config LIMIT 1",
-    )
-    .fetch_optional(&state.pool)
-    .await
-    .unwrap_or(None)
-    .flatten()
-    .filter(|s| crate::sms::is_valid_country_code(s))
-    .unwrap_or_else(|| "+1".to_string());
-    let phone_to_store: Option<String> = if sms_notifications_enabled != 0 {
-        match form
-            .phone
-            .as_deref()
-            .map(str::trim)
-            .filter(|p| !p.is_empty())
-        {
-            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country) {
-                Some(phone) => Some(phone),
-                None => {
-                    return render_booking_action_error(
-                        &state,
-                        &headers,
-                        "Invalid phone number",
-                        "Please enter a valid phone number.",
-                    );
-                }
-            },
-            None => None,
-        }
-    } else {
-        None
     };
 
     let insert_result = sqlx::query(
@@ -10926,6 +10928,41 @@ async fn handle_dynamic_group_booking(
         None
     };
 
+    // Validate and normalize phone before opening the transaction so an
+    // invalid number never holds a transaction open or acquires the resource lock.
+    let sms_default_country_dg: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+    let phone_to_store: Option<String> = if sms_notifications_enabled != 0 {
+        match form
+            .phone
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country_dg) {
+                Some(phone) => Some(phone),
+                None => {
+                    return render_booking_action_error(
+                        state,
+                        headers,
+                        "Invalid phone number",
+                        "Please enter a valid phone number.",
+                    );
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
+
     let mut tx = match state.pool.begin().await {
         Ok(tx) => tx,
         Err(e) => return internal_error_response("database query", &e),
@@ -10964,39 +11001,6 @@ async fn handle_dynamic_group_booking(
         }
         crate::resources::ResourceCheck::Free { assigned } => assigned,
         crate::resources::ResourceCheck::NoResources => None,
-    };
-
-    let sms_default_country_dg: String = sqlx::query_scalar::<_, Option<String>>(
-        "SELECT default_country_code FROM twilio_config LIMIT 1",
-    )
-    .fetch_optional(&state.pool)
-    .await
-    .unwrap_or(None)
-    .flatten()
-    .filter(|s| crate::sms::is_valid_country_code(s))
-    .unwrap_or_else(|| "+1".to_string());
-    let phone_to_store: Option<String> = if sms_notifications_enabled != 0 {
-        match form
-            .phone
-            .as_deref()
-            .map(str::trim)
-            .filter(|p| !p.is_empty())
-        {
-            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country_dg) {
-                Some(phone) => Some(phone),
-                None => {
-                    return render_booking_action_error(
-                        state,
-                        headers,
-                        "Invalid phone number",
-                        "Please enter a valid phone number.",
-                    );
-                }
-            },
-            None => None,
-        }
-    } else {
-        None
     };
 
     let insert_result = sqlx::query(
@@ -17167,7 +17171,7 @@ async fn admin_update_twilio_test(
 
     match crate::sms::send_test_sms(&config, &to).await {
         Ok(()) => {
-            tracing::info!(admin = %admin.0.email, %to, "admin: twilio test SMS sent");
+            tracing::info!(admin = %admin.0.email, "admin: twilio test SMS sent");
             Redirect::to("/dashboard/admin?twilio_test=sent").into_response()
         }
         Err(e) => {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1383,6 +1383,9 @@ pub async fn create_router(pool: SqlitePool, data_dir: PathBuf, secret_key: [u8;
         .route("/dashboard/admin/smtp", post(admin_update_smtp))
         .route("/dashboard/admin/smtp/test", post(admin_update_smtp_test))
         .route("/dashboard/admin/smtp/clear", post(admin_update_smtp_clear))
+        .route("/dashboard/admin/twilio", post(admin_update_twilio))
+        .route("/dashboard/admin/twilio/test", post(admin_update_twilio_test))
+        .route("/dashboard/admin/twilio/clear", post(admin_update_twilio_clear))
         .route("/dashboard/admin/jitsi", post(admin_update_jitsi))
         .route(
             "/dashboard/admin/meeting-webhook",
@@ -1965,12 +1968,13 @@ async fn dashboard_bookings(
     .await
     .unwrap_or_default();
 
-    let upcoming_bookings: Vec<(String, String, String, String, String, String, i32, String, String, String)> =
+    let upcoming_bookings: Vec<(String, String, String, Option<String>, String, String, String, i32, String, String, String, bool)> =
         sqlx::query_as(
-            "SELECT b.id, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, b.reschedule_by_host,
+            "SELECT b.id, b.guest_name, b.guest_email, b.phone_number, b.start_at, b.end_at, et.title, b.reschedule_by_host,
                     COALESCE(NULLIF(et.timezone, ''), u.timezone) AS stored_tz,
                     COALESCE(NULLIF(b.guest_timezone, ''), 'UTC') AS guest_tz,
-                    COALESCE(r.name, '') AS resource_name
+                    COALESCE(r.name, '') AS resource_name,
+                    et.sms_notifications_enabled
          FROM bookings b
          JOIN event_types et ON et.id = b.event_type_id
          JOIN accounts a ON a.id = et.account_id
@@ -2057,13 +2061,14 @@ async fn dashboard_bookings(
     let bookings_ctx: Vec<minijinja::Value> = upcoming_bookings
         .iter()
         .map(
-            |(id, name, email, start, end, title, resched, stored_tz, guest_tz, resource_name)| {
+            |(id, name, email, phone, start, end, title, resched, stored_tz, guest_tz, resource_name, sms_enabled)| {
                 let (primary, secondary) =
                     format_booking_for_dashboard(start, end, stored_tz, host_tz, guest_tz);
                 context! {
                     id => id,
                     guest_name => name,
                     guest_email => email,
+                    guest_phone => if *sms_enabled { phone.as_deref().unwrap_or("") } else { "" },
                     start_at => primary,
                     start_at_guest => secondary,
                     event_title => title,
@@ -4159,6 +4164,7 @@ async fn cancel_booking(
 
     // Verify the booking belongs to this user and is confirmed or pending.
     // Pending bookings are "declined" (no CalDAV event was ever pushed); confirmed ones are "cancelled".
+    #[allow(clippy::type_complexity)]
     let booking: Option<(
         String,
         String,
@@ -4170,8 +4176,10 @@ async fn cancel_booking(
         String,
         String,
         String,
+        Option<String>,
+        bool,
     )> = sqlx::query_as(
-        "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, et.id, COALESCE(b.guest_timezone, 'UTC'), b.status
+        "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, et.id, COALESCE(b.guest_timezone, 'UTC'), b.status, b.phone_number, et.sms_notifications_enabled
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -4194,6 +4202,8 @@ async fn cancel_booking(
         et_id,
         guest_timezone,
         prev_status,
+        phone_number,
+        sms_notifications_enabled,
     ) = match booking {
         Some(b) => b,
         None => return Redirect::to("/dashboard/bookings").into_response(),
@@ -4215,17 +4225,17 @@ async fn cancel_booking(
         resource_delete_booking(&state.pool, &state.secret_key, &uid).await;
     }
 
+    // Convert event-type-local stored times into the guest's tz; see #101.
+    // Computed once, outside the SMTP-only block, so SMS can use it too.
+    let stored_tz = get_host_tz(&state.pool, &et_id).await;
+    let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
+    let (date, start_time, end_time) =
+        booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
+    let reason = form.reason.filter(|r| !r.trim().is_empty());
+
     if let Ok(Some(smtp_config)) =
         crate::email::load_smtp_config(&state.pool, &state.secret_key).await
     {
-        // Convert event-type-local stored times into the guest's tz; see #101.
-        let stored_tz = get_host_tz(&state.pool, &et_id).await;
-        let guest_tz_parsed = guest_timezone.parse::<Tz>().unwrap_or(Tz::UTC);
-        let (date, start_time, end_time) =
-            booking_strings_in_guest_tz(&start_at, &end_at, stored_tz, guest_tz_parsed);
-
-        let reason = form.reason.filter(|r| !r.trim().is_empty());
-
         let details = crate::email::CancellationDetails {
             event_title: event_title.clone(),
             date: date.clone(),
@@ -4251,6 +4261,30 @@ async fn cancel_booking(
         } else {
             let _ = crate::email::send_guest_cancellation(&smtp_config, &details).await;
             let _ = crate::email::send_host_cancellation(&smtp_config, &details).await;
+        }
+    }
+
+    // Send cancellation SMS to guest, independent of SMTP. Declines
+    // (pending -> declined) get the same "cancelled" wording as a
+    // confirmed cancellation — the guest never had a confirmed slot to
+    // begin with, so the distinction doesn't matter to them.
+    if sms_notifications_enabled {
+        if let Some(phone) = &phone_number {
+            if let Ok(Some(twilio_config)) =
+                crate::sms::load_twilio_config(&state.pool, &state.secret_key).await
+            {
+                if let Err(e) = crate::sms::send_cancellation_sms(
+                    &twilio_config,
+                    phone,
+                    &event_title,
+                    &date,
+                    &start_time,
+                )
+                .await
+                {
+                    tracing::warn!(booking_id = %bid, error = %e, "failed to send host-cancellation SMS");
+                }
+            }
         }
     }
 
@@ -4484,6 +4518,7 @@ struct EventTypeForm {
     #[serde(default)]
     min_notice_min: String,
     requires_confirmation: Option<String>, // checkbox: "on" or absent
+    sms_notifications_enabled: Option<String>, // checkbox: "on" or absent
     visibility: Option<String>,            // "public", "internal", or "private"
     location_type: Option<String>, // "link", "phone", "in_person", "custom", "jitsi_auto", "webhook_auto"
     location_value: Option<String>,
@@ -4947,6 +4982,7 @@ async fn create_event_type(
 
     let et_id = uuid::Uuid::new_v4().to_string();
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let sms_notifications_enabled = form.sms_notifications_enabled.as_deref() == Some("on");
 
     let location_type = form.location_type.as_deref().unwrap_or("link");
     let location_value = form
@@ -5020,8 +5056,8 @@ async fn create_event_type(
         .map(str::to_string);
 
     let _ = sqlx::query(
-        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, reminder_minutes, visibility, max_additional_guests, default_calendar_view, first_slot_only, timezone, cancel_notice_min, reschedule_notice_min, meeting_pattern_override)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, reminder_minutes, visibility, max_additional_guests, default_calendar_view, first_slot_only, timezone, cancel_notice_min, reschedule_notice_min, meeting_pattern_override, sms_notifications_enabled)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&et_id)
     .bind(&account_id)
@@ -5047,6 +5083,7 @@ async fn create_event_type(
     .bind(cancel_notice_min)
     .bind(reschedule_notice_min)
     .bind(&meeting_pattern_override)
+    .bind(sms_notifications_enabled as i32)
     .execute(&state.pool)
     .await;
 
@@ -5454,6 +5491,17 @@ async fn edit_event_type_form(
             form_buffer_after => buf_after,
             form_min_notice => min_notice,
             form_requires_confirmation => requires_conf != 0,
+            form_sms_notifications_enabled => {
+                sqlx::query_scalar::<_, Option<i32>>(
+                    "SELECT sms_notifications_enabled FROM event_types WHERE id = ?",
+                )
+                .bind(&et_id)
+                .fetch_optional(&state.pool)
+                .await
+                .unwrap_or(None)
+                .flatten()
+                .unwrap_or(0) != 0
+            },
             form_visibility => visibility,
             form_location_type => loc_type,
             form_location_value => loc_value.unwrap_or_default(),
@@ -5524,6 +5572,7 @@ async fn update_event_type(
 
     let new_slug = form.slug.trim().to_lowercase().replace(' ', "-");
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let sms_notifications_enabled = form.sms_notifications_enabled.as_deref() == Some("on");
     let visibility = match form.visibility.as_deref().unwrap_or("public") {
         v @ ("public" | "internal" | "private") => v.to_string(),
         _ => "public".to_string(),
@@ -5602,7 +5651,7 @@ async fn update_event_type(
         .map(str::to_string);
 
     let _ = sqlx::query(
-        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ?, cancel_notice_min = ?, reschedule_notice_min = ?, meeting_pattern_override = ? WHERE id = ?",
+        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ?, cancel_notice_min = ?, reschedule_notice_min = ?, meeting_pattern_override = ?, sms_notifications_enabled = ? WHERE id = ?",
     )
     .bind(&new_slug)
     .bind(form.title.trim())
@@ -5625,6 +5674,7 @@ async fn update_event_type(
     .bind(cancel_notice_min)
     .bind(reschedule_notice_min)
     .bind(&meeting_pattern_override)
+    .bind(sms_notifications_enabled as i32)
     .bind(&et_id)
     .execute(&state.pool)
     .await;
@@ -7037,6 +7087,7 @@ async fn render_event_type_form_error(
             form_buffer_after => parse_int_field(&form.buffer_after, 0),
             form_min_notice => parse_int_field(&form.min_notice_min, 60),
             form_requires_confirmation => form.requires_confirmation.as_deref() == Some("on"),
+            form_sms_notifications_enabled => form.sms_notifications_enabled.as_deref() == Some("on"),
             form_visibility => form.visibility.as_deref().unwrap_or("public"),
             form_location_type => form.location_type.as_deref().unwrap_or("link"),
             form_location_value => form.location_value.as_deref().unwrap_or(""),
@@ -8132,6 +8183,7 @@ async fn create_group_event_type(
 
     let et_id = uuid::Uuid::new_v4().to_string();
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let sms_notifications_enabled = form.sms_notifications_enabled.as_deref() == Some("on");
     let location_type = form.location_type.as_deref().unwrap_or("link");
     let location_value = form
         .location_value
@@ -8176,8 +8228,8 @@ async fn create_group_event_type(
         .map(str::to_string);
 
     let _ = sqlx::query(
-        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, default_calendar_view, first_slot_only, timezone, cancel_notice_min, reschedule_notice_min, meeting_pattern_override)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO event_types (id, account_id, slug, title, description, duration_min, slot_interval_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, location_type, location_value, team_id, created_by_user_id, default_calendar_view, first_slot_only, timezone, cancel_notice_min, reschedule_notice_min, meeting_pattern_override, sms_notifications_enabled)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&et_id)
     .bind(&account_id)
@@ -8200,6 +8252,7 @@ async fn create_group_event_type(
     .bind(cancel_notice_min)
     .bind(reschedule_notice_min)
     .bind(&meeting_pattern_override)
+    .bind(sms_notifications_enabled as i32)
     .execute(&state.pool)
     .await;
 
@@ -8659,6 +8712,7 @@ async fn update_group_event_type(
 
     let new_slug = form.slug.trim().to_lowercase().replace(' ', "-");
     let requires_confirmation = form.requires_confirmation.as_deref() == Some("on");
+    let sms_notifications_enabled = form.sms_notifications_enabled.as_deref() == Some("on");
     let visibility = form.visibility.as_deref().unwrap_or("public").to_string();
 
     // Check slug uniqueness within the team if changed
@@ -8734,7 +8788,7 @@ async fn update_group_event_type(
         .map(str::to_string);
 
     let _ = sqlx::query(
-        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ?, cancel_notice_min = ?, reschedule_notice_min = ?, meeting_pattern_override = ? WHERE id = ?",
+        "UPDATE event_types SET slug = ?, title = ?, description = ?, duration_min = ?, slot_interval_min = ?, buffer_before = ?, buffer_after = ?, min_notice_min = ?, requires_confirmation = ?, location_type = ?, location_value = ?, reminder_minutes = ?, visibility = ?, max_additional_guests = ?, scheduling_mode = ?, default_calendar_view = ?, first_slot_only = ?, timezone = ?, cancel_notice_min = ?, reschedule_notice_min = ?, meeting_pattern_override = ?, sms_notifications_enabled = ? WHERE id = ?",
     )
     .bind(&new_slug)
     .bind(form.title.trim())
@@ -8757,6 +8811,7 @@ async fn update_group_event_type(
     .bind(cancel_notice_min)
     .bind(reschedule_notice_min)
     .bind(&meeting_pattern_override)
+    .bind(sms_notifications_enabled as i32)
     .bind(&et_id)
     .execute(&state.pool)
     .await;
@@ -9506,8 +9561,8 @@ async fn show_group_book_form(
 ) -> Response {
     let embed = query.embed_params();
     let lang = crate::i18n::detect_from_headers(&headers);
-    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, String, i32, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, t.name, et.visibility, et.max_additional_guests, t.visibility, t.invite_token, t.id
+    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, String, i32, String, Option<String>, String, bool)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, t.name, et.visibility, et.max_additional_guests, t.visibility, t.invite_token, t.id, et.sms_notifications_enabled
          FROM event_types et
          JOIN teams t ON t.id = et.team_id
          WHERE t.slug = ? AND et.slug = ? AND et.enabled = 1",
@@ -9532,6 +9587,7 @@ async fn show_group_book_form(
         team_visibility,
         team_invite_token,
         team_id,
+        sms_notifications_enabled,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
@@ -9596,7 +9652,15 @@ async fn show_group_book_form(
 
     let guest_tz = parse_guest_tz(query.tz.as_deref());
     let guest_tz_name = guest_tz.name().to_string();
-
+    let phone_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
     let date = match NaiveDate::parse_from_str(&query.date, "%Y-%m-%d") {
         Ok(d) => d,
         Err(_) => return Html("Invalid date format.".to_string()).into_response(),
@@ -9641,6 +9705,9 @@ async fn show_group_book_form(
             form_email => invite_guest_email.as_deref().unwrap_or(""),
             form_notes => "",
             invite_token => query.invite.as_deref().unwrap_or(""),
+            sms_notifications_enabled => sms_notifications_enabled,
+            phone_default_country => phone_default_country,
+            form_phone => "",
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
             captcha_enabled => captcha.enabled,
@@ -9730,6 +9797,13 @@ async fn handle_group_booking(
         None => return Html("Event type not found.".to_string()).into_response(),
     };
     let needs_approval = requires_confirmation != 0;
+    let sms_notifications_enabled: i32 =
+        sqlx::query_scalar("SELECT sms_notifications_enabled FROM event_types WHERE id = ?")
+            .bind(&et_id)
+            .fetch_optional(&state.pool)
+            .await
+            .unwrap_or(None)
+            .unwrap_or(0);
     let scheduling_mode: String =
         sqlx::query_scalar("SELECT scheduling_mode FROM event_types WHERE id = ?")
             .bind(&et_id)
@@ -9977,9 +10051,42 @@ async fn handle_group_booking(
         crate::resources::ResourceCheck::NoResources => None,
     };
 
+    let sms_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+    let phone_to_store: Option<String> = if sms_notifications_enabled != 0 {
+        match form
+            .phone
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country) {
+                Some(phone) => Some(phone),
+                None => {
+                    return render_booking_action_error(
+                        &state,
+                        &headers,
+                        "Invalid phone number",
+                        "Please enter a valid phone number.",
+                    );
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
+
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, assigned_user_id, confirm_token, language, assigned_resource_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, assigned_user_id, confirm_token, language, assigned_resource_id, phone_number)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -9997,6 +10104,7 @@ async fn handle_group_booking(
     .bind(&confirm_token)
     .bind(lang)
     .bind(&assigned_resource_id)
+    .bind(&phone_to_store)
     .execute(&mut *tx)
     .await;
 
@@ -10183,6 +10291,21 @@ async fn handle_group_booking(
             }
         }
     }
+
+    // Send booking SMS independently of the email/host notification path.
+    // Pending bookings are notified when they are approved.
+    send_booking_sms_if_enabled(
+        &state.pool,
+        &state.secret_key,
+        sms_notifications_enabled != 0,
+        phone_to_store.as_deref(),
+        &id,
+        &et_title,
+        &form.date,
+        &form.time,
+        needs_approval,
+    )
+    .await;
 
     let date_label = crate::i18n::format_long_date(date, lang);
 
@@ -10532,8 +10655,8 @@ async fn show_dynamic_group_book_form(
     };
 
     let owner_username = &usernames[0];
-    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, et.visibility, et.max_additional_guests
+    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32, bool)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, et.visibility, et.max_additional_guests, et.sms_notifications_enabled
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -10555,6 +10678,7 @@ async fn show_dynamic_group_book_form(
         loc_value,
         visibility,
         max_additional_guests,
+        sms_notifications_enabled,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
@@ -10572,6 +10696,15 @@ async fn show_dynamic_group_book_form(
 
     let guest_tz = parse_guest_tz(query.tz.as_deref());
     let guest_tz_name = guest_tz.name().to_string();
+    let phone_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
 
     let date = match NaiveDate::parse_from_str(&query.date, "%Y-%m-%d") {
         Ok(d) => d,
@@ -10607,6 +10740,9 @@ async fn show_dynamic_group_book_form(
             },
             host_name => host_name,
             username => combined_username,
+            sms_notifications_enabled => sms_notifications_enabled,
+            phone_default_country => phone_default_country,
+            form_phone => "",
             date => query.date,
             date_label => date_label,
             time_start => query.time,
@@ -10658,8 +10794,8 @@ async fn handle_dynamic_group_booking(
     };
 
     let owner_username = &usernames[0];
-    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, u.id, et.reminder_minutes, et.visibility, et.max_additional_guests
+    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, i32)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, u.id, et.reminder_minutes, et.visibility, et.max_additional_guests, et.sms_notifications_enabled
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -10686,6 +10822,7 @@ async fn handle_dynamic_group_booking(
         reminder_min,
         visibility,
         max_additional_guests,
+        sms_notifications_enabled,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
@@ -10829,9 +10966,42 @@ async fn handle_dynamic_group_booking(
         crate::resources::ResourceCheck::NoResources => None,
     };
 
+    let sms_default_country_dg: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+    let phone_to_store: Option<String> = if sms_notifications_enabled != 0 {
+        match form
+            .phone
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country_dg) {
+                Some(phone) => Some(phone),
+                None => {
+                    return render_booking_action_error(
+                        state,
+                        headers,
+                        "Invalid phone number",
+                        "Please enter a valid phone number.",
+                    );
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
+
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language, assigned_resource_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language, assigned_resource_id, phone_number)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -10848,6 +11018,7 @@ async fn handle_dynamic_group_booking(
     .bind(&confirm_token)
     .bind(lang)
     .bind(&assigned_resource_id)
+    .bind(&phone_to_store)
     .execute(&mut *tx)
     .await;
 
@@ -11281,8 +11452,8 @@ async fn show_book_form_for_user(
             .into_response();
     }
 
-    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32, Option<String>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, et.visibility, et.max_additional_guests, u.language
+    let et: Option<(String, String, String, Option<String>, i32, String, Option<String>, String, i32, Option<String>, bool)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.description, et.duration_min, et.location_type, et.location_value, et.visibility, et.max_additional_guests, u.language, et.sms_notifications_enabled
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -11305,6 +11476,7 @@ async fn show_book_form_for_user(
         visibility,
         max_additional_guests,
         user_lang,
+        sms_notifications_enabled,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
@@ -11361,6 +11533,15 @@ async fn show_book_form_for_user(
 
     let guest_tz = parse_guest_tz(query.tz.as_deref());
     let guest_tz_name = guest_tz.name().to_string();
+    let phone_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
 
     let date = match NaiveDate::parse_from_str(&query.date, "%Y-%m-%d") {
         Ok(d) => d,
@@ -11396,6 +11577,9 @@ async fn show_book_form_for_user(
             },
             host_name => host_name,
             username => username,
+            sms_notifications_enabled => sms_notifications_enabled,
+            phone_default_country => phone_default_country,
+            form_phone => "",
             date => query.date,
             date_label => date_label,
             time_start => query.time,
@@ -11464,8 +11648,8 @@ async fn handle_booking_for_user(
         return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
-    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, Option<String>)> = sqlx::query_as(
-        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, u.id, et.reminder_minutes, et.visibility, et.max_additional_guests, u.language
+    let et: Option<(String, String, String, i32, i32, i32, i32, i32, String, Option<String>, String, Option<i32>, String, i32, Option<String>, bool)> = sqlx::query_as(
+        "SELECT et.id, et.slug, et.title, et.duration_min, et.buffer_before, et.buffer_after, et.min_notice_min, et.requires_confirmation, et.location_type, et.location_value, u.id, et.reminder_minutes, et.visibility, et.max_additional_guests, u.language, et.sms_notifications_enabled
          FROM event_types et
          JOIN accounts a ON a.id = et.account_id
          JOIN users u ON u.id = a.user_id
@@ -11493,6 +11677,7 @@ async fn handle_booking_for_user(
         visibility,
         max_additional_guests,
         user_lang,
+        sms_notifications_enabled,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
@@ -11500,6 +11685,38 @@ async fn handle_booking_for_user(
 
     let lang = crate::i18n::resolve(user_lang.as_deref(), &headers);
     let needs_approval = requires_confirmation != 0;
+    let sms_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+    let phone_to_store: Option<String> = if sms_notifications_enabled {
+        match form
+            .phone
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country) {
+                Some(phone) => Some(phone),
+                None => {
+                    return render_booking_action_error(
+                        &state,
+                        &headers,
+                        "Invalid phone number",
+                        "Please enter a valid phone number.",
+                    );
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
 
     // Parse additional guests
     let additional_attendees = match parse_additional_guests(
@@ -11664,8 +11881,8 @@ async fn handle_booking_for_user(
     };
 
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language, assigned_resource_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language, assigned_resource_id, phone_number)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -11682,6 +11899,7 @@ async fn handle_booking_for_user(
     .bind(&confirm_token)
     .bind(lang)
     .bind(&assigned_resource_id)
+    .bind(&phone_to_store)
     .execute(&mut *tx)
     .await;
 
@@ -11840,6 +12058,21 @@ async fn handle_booking_for_user(
             }
         }
     }
+
+    // Send booking SMS independently of the email/host notification path.
+    // Pending bookings are notified when they are approved.
+    send_booking_sms_if_enabled(
+        &state.pool,
+        &state.secret_key,
+        sms_notifications_enabled,
+        phone_to_store.as_deref(),
+        &id,
+        &et_title,
+        &form.date,
+        &form.time,
+        needs_approval,
+    )
+    .await;
 
     let host_name: String = sqlx::query_scalar("SELECT name FROM users WHERE username = ?")
         .bind(&username)
@@ -13581,8 +13814,8 @@ async fn show_book_form(
     Query(query): Query<BookQuery>,
 ) -> impl IntoResponse {
     let lang = crate::i18n::detect_from_headers(&headers);
-    let et: Option<(String, String, String, Option<String>, i32, i32, String)> = sqlx::query_as(
-        "SELECT id, slug, title, description, duration_min, max_additional_guests, visibility
+    let et: Option<(String, String, String, Option<String>, i32, i32, String, bool)> = sqlx::query_as(
+        "SELECT id, slug, title, description, duration_min, max_additional_guests, visibility, sms_notifications_enabled
          FROM event_types WHERE slug = ? AND enabled = 1",
     )
     .bind(&slug)
@@ -13590,7 +13823,7 @@ async fn show_book_form(
     .await
     .unwrap_or(None);
 
-    let (et_id, et_slug, et_title, et_desc, duration, max_additional_guests, visibility) = match et
+    let (et_id, et_slug, et_title, et_desc, duration, max_additional_guests, visibility, sms_notifications_enabled) = match et
     {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()),
@@ -13612,6 +13845,17 @@ async fn show_book_form(
 
     let guest_tz = parse_guest_tz(query.tz.as_deref());
     let guest_tz_name = guest_tz.name().to_string();
+    let phone_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+
+
 
     let date = match NaiveDate::parse_from_str(&query.date, "%Y-%m-%d") {
         Ok(d) => d,
@@ -13653,6 +13897,9 @@ async fn show_book_form(
             form_name => "",
             form_email => "",
             form_notes => "",
+            form_phone => "",
+            sms_notifications_enabled => sms_notifications_enabled,
+            phone_default_country => phone_default_country,
             max_additional_guests => max_additional_guests,
             company_link => state.company_link.read().await.clone(),
             captcha_enabled => captcha.enabled,
@@ -13758,6 +14005,69 @@ struct BookForm {
     additional_guests: Option<String>,
     #[serde(rename = "cap-token", default)]
     captcha_token: Option<String>,
+    /// Optional guest phone number (E.164, e.g. `+15551234567`). Only shown
+    /// on the booking page / used for SMS when the event type has
+    /// `sms_notifications_enabled` set; ignored otherwise even if posted.
+    #[serde(default)]
+    phone: Option<String>,
+}
+
+async fn send_booking_sms_if_enabled(
+    pool: &sqlx::SqlitePool,
+    secret_key: &[u8; 32],
+    sms_enabled: bool,
+    phone: Option<&str>,
+    booking_id: &str,
+    event_title: &str,
+    date: &str,
+    start_time: &str,
+    pending_approval: bool,
+) {
+    if !sms_enabled {
+        return;
+    }
+
+    let phone = match phone {
+        Some(phone) => phone,
+        None => {
+            tracing::debug!(booking_id = %booking_id, "booking SMS skipped: no guest phone number");
+            return;
+        }
+    };
+
+    if pending_approval {
+        tracing::debug!(
+            booking_id = %booking_id,
+            "booking SMS deferred: booking requires approval"
+        );
+        return;
+    }
+
+    let twilio_config = match crate::sms::load_twilio_config(pool, secret_key).await {
+        Ok(Some(config)) => config,
+        Ok(None) => {
+            tracing::warn!(booking_id = %booking_id, "booking SMS skipped: Twilio is not configured");
+            return;
+        }
+        Err(e) => {
+            tracing::error!(
+                booking_id = %booking_id,
+                error = %e,
+                "booking SMS skipped: failed to load Twilio configuration"
+            );
+            return;
+        }
+    };
+
+    if let Err(e) = crate::sms::send_booking_confirmation_sms(
+        &twilio_config, phone, event_title, date, start_time,
+    )
+    .await
+    {
+        tracing::warn!(booking_id = %booking_id, error = %e, "failed to send booking confirmation SMS");
+    } else {
+        tracing::info!(booking_id = %booking_id, "booking confirmation SMS sent");
+    }
 }
 
 async fn handle_booking(
@@ -13796,8 +14106,22 @@ async fn handle_booking(
         return render_booking_action_error(&state, &headers, "Invalid booking details", &e);
     }
 
-    let et: Option<(String, String, String, i32, i32, i32, i32, i32, Option<i32>, i32, String)> = sqlx::query_as(
-        "SELECT id, slug, title, duration_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, reminder_minutes, max_additional_guests, visibility
+    #[allow(clippy::type_complexity)]
+    let et: Option<(
+        String,
+        String,
+        String,
+        i32,
+        i32,
+        i32,
+        i32,
+        i32,
+        Option<i32>,
+        i32,
+        String,
+        bool,
+    )> = sqlx::query_as(
+        "SELECT id, slug, title, duration_min, buffer_before, buffer_after, min_notice_min, requires_confirmation, reminder_minutes, max_additional_guests, visibility, sms_notifications_enabled
          FROM event_types WHERE slug = ? AND enabled = 1",
     )
     .bind(&slug)
@@ -13817,11 +14141,50 @@ async fn handle_booking(
         reminder_min,
         max_additional_guests,
         visibility,
+        sms_notifications_enabled,
     ) = match et {
         Some(e) => e,
         None => return Html("Event type not found.".to_string()).into_response(),
     };
     let needs_approval = requires_confirmation != 0;
+
+    // Optional phone number, only meaningful (and only stored) when this
+    // event type opted into SMS notifications. A guest-posted phone value
+    // is silently dropped otherwise, so enabling/disabling SMS per event
+    // type can never leak a phone number nobody asked to collect.
+    let sms_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+
+    let phone_to_store: Option<String> = if sms_notifications_enabled {
+        match form
+            .phone
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            Some(raw) => match crate::sms::normalize_guest_phone(raw, &sms_default_country) {
+                Some(phone) => Some(phone),
+                None => {
+                    return render_booking_action_error(
+                        &state,
+                        &headers,
+                        "Invalid phone number",
+                        "Please enter a valid phone number.",
+                    );
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
 
     // Block non-public event types on legacy route
     if visibility == "private" || visibility == "internal" {
@@ -13972,8 +14335,8 @@ async fn handle_booking(
     };
 
     let insert_result = sqlx::query(
-        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language, assigned_resource_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, notes, start_at, end_at, status, cancel_token, reschedule_token, confirm_token, language, assigned_resource_id, phone_number)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&et_id)
@@ -13990,6 +14353,7 @@ async fn handle_booking(
     .bind(&confirm_token)
     .bind(lang)
     .bind(&assigned_resource_id)
+    .bind(&phone_to_store)
     .execute(&mut *tx)
     .await;
 
@@ -14136,7 +14500,23 @@ async fn handle_booking(
                 let _ = crate::email::send_host_notification(&smtp_config, &details).await;
             }
         }
+
     }
+
+    // Send booking SMS independently of the email/host notification path.
+    // Pending bookings are notified when they are approved.
+    send_booking_sms_if_enabled(
+        &state.pool,
+        &state.secret_key,
+        sms_notifications_enabled,
+        phone_to_store.as_deref(),
+        &id,
+        &et_title,
+        &form.date,
+        &form.time,
+        needs_approval,
+    )
+    .await;
 
     // Render confirmation
     let host_name: String = sqlx::query_scalar(
@@ -15109,6 +15489,47 @@ async fn admin_dashboard(
     // Flash banner after a "send test email" round-trip (?smtp_test=sent|error).
     let smtp_test_result = query.get("smtp_test").cloned().unwrap_or_default();
 
+    let (twilio_configured, twilio_account_sid, twilio_from_number, twilio_enabled, twilio_from_env, twilio_error) =
+        match crate::sms::load_twilio_status(&state.pool).await {
+            Ok(Some(status)) => (
+                true,
+                status.account_sid,
+                status.from_number,
+                status.enabled,
+                status.from_env,
+                String::new(),
+            ),
+            Ok(None) => (
+                false,
+                String::new(),
+                String::new(),
+                false,
+                false,
+                String::new(),
+            ),
+            Err(e) => (
+                false,
+                String::new(),
+                String::new(),
+                false,
+                true,
+                e.to_string(),
+            ),
+        };
+
+    let twilio_default_country: String = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT default_country_code FROM twilio_config LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .unwrap_or(None)
+    .flatten()
+    .filter(|s| crate::sms::is_valid_country_code(s))
+    .unwrap_or_else(|| "+1".to_string());
+
+    // Flash banner after a "send test SMS" round-trip (?twilio_test=sent|error).
+    let twilio_test_result = query.get("twilio_test").cloned().unwrap_or_default();
+
     let tmpl = match state.templates.get_template("admin.html") {
         Ok(t) => t,
         Err(e) => return internal_error_html("template render", &e),
@@ -15214,6 +15635,18 @@ async fn admin_dashboard(
             smtp_from_env => smtp_from_env,
             smtp_error => smtp_error,
             smtp_test_result => smtp_test_result,
+            twilio_configured => twilio_configured,
+            twilio_account_sid => twilio_account_sid,
+            twilio_from_number => twilio_from_number,
+            twilio_default_country => twilio_default_country,
+            sms_country_codes => crate::sms::COUNTRY_CODES
+                .iter()
+                .map(|(code, label)| context! { code => code, label => label })
+                .collect::<Vec<_>>(),
+            twilio_enabled => twilio_enabled,
+            twilio_from_env => twilio_from_env,
+            twilio_error => twilio_error,
+            twilio_test_result => twilio_test_result,
             captcha_configured => captcha_configured,
             captcha_instance_url => captcha_instance_url,
             captcha_site_key => captcha_site_key,
@@ -16562,6 +16995,220 @@ async fn admin_update_smtp_clear(
     Redirect::to("/dashboard/admin").into_response()
 }
 
+// --- Twilio (SMS) settings (database-backed, editable from the admin panel) ---
+//
+// Deliberately mirrors the SMTP settings above: env-var override, DB
+// singleton row, "keep current" pattern on the secret field, AES-256-GCM at
+// rest via crate::crypto. SMS is entirely opt-in: with no Twilio config, the
+// event-type toggle simply has nothing to send through, and the booking flow
+// behaves exactly as before.
+
+#[derive(Deserialize)]
+struct AdminTwilioForm {
+    _csrf: Option<String>,
+    account_sid: Option<String>,
+    /// Leave empty to keep the currently stored auth token (keep-current pattern).
+    auth_token: Option<String>,
+    from_number: Option<String>,
+    /// Default country calling code used to normalize guest-entered local phone numbers.
+    default_country_code: Option<String>,
+    /// HTML checkbox: present (any value) when checked, absent when unchecked.
+    enabled: Option<String>,
+}
+
+async fn admin_update_twilio(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminTwilioForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    // Defensive guard: when the env block governs, the DB config is shadowed
+    // and the UI form is locked. Refuse to write so the two channels never diverge.
+    if crate::sms::twilio_env_active() {
+        return Redirect::to("/dashboard/admin").into_response();
+    }
+
+    let redirect_err = |msg: &str| {
+        let encoded = urlencoding::encode(msg).into_owned();
+        Redirect::to(&format!("/dashboard/admin?error={}", encoded)).into_response()
+    };
+
+    let account_sid = form.account_sid.unwrap_or_default().trim().to_string();
+    if account_sid.is_empty() {
+        return redirect_err("Twilio Account SID is required.");
+    }
+
+    let from_number = form.from_number.unwrap_or_default().trim().to_string();
+    if !crate::sms::is_plausible_e164(&from_number) {
+        return redirect_err("Twilio 'from' number must be in international format, e.g. +15551234567.");
+    }
+
+    let enabled = form.enabled.is_some();
+    let default_country_code = form
+        .default_country_code
+        .unwrap_or_else(|| "+1".to_string());
+    if !crate::sms::is_valid_country_code(&default_country_code) {
+        return redirect_err("Invalid default country code.");
+    }
+
+    let auth_token = form.auth_token.unwrap_or_default();
+    let token_provided = !auth_token.trim().is_empty();
+
+    let existing: Option<(String,)> = match sqlx::query_as("SELECT id FROM twilio_config LIMIT 1")
+        .fetch_optional(&state.pool)
+        .await
+    {
+        Ok(row) => row,
+        Err(e) => return internal_error_response("check existing twilio config", &e),
+    };
+
+    let result = match existing {
+        Some((id,)) if token_provided => {
+            let auth_token_enc = match crate::crypto::encrypt_password(&state.secret_key, &auth_token) {
+                Ok(s) => s,
+                Err(e) => return internal_error_response("encrypt twilio auth token", &e),
+            };
+            sqlx::query(
+                "UPDATE twilio_config SET account_sid = ?, auth_token_enc = ?, from_number = ?, default_country_code = ?, enabled = ? WHERE id = ?",
+            )
+            .bind(&account_sid)
+            .bind(&auth_token_enc)
+            .bind(&from_number)
+            .bind(&default_country_code)
+            .bind(enabled)
+            .bind(&id)
+            .execute(&state.pool)
+            .await
+        }
+        Some((id,)) => {
+            // Keep-current: do not touch auth_token_enc.
+            sqlx::query(
+                "UPDATE twilio_config SET account_sid = ?, from_number = ?, default_country_code = ?, enabled = ? WHERE id = ?",
+            )
+            .bind(&account_sid)
+            .bind(&from_number)
+            .bind(&default_country_code)
+            .bind(enabled)
+            .bind(&id)
+            .execute(&state.pool)
+            .await
+        }
+        None => {
+            // Fresh config needs an auth token — there is nothing to keep.
+            if !token_provided {
+                return redirect_err(
+                    "An auth token is required when configuring Twilio for the first time.",
+                );
+            }
+            let auth_token_enc = match crate::crypto::encrypt_password(&state.secret_key, &auth_token) {
+                Ok(s) => s,
+                Err(e) => return internal_error_response("encrypt twilio auth token", &e),
+            };
+            sqlx::query(
+                "INSERT INTO twilio_config (id, account_sid, auth_token_enc, from_number, default_country_code, enabled) VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&account_sid)
+            .bind(&auth_token_enc)
+            .bind(&from_number)
+            .bind(&default_country_code)
+            .bind(enabled)
+            .execute(&state.pool)
+            .await
+        }
+    };
+
+    if let Err(e) = result {
+        return internal_error_response("save twilio config", &e);
+    }
+
+    tracing::info!(admin = %_admin.0.email, "admin: twilio config updated");
+    Redirect::to("/dashboard/admin").into_response()
+}
+
+#[derive(Deserialize)]
+struct AdminTwilioTestForm {
+    _csrf: Option<String>,
+    to: Option<String>,
+}
+
+async fn admin_update_twilio_test(
+    State(state): State<Arc<AppState>>,
+    admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminTwilioTestForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    let to = match form.to.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
+        Some(to) => to,
+        None => return Redirect::to("/dashboard/admin?twilio_test=error").into_response(),
+    };
+    if !crate::sms::is_plausible_e164(&to) {
+        return Redirect::to("/dashboard/admin?twilio_test=error").into_response();
+    }
+
+    let config = match crate::sms::load_twilio_config(&state.pool, &state.secret_key).await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            return Redirect::to("/dashboard/admin?twilio_test=error").into_response();
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "admin: twilio test could not load config");
+            return Redirect::to("/dashboard/admin?twilio_test=error").into_response();
+        }
+    };
+
+    match crate::sms::send_test_sms(&config, &to).await {
+        Ok(()) => {
+            tracing::info!(admin = %admin.0.email, %to, "admin: twilio test SMS sent");
+            Redirect::to("/dashboard/admin?twilio_test=sent").into_response()
+        }
+        Err(e) => {
+            tracing::warn!(admin = %admin.0.email, error = %e, "admin: twilio test SMS failed");
+            Redirect::to("/dashboard/admin?twilio_test=error").into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct AdminTwilioClearForm {
+    _csrf: Option<String>,
+}
+
+async fn admin_update_twilio_clear(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminUser,
+    headers: HeaderMap,
+    Form(form): Form<AdminTwilioClearForm>,
+) -> impl IntoResponse {
+    if let Err(resp) = verify_csrf_token(&headers, &form._csrf) {
+        return resp;
+    }
+
+    // Same guard as admin_update_twilio: when the env block governs, the DB
+    // config is shadowed and the UI hides this button — refuse the write defensively.
+    if crate::sms::twilio_env_active() {
+        return Redirect::to("/dashboard/admin").into_response();
+    }
+
+    if let Err(e) = sqlx::query("DELETE FROM twilio_config")
+        .execute(&state.pool)
+        .await
+    {
+        return internal_error_response("clear twilio config", &e);
+    }
+
+    tracing::info!(admin = %_admin.0.email, "admin: twilio config cleared");
+    Redirect::to("/dashboard/admin").into_response()
+}
+
 // --- Auto-generated meeting link settings ---
 
 #[derive(Deserialize)]
@@ -17031,9 +17678,10 @@ async fn approve_booking_by_token(
 ) -> impl IntoResponse {
     let lang = crate::i18n::detect_from_headers(&headers);
     // Look up booking by confirm_token
-    let booking: Option<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>, String)> =
+    #[allow(clippy::type_complexity)]
+    let booking: Option<(String, String, String, String, String, String, String, String, String, Option<String>, Option<String>, String, Option<String>, String, Option<String>, bool)> =
         sqlx::query_as(
-            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, a.user_id, u.name, et.location_value, b.cancel_token, COALESCE(b.guest_timezone, 'UTC'), b.reschedule_token, b.event_type_id
+            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, a.user_id, u.name, et.location_value, b.cancel_token, COALESCE(b.guest_timezone, 'UTC'), b.reschedule_token, b.event_type_id, b.phone_number, et.sms_notifications_enabled
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -17060,6 +17708,8 @@ async fn approve_booking_by_token(
         guest_timezone,
         reschedule_token,
         event_type_id,
+        phone_number,
+        sms_notifications_enabled,
     ) = match booking {
         Some(b) => b,
         None => {
@@ -17247,6 +17897,27 @@ async fn approve_booking_by_token(
         // Also send host a confirmation email (no ICS, event pushed via CalDAV)
         if let Err(e) = crate::email::send_host_booking_confirmed(&smtp_config, &details).await {
             tracing::error!(error = %e, host_email = %details.host_email, "host confirmation email failed");
+        }
+    }
+
+    // Send confirmation SMS to guest, now that the booking is confirmed.
+    if sms_notifications_enabled {
+        if let Some(phone) = &phone_number {
+            if let Ok(Some(twilio_config)) =
+                crate::sms::load_twilio_config(&state.pool, &state.secret_key).await
+            {
+                if let Err(e) = crate::sms::send_booking_confirmation_sms(
+                    &twilio_config,
+                    phone,
+                    &event_title,
+                    &date,
+                    &start_time,
+                )
+                .await
+                {
+                    tracing::warn!(booking_id = %bid, error = %e, "failed to send approval confirmation SMS");
+                }
+            }
         }
     }
 
@@ -17658,9 +18329,10 @@ async fn guest_cancel_booking(
         return resp;
     }
     let lang = crate::i18n::detect_from_headers(&headers);
-    let booking: Option<(String, String, String, String, String, String, String, String, String, String, String)> =
+    #[allow(clippy::type_complexity)]
+    let booking: Option<(String, String, String, String, String, String, String, String, String, String, String, Option<String>, bool)> =
         sqlx::query_as(
-            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), COALESCE(b.guest_timezone, 'UTC'), et.id
+            "SELECT b.id, b.uid, b.guest_name, b.guest_email, b.start_at, b.end_at, et.title, u.name, COALESCE(u.booking_email, u.email), COALESCE(b.guest_timezone, 'UTC'), et.id, b.phone_number, et.sms_notifications_enabled
              FROM bookings b
              JOIN event_types et ON et.id = b.event_type_id
              JOIN accounts a ON a.id = et.account_id
@@ -17684,6 +18356,8 @@ async fn guest_cancel_booking(
         host_email,
         guest_timezone,
         et_id,
+        phone_number,
+        sms_notifications_enabled,
     ) = match booking {
         Some(b) => b,
         None => {
@@ -17779,6 +18453,27 @@ async fn guest_cancel_booking(
 
         let _ = crate::email::send_guest_cancellation(&smtp_config, &details).await;
         let _ = crate::email::send_host_cancellation(&smtp_config, &details).await;
+    }
+
+    // Send cancellation SMS to guest, independent of SMTP.
+    if sms_notifications_enabled {
+        if let Some(phone) = &phone_number {
+            if let Ok(Some(twilio_config)) =
+                crate::sms::load_twilio_config(&state.pool, &state.secret_key).await
+            {
+                if let Err(e) = crate::sms::send_cancellation_sms(
+                    &twilio_config,
+                    phone,
+                    &event_title,
+                    &date,
+                    &start_time,
+                )
+                .await
+                {
+                    tracing::warn!(booking_id = %bid, error = %e, "failed to send guest cancellation SMS");
+                }
+            }
+        }
     }
 
     let tmpl = match state.templates.get_template("booking_cancelled_guest.html") {
@@ -29052,6 +29747,41 @@ mod tests {
         assert!(
             body.contains("Pending Guest"),
             "Pending bookings should appear in pending approval section"
+        );
+    }
+
+    // --- Upcoming bookings include guest phone when SMS notifications are enabled ---
+
+    #[tokio::test]
+    async fn dashboard_bookings_shows_guest_phone_for_sms_booking() {
+        let (app, pool, session, et_id) = setup_test_app().await;
+
+        sqlx::query("UPDATE event_types SET sms_notifications_enabled = 1 WHERE id = ?")
+            .bind(&et_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let booking_id = uuid::Uuid::new_v4().to_string();
+        let cancel_tok = uuid::Uuid::new_v4().to_string();
+        let resched_tok = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO bookings (id, event_type_id, uid, guest_name, guest_email, guest_timezone, start_at, end_at, status, cancel_token, reschedule_token, phone_number) VALUES (?, ?, 'uid-phone-dash', 'Phone Guest', 'phone-dash@test.com', 'UTC', '2030-06-15T10:00:00', '2030-06-15T10:30:00', 'confirmed', ?, ?, '+15550000001')")
+            .bind(&booking_id)
+            .bind(&et_id)
+            .bind(&cancel_tok)
+            .bind(&resched_tok)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(get_authed("/dashboard/bookings", &session))
+            .await
+            .unwrap();
+        let body = body_string(response).await;
+        assert!(
+            body.contains("Phone Guest") && body.contains("+15550000001"),
+            "Upcoming booking should display the guest phone number when SMS is enabled"
         );
     }
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -736,6 +736,91 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
   {% endif %}
 </div>
 
+<!-- Twilio (SMS) settings -->
+<div class="card">
+  <h2>SMS settings (Twilio)</h2>
+  <p style="color: var(--text-muted); font-size: 0.85rem; margin-top: -0.5rem; margin-bottom: 1rem;">
+    Optional. SMS is only sent for bookings on event types where "SMS notifications" is turned on, and only when the guest left a phone number.
+  </p>
+
+  {% if twilio_test_result == "sent" %}
+  <p style="color: var(--success); font-size: 0.875rem;">✓ Test SMS sent.</p>
+  {% elif twilio_test_result == "error" %}
+  <p style="color: var(--error-text); font-size: 0.875rem;">✗ Test SMS could not be sent. Check the server logs and your Twilio settings.</p>
+  {% endif %}
+
+  {% if twilio_error %}
+  <p style="color: var(--error-text); font-size: 0.875rem;">Twilio environment configuration error: {{ twilio_error }}</p>
+  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 0.75rem;">Fix the <code>CALRS_TWILIO_*</code> environment variables, or unset them to manage SMS from the database here.</p>
+
+  {% elif twilio_from_env %}
+  <div style="border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.85rem; color: var(--text-secondary);">
+    Managed via <strong>environment variables</strong> (overrides the database). Edit the <code>CALRS_TWILIO_*</code> variables to change it, or unset them to manage SMS from here.
+  </div>
+  <div style="font-size: 0.875rem; color: var(--text-secondary); line-height: 1.8;">
+    <div>Status: <strong style="color: var(--success);">configured</strong>{% if not twilio_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %} <span style="color: var(--text-muted);">(via environment)</span></div>
+    <div>Account SID: <span style="color: var(--text-muted);">{{ twilio_account_sid }}</span></div>
+    <div>From number: <span style="color: var(--text-muted);">{{ twilio_from_number }}</span></div>
+  </div>
+  <form method="post" action="/dashboard/admin/twilio/test" style="margin-top: 1rem;">
+    <div class="form-group">
+      <label>Send a test SMS to <span class="hint">(E.164 format)</span></label>
+      <input type="text" name="to" value="" placeholder="+15551234567">
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600;">Send test SMS</button>
+  </form>
+
+  {% else %}
+  <div style="margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
+    Status: {% if twilio_configured %}<strong style="color: var(--success);">configured</strong>{% if not twilio_enabled %} <span style="color: var(--error-text);">(disabled)</span>{% endif %}{% else %}<span style="color: var(--text-muted);">not configured</span>{% endif %}
+  </div>
+  <form method="post" action="/dashboard/admin/twilio">
+    <div style="margin-bottom: 1rem;">
+      <label style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.925rem; cursor: pointer;">
+        <input type="checkbox" name="enabled" value="on" {% if twilio_enabled or not twilio_configured %}checked{% endif %} style="width: 1rem; height: 1rem;">
+        SMS enabled
+      </label>
+    </div>
+    <div class="form-group">
+      <label>Account SID</label>
+      <input type="text" name="account_sid" value="{{ twilio_account_sid }}" placeholder="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" required>
+    </div>
+    <div class="form-group">
+      <label>Auth token <span class="hint">(leave empty to keep current)</span></label>
+      <input type="password" name="auth_token" value="" placeholder="Leave empty to keep unchanged">
+    </div>
+    <div class="form-group">
+      <label>From number <span class="hint">(your Twilio number, E.164)</span></label>
+      <input type="text" name="from_number" value="{{ twilio_from_number }}" placeholder="+15551234567" required>
+    </div>
+    <div style="margin-top: 1rem;">
+      <label>Default country code <span class="hint">(used when guests enter a local phone number)</span></label>
+      <select name="default_country_code" style="width: 100%;">
+        {% for country in sms_country_codes %}
+        <option value="{{ country.code }}" {% if twilio_default_country == country.code %}selected{% endif %}>{{ country.label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600; color: var(--accent); border-color: var(--accent);">Save SMS settings</button>
+  </form>
+
+  {% if twilio_configured %}
+  <form method="post" action="/dashboard/admin/twilio/test" style="margin-top: 1.25rem;">
+    <div class="form-group">
+      <label>Send a test SMS to <span class="hint">(E.164 format)</span></label>
+      <input type="text" name="to" value="" placeholder="+15551234567">
+    </div>
+    <button type="submit" class="slot-btn" style="cursor: pointer; font-weight: 600;">Send test SMS</button>
+  </form>
+  <form method="post" action="/dashboard/admin/twilio/clear" style="margin-top: 1rem;" onsubmit="return confirm('Delete the database Twilio configuration?');">
+    <button type="submit" class="slot-btn" style="cursor: pointer; color: var(--error-text); border-color: var(--error-text);">Clear database config</button>
+  </form>
+  {% endif %}
+
+  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 1rem;">Alternatively, configure via environment variables (which override this): <code>CALRS_TWILIO_ACCOUNT_SID</code>, <code>CALRS_TWILIO_AUTH_TOKEN</code>, <code>CALRS_TWILIO_FROM_NUMBER</code>.</p>
+  {% endif %}
+</div>
+
 <script>
 (function() {
   var USER_PAGE_SIZE = 5;

--- a/templates/book.html
+++ b/templates/book.html
@@ -55,6 +55,35 @@
       <label for="email">{{ t("book-email-label") }}</label>
       <input type="email" id="email" name="email" required maxlength="255" value="{{ form_email }}" placeholder="{{ t('book-email-placeholder') }}" pattern="[^@\s]+@[^@\s]+\.[^@\s]{2,}" title="{{ t('book-email-invalid') }}">
     </div>
+
+    {% if sms_notifications_enabled %}
+    <div class="form-group">
+      <label for="phone">Phone number</label>
+      <input type="tel" id="phone" name="phone" maxlength="20" value="{{ form_phone }}" placeholder="+XXXXXXXXXXX" title="Enter your phone number in international format (e.g. +XXXXXXXXXXX) or local format">
+    </div>
+    <script>
+    (function() {
+      var phoneInput = document.getElementById('phone');
+      var prefix = {{ phone_default_country | tojson }};
+      if (!phoneInput || !prefix) return;
+      // Strip the country calling code prefix if the user pastes/types it,
+      // so that normalize_guest_phone on the server always gets a clean local number
+      // (server-side normalization handles both 0XXXXXXXX and XXXXXXXX forms).
+      phoneInput.addEventListener('input', function() {
+        var val = phoneInput.value.trim();
+        // Remove leading + prefix variant (e.g. +1555... → 0555...)
+        if (val.startsWith(prefix)) {
+          phoneInput.value = '0' + val.slice(prefix.length);
+        }
+        // Remove 00-prefixed international form (e.g. 001555... → 0555...)
+        var oo = '00' + prefix.replace(/^\+/, '');
+        if (val.startsWith(oo)) {
+          phoneInput.value = '0' + val.slice(oo.length);
+        }
+      });
+    })();
+    </script>
+    {% endif %}
     <script>
     (function() {
       var email = document.getElementById('email');

--- a/templates/book.html
+++ b/templates/book.html
@@ -61,28 +61,6 @@
       <label for="phone">Phone number</label>
       <input type="tel" id="phone" name="phone" maxlength="20" value="{{ form_phone }}" placeholder="+XXXXXXXXXXX" title="Enter your phone number in international format (e.g. +XXXXXXXXXXX) or local format">
     </div>
-    <script>
-    (function() {
-      var phoneInput = document.getElementById('phone');
-      var prefix = {{ phone_default_country | tojson }};
-      if (!phoneInput || !prefix) return;
-      // Strip the country calling code prefix if the user pastes/types it,
-      // so that normalize_guest_phone on the server always gets a clean local number
-      // (server-side normalization handles both 0XXXXXXXX and XXXXXXXX forms).
-      phoneInput.addEventListener('input', function() {
-        var val = phoneInput.value.trim();
-        // Remove leading + prefix variant (e.g. +1555... → 0555...)
-        if (val.startsWith(prefix)) {
-          phoneInput.value = '0' + val.slice(prefix.length);
-        }
-        // Remove 00-prefixed international form (e.g. 001555... → 0555...)
-        var oo = '00' + prefix.replace(/^\+/, '');
-        if (val.startsWith(oo)) {
-          phoneInput.value = '0' + val.slice(oo.length);
-        }
-      });
-    })();
-    </script>
     {% endif %}
     <script>
     (function() {

--- a/templates/dashboard_bookings.html
+++ b/templates/dashboard_bookings.html
@@ -64,7 +64,9 @@
             <span class="badge badge-warning" style="margin-left: 0.25rem;">awaiting reschedule</span>
           {% endif %}
         </div>
-        <div style="color: var(--text-muted); font-size: 0.85rem;">{{ b.start_at }} &middot; {{ b.guest_email }}</div>
+        <div style="color: var(--text-muted); font-size: 0.85rem;">
+          {{ b.start_at }} &middot; {{ b.guest_email }}{% if b.guest_phone %} &middot; {{ b.guest_phone }}{% endif %}
+        </div>
         {% if b.start_at_guest %}<div style="color: var(--text-muted); font-size: 0.75rem;">Guest booked: {{ b.start_at_guest }}</div>{% endif %}
         {% if b.resource_name %}<div style="color: var(--text-muted); font-size: 0.75rem;">Resource: {{ b.resource_name }}</div>{% endif %}
       </div>

--- a/templates/event_type_form.html
+++ b/templates/event_type_form.html
@@ -439,6 +439,14 @@
       </div>
     </label>
 
+    <label style="display: flex; align-items: center; gap: 0.625rem; cursor: pointer; padding: 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); transition: all 0.15s ease; margin-top: 0.5rem;">
+      <input type="checkbox" name="sms_notifications_enabled" {% if form_sms_notifications_enabled %}checked{% endif %} style="accent-color: var(--accent); width: 1.125rem; height: 1.125rem;">
+      <div>
+        <strong style="font-size: 0.925rem;">SMS notifications</strong>
+        <div style="color: var(--text-muted); font-size: 0.825rem;">Adds an optional phone number field to the booking form and sends SMS updates via Twilio, in addition to email. Requires Twilio to be configured in the admin panel.</div>
+      </div>
+    </label>
+
     <div class="form-group" style="margin-top: 0.75rem;">
       <label for="max_additional_guests">Additional guests</label>
       <select id="max_additional_guests" name="max_additional_guests" style="padding: 0.625rem 0.75rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.925rem; font-family: inherit; background: var(--surface); color: var(--text); width: 100%;">


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>SMS Notifications via Twilio</h1><p>Adds opt-in SMS booking notifications through the Twilio REST API, following the existing SMTP pattern throughout the codebase.</p><h2>What this does</h2><ul><li><p><strong>Per-event-type opt-in</strong> — Adds an <strong>SMS notifications</strong> checkbox to the event type form, enabling SMS notifications only for that event type. Existing event types default to disabled, so there is no behaviour change for existing installations.</p></li><li><p><strong>Guest phone number</strong> — When SMS notifications are enabled for an event type, the booking form displays an optional phone number field. The guest's number is normalised to E.164 format on the server.</p></li><li><p><strong>SMS notifications</strong> — Sends notifications for:</p><ul><li><p>Booking confirmation (or after approval for pending bookings)</p></li><li><p>Host-initiated cancellation</p></li><li><p>Guest-initiated cancellation</p></li></ul></li><li><p><strong>Admin panel</strong> — Adds an <strong>SMS settings (Twilio)</strong> section where administrators can configure:</p><ul><li><p>Twilio Account SID</p></li><li><p>Twilio Auth Token</p></li><li><p>From number</p></li><li><p>Default country code for normalising locally formatted guest numbers</p></li></ul></li><li><p><strong>Environment variable override</strong> — <code inline="">CALRS_TWILIO_ACCOUNT_SID</code>, <code inline="">CALRS_TWILIO_AUTH_TOKEN</code>, and <code inline="">CALRS_TWILIO_FROM_NUMBER</code> override the database configuration, following the same <strong>"full block wins"</strong> semantics as <code inline="">CALRS_SMTP_*</code>. The admin form is locked while the environment-variable configuration is active.</p></li><li><p><strong>Dashboard bookings</strong> — Displays the guest's phone number inline next to their email address when SMS is enabled for that booking.</p></li></ul><h2>Files changed</h2>
File | Change
-- | --
src/sms.rs | New module — Twilio REST client, phone number normalisation, and country code list
migrations/062_sms_notifications.sql | Adds phone_number to bookings, sms_notifications_enabled to event_types, and the twilio_config table
migrations/063_sms_default_country_code.sql | Adds default_country_code to twilio_config
src/db.rs | Registers migrations 062 and 063
src/main.rs | Adds mod sms
src/models.rs | Adds sms_notifications_enabled to EventType and phone_number to Booking
src/web/mod.rs | Adds Twilio admin routes and extends booking/cancellation/approval flows with SMS
templates/admin.html | Adds Twilio configuration UI
templates/book.html | Adds optional phone number field, shown only when SMS is enabled
templates/dashboard_bookings.html | Displays the guest phone number next to their email
templates/event_type_form.html | Adds the SMS notifications checkbox

<h2>Design decisions</h2><h3>No new Cargo dependencies</h3><p>Twilio's REST API is plain HTTPS, so the implementation reuses the existing <code inline="">reqwest</code> client already used for CalDAV instead of adding a Twilio SDK.</p><h3>Purely opt-in, zero default behaviour change</h3><p><code inline="">sms_notifications_enabled</code> defaults to <code inline="">0</code>, and <code inline="">phone_number</code> is nullable. Installations with no Twilio configuration and no event types configured for SMS behave exactly as before.</p><h3>Auth token encrypted at rest</h3><p>The Twilio auth token uses the existing <code inline="">crate::crypto</code> implementation (AES-256-GCM), the same mechanism used for SMTP passwords.</p><h3>Pending bookings</h3><p>SMS notifications are deferred until a pending booking is approved, matching the existing email notification behaviour.</p><h3>Phone number normalisation</h3><ul><li><p>Local numbers starting with <code inline="">0</code> are converted to <code inline="">+&lt;country_code&gt;&lt;number&gt;</code> using the admin-configured default country code.</p></li><li><p>International numbers starting with <code inline="">+</code> are passed through unchanged.</p></li><li><p>Numbers using the <code inline="">00</code> international prefix are passed through unchanged.</p></li></ul><h2>Testing</h2><ul><li><p><strong>Unit tests</strong> in <code inline="">sms.rs</code> cover:</p><ul><li><p>E.164 validation</p></li><li><p>Environment-variable block detection</p></li></ul></li><li><p><strong>Integration test</strong> <code inline="">dashboard_bookings_shows_guest_phone_for_sms_booking</code> in <code inline="">web/mod.rs</code> verifies that the guest's phone number is displayed in the bookings dashboard when SMS is enabled.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional SMS notifications for booking confirmations, cancellations, approvals, and host cancellations.
  - Added administrator controls for SMS setup, enablement, default country code, test messages, and configuration clearing.
  - Added event-level SMS opt-in settings.
  - Booking forms now accept optional phone numbers with validation and normalization.
  - Dashboards display guest phone numbers when available.
  - Added support for environment-managed SMS configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->