### PR TITLE
feat(dashboard): add copy link button for event types

### DIFF
--- a/i18n/en/main.ftl
+++ b/i18n/en/main.ftl
@@ -266,3 +266,10 @@ confirmed-reschedule-notice-info = Rescheduling requires at least { $minutes } m
 booking-blocked-title-cancel = This booking can no longer be cancelled online
 booking-blocked-title-reschedule = This booking can no longer be rescheduled online
 booking-blocked-body = The host requires at least { $minutes } minutes of notice. If you cannot attend, please email <a href="mailto:{ $host_email }">{ $host_email }</a> directly.
+
+# Dashboard event types listing (templates/dashboard_event_types.html)
+
+dashboard-event-types-copy = Copy
+dashboard-event-types-copied = Copied!
+dashboard-event-types-copy-title = Copy booking link
+dashboard-event-types-copy-failed = Copy failed

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1750,8 +1750,10 @@ async fn dashboard(
 async fn dashboard_event_types(
     State(state): State<Arc<AppState>>,
     auth_user: crate::auth::AuthUser,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
     let user = &auth_user.user;
+    let lang = crate::i18n::resolve(user.language.as_deref(), &headers);
 
     let event_types: Vec<(String, String, String, i32, bool, i32, i64, String)> = sqlx::query_as(
         "SELECT et.id, et.slug, et.title, et.duration_min, et.enabled, et.requires_confirmation,
@@ -1916,6 +1918,7 @@ async fn dashboard_event_types(
             can_create_team_et => can_create_team_et,
             impersonating => impersonating,
             impersonating_name => impersonating_name,
+            lang => lang,
         })
         .unwrap_or_else(|e| internal_error_body("template render", &e)),
     )

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -38,7 +38,7 @@
         </div>
       </div>
       <div class="et-actions">
-        <button type="button" class="slot-btn copy-link-btn" style="font-size: 0.8rem; cursor: pointer;" title="Copy booking link" data-path="/{% if et.is_team %}team/{{ et.team_slug }}{% else %}u/{{ username }}{% endif %}/{{ et.slug }}">Copy</button>
+        <button type="button" class="slot-btn copy-link-btn" style="font-size: 0.8rem; cursor: pointer;" title="{{ t('dashboard-event-types-copy-title') }}" data-copy-label="{{ t('dashboard-event-types-copy') }}" data-copied-label="{{ t('dashboard-event-types-copied') }}" data-copy-failed-label="{{ t('dashboard-event-types-copy-failed') }}" data-path="/{% if et.is_team %}team/{{ et.team_slug }}{% else %}u/{{ username }}{% endif %}/{{ et.slug }}">{{ t('dashboard-event-types-copy') }}</button>
         {% if et.can_manage %}
         <a href="{{ et.edit_url }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Edit</a>
         <form method="post" action="{{ et.toggle_url }}" style="margin: 0;">
@@ -83,11 +83,37 @@ document.addEventListener('click', function(e) {
   var copyBtn = e.target.closest('.copy-link-btn');
   if (copyBtn) {
     var url = window.location.origin + copyBtn.dataset.path;
-    navigator.clipboard.writeText(url).then(function() {
-      copyBtn.textContent = 'Copied!';
+    function flashCopied() {
+      copyBtn.textContent = copyBtn.dataset.copiedLabel;
       copyBtn.classList.add('copied');
-      setTimeout(function() { copyBtn.textContent = 'Copy'; copyBtn.classList.remove('copied'); }, 1500);
-    });
+      setTimeout(function() { copyBtn.textContent = copyBtn.dataset.copyLabel; copyBtn.classList.remove('copied'); }, 1500);
+    }
+    function flashFailed() {
+      copyBtn.textContent = copyBtn.dataset.copyFailedLabel;
+      copyBtn.classList.remove('copied');
+      setTimeout(function() { copyBtn.textContent = copyBtn.dataset.copyLabel; }, 1500);
+    }
+    function fallbackCopy() {
+      var ta = document.createElement('textarea');
+      ta.value = url;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        if (document.execCommand('copy')) flashCopied();
+        else flashFailed();
+      } catch (err) {
+        flashFailed();
+      }
+      ta.remove();
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(flashCopied, fallbackCopy);
+    } else {
+      fallbackCopy();
+    }
     return;
   }
   var btn = e.target.closest('.action-menu-toggle');

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -83,17 +83,33 @@ document.addEventListener('click', function(e) {
   var copyBtn = e.target.closest('.copy-link-btn');
   if (copyBtn) {
     var url = window.location.origin + copyBtn.dataset.path;
+    copyBtn._copyGen = (copyBtn._copyGen || 0) + 1;
+    var gen = copyBtn._copyGen;
+    if (copyBtn._copyTimer) {
+      clearTimeout(copyBtn._copyTimer);
+      copyBtn._copyTimer = null;
+    }
+    function stillCurrent() { return copyBtn._copyGen === gen; }
+    function restoreLabel() {
+      if (!stillCurrent()) return;
+      copyBtn.textContent = copyBtn.dataset.copyLabel;
+      copyBtn.classList.remove('copied');
+      copyBtn._copyTimer = null;
+    }
     function flashCopied() {
+      if (!stillCurrent()) return;
       copyBtn.textContent = copyBtn.dataset.copiedLabel;
       copyBtn.classList.add('copied');
-      setTimeout(function() { copyBtn.textContent = copyBtn.dataset.copyLabel; copyBtn.classList.remove('copied'); }, 1500);
+      copyBtn._copyTimer = setTimeout(restoreLabel, 1500);
     }
     function flashFailed() {
+      if (!stillCurrent()) return;
       copyBtn.textContent = copyBtn.dataset.copyFailedLabel;
       copyBtn.classList.remove('copied');
-      setTimeout(function() { copyBtn.textContent = copyBtn.dataset.copyLabel; }, 1500);
+      copyBtn._copyTimer = setTimeout(restoreLabel, 1500);
     }
     function fallbackCopy() {
+      if (!stillCurrent()) return;
       var ta = document.createElement('textarea');
       ta.value = url;
       ta.setAttribute('readonly', '');

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -9,6 +9,7 @@
 .action-menu-dropdown a:hover, .action-menu-dropdown button:hover { background: var(--surface-hover); }
 .action-menu-dropdown .danger { color: var(--error-text); }
 .et-meta { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.15rem; }
+.copy-link-btn.copied { color: var(--success) !important; border-color: var(--success) !important; }
 </style>
 <div class="card">
   <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
@@ -37,6 +38,7 @@
         </div>
       </div>
       <div class="et-actions">
+        <button type="button" class="slot-btn copy-link-btn" style="font-size: 0.8rem; cursor: pointer;" title="Copy booking link" data-path="/{% if et.is_team %}team/{{ et.team_slug }}{% else %}u/{{ username }}{% endif %}/{{ et.slug }}">Copy</button>
         {% if et.can_manage %}
         <a href="{{ et.edit_url }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Edit</a>
         <form method="post" action="{{ et.toggle_url }}" style="margin: 0;">
@@ -78,6 +80,16 @@
 
 <script>
 document.addEventListener('click', function(e) {
+  var copyBtn = e.target.closest('.copy-link-btn');
+  if (copyBtn) {
+    var url = window.location.origin + copyBtn.dataset.path;
+    navigator.clipboard.writeText(url).then(function() {
+      copyBtn.textContent = 'Copied!';
+      copyBtn.classList.add('copied');
+      setTimeout(function() { copyBtn.textContent = 'Copy'; copyBtn.classList.remove('copied'); }, 1500);
+    });
+    return;
+  }
   var btn = e.target.closest('.action-menu-toggle');
   if (btn) {
     e.stopPropagation();


### PR DESCRIPTION
Introduced a new button to copy the booking link for event types, enhancing user experience. The button updates its text to 'Copied!' upon successful copy action, providing immediate feedback. Styles have been adjusted to reflect the copied state. This feature aims to streamline the process of sharing booking links (quickly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-link buttons to event type rows.
  * Clicking a button copies the event’s booking URL and shows temporary success or failure feedback.
  * Added compatibility support for browsers without the Clipboard API.
  * Added localized labels, tooltips, and messages for copy-link actions.
  * Confirmation and failure states automatically return to the default label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->