### PR TITLE
fix(slots): back arrow on the first month, and a fail-open negative horizon

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -13360,7 +13360,7 @@ async fn get_booking_horizon(pool: &SqlitePool, et_id: &str) -> Option<i32> {
 /// `None` horizon means unlimited, so no date is ever past it. A horizon that
 /// runs off the end of the representable calendar is unlimited for the same
 /// reason, so `checked_add_signed` degrades to `None` rather than panicking
-/// (`NaiveDate + TimeDelta` panics on overflow) — the day loop in
+/// (`NaiveDate + TimeDelta` panics on overflow). The day loop in
 /// `compute_slots_from_rules` treats such a horizon as unreachable too.
 fn horizon_last_date(now_host: NaiveDateTime, horizon: Option<i32>) -> Option<NaiveDate> {
     horizon.and_then(|days| {
@@ -27026,6 +27026,90 @@ mod tests {
         assert!(
             body_start < slots_outer_start,
             "Reschedule banner div must appear before slots-outer div to avoid flex layout breakage"
+        );
+    }
+
+    /// Render slots.html on the first bookable month, where the handler passes
+    /// `prev_month` as `None`, and verify the calendar payload carries an empty
+    /// string rather than the literal "none".
+    ///
+    /// Regression test for the same class as the `default(value='')` bug above:
+    /// minijinja renders a Rust `None` as "none", and `default()` does not
+    /// catch it because the value is defined, just none. The JS guard then saw
+    /// a truthy "none" and drew a back arrow pointing at ?month=none.
+    #[test]
+    fn slots_template_renders_absent_prev_month_as_empty() {
+        let mut env = minijinja::Environment::new();
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
+        env.set_loader(minijinja::path_loader("templates"));
+        crate::i18n::register(&mut env);
+        let tmpl = env
+            .get_template("slots.html")
+            .expect("slots.html should load");
+
+        // Exactly what build_month_params hands the template.
+        let render = |prev: Option<String>| {
+            tmpl.render(context! {
+                event_type => context! { slug => "intro", title => "Intro Call", duration_min => 30 },
+                host_name => "Alice",
+                username => "alice",
+                days => Vec::<minijinja::Value>::new(),
+                available_dates => Vec::<String>::new(),
+                month_label => "March 2026",
+                month_year => "2026-03",
+                prev_month => prev,
+                next_month => Some("2026-04".to_string()),
+                first_weekday => 0,
+                days_in_month => 31,
+                today_date => "2026-03-14",
+                guest_tz => "UTC",
+            })
+            .expect("slots.html should render")
+        };
+        let payload_line = |rendered: &str, key: &str| {
+            rendered
+                .lines()
+                .find(|l| l.contains(&format!("\"{key}\"")))
+                .unwrap_or_else(|| panic!("the calendar payload must carry {key}"))
+                .trim()
+                .to_string()
+        };
+
+        let first_month = render(None);
+        assert_eq!(
+            payload_line(&first_month, "prevMonth"),
+            "\"prevMonth\": \"\",",
+            "an absent previous month must serialise as an empty string, not \"none\""
+        );
+        assert!(
+            first_month.contains("\"hasPrevMonth\": false"),
+            "hasPrevMonth must be false when there is no previous month"
+        );
+
+        // Control: a previous month that does exist must still come through,
+        // so this cannot pass by blanking prevMonth unconditionally.
+        let later_month = render(Some("2026-02".to_string()));
+        assert_eq!(
+            payload_line(&later_month, "prevMonth"),
+            "\"prevMonth\": \"2026-02\","
+        );
+        assert!(
+            later_month.contains("\"hasPrevMonth\": true"),
+            "hasPrevMonth must be true when a previous month exists"
+        );
+
+        // The forward arrow is the already-correct sibling: same construct,
+        // unchanged by this fix, asserted so the two stay in step.
+        assert_eq!(
+            payload_line(&first_month, "nextMonth"),
+            "\"nextMonth\": \"2026-04\","
+        );
+
+        // The AJAX path must gate on the flag, matching the forward arrow,
+        // so a future regression in the payload cannot resurrect the arrow.
+        assert!(
+            first_month.contains("if (data.hasPrevMonth && data.prevMonth)"),
+            "the AJAX back arrow must gate on hasPrevMonth, as the forward arrow does"
         );
     }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -13362,11 +13362,19 @@ async fn get_booking_horizon(pool: &SqlitePool, et_id: &str) -> Option<i32> {
 /// reason, so `checked_add_signed` degrades to `None` rather than panicking
 /// (`NaiveDate + TimeDelta` panics on overflow). The day loop in
 /// `compute_slots_from_rules` treats such a horizon as unreachable too.
+///
+/// A negative horizon is only reachable by writing the column directly, since
+/// `parse_optional_day_count` rejects one. It has to mean "nothing bookable",
+/// so it is clamped to yesterday. Left to the arithmetic, a large negative
+/// overflows to `None` and reads as unlimited, which is the wrong direction
+/// to fail in.
 fn horizon_last_date(now_host: NaiveDateTime, horizon: Option<i32>) -> Option<NaiveDate> {
     horizon.and_then(|days| {
-        now_host
-            .date()
-            .checked_add_signed(Duration::days(days as i64))
+        let date = now_host.date();
+        if days < 0 {
+            return date.pred_opt();
+        }
+        date.checked_add_signed(Duration::days(days as i64))
     })
 }
 
@@ -32329,6 +32337,34 @@ mod tests {
         let (_, _, _, _, unbounded, _, _, _, _) =
             build_month_params(today.year(), today.month(), Tz::UTC, Tz::UTC, "en", None);
         assert!(unbounded.is_some(), "NULL horizon keeps the link");
+    }
+
+    #[test]
+    fn horizon_last_date_fails_closed_on_a_negative_horizon() {
+        // parse_optional_day_count rejects negatives, so the column can only
+        // hold one if it is written directly. However it gets there, it must
+        // block every date rather than read as unlimited.
+        //
+        // Small negatives always did, because the arithmetic lands in the past
+        // on its own. A large one overflowed the representable calendar and
+        // returned None, which every caller treats as "no limit": the wrong
+        // direction to fail in, and the case this pins.
+        let now = host_today().and_hms_opt(9, 0, 0).unwrap();
+        let today = now.date();
+
+        assert_eq!(
+            parse_optional_day_count("-5"),
+            None,
+            "the form must never store a negative horizon in the first place"
+        );
+
+        for days in [-1, -400, -95_000_000, i32::MIN + 1, i32::MIN] {
+            let last = horizon_last_date(now, Some(days));
+            assert!(
+                last.is_some_and(|last| today > last),
+                "a negative horizon ({days}) must leave today itself unbookable, got {last:?}"
+            );
+        }
     }
 
     #[test]

--- a/templates/slots.html
+++ b/templates/slots.html
@@ -806,7 +806,7 @@
     "monthYear": "{{ month_year }}",
     "monthLabel": "{{ month_label }}",
     "hasPrevMonth": {% if prev_month is defined and prev_month %}true{% else %}false{% endif %},
-    "prevMonth": "{{ prev_month | default(value='') }}",
+    "prevMonth": "{% if prev_month is defined and prev_month %}{{ prev_month }}{% endif %}",
     "hasNextMonth": {% if next_month is defined and next_month %}true{% else %}false{% endif %},
     "nextMonth": "{% if next_month is defined and next_month %}{{ next_month }}{% endif %}",
     "defaultCalendarView": "{{ default_calendar_view | default(value='month') }}",
@@ -1214,7 +1214,7 @@
     var nav = document.getElementById('main-cal-nav');
     if (!nav) return;
     nav.innerHTML = '';
-    if (data.prevMonth) {
+    if (data.hasPrevMonth && data.prevMonth) {
       var prevUrl = basePath + '?month=' + data.prevMonth;
       if (guestTz) prevUrl += '&tz=' + encodeURIComponent(guestTz);
       if (inviteToken) prevUrl += '&invite=' + encodeURIComponent(inviteToken);


### PR DESCRIPTION
Two small fixes found while reviewing #186, neither of them part of that feature.

## 1. An absent previous month rendered as the literal string `"none"`

minijinja renders a Rust `None` as `"none"`, and `| default(value='')` does not catch it, because the value is *defined*, just none. So on the first bookable month the calendar payload carried:

```json
"prevMonth": "none",
```

and the AJAX guard was `if (data.prevMonth)`, which is truthy for `"none"`. After navigating months, the back arrow appeared where it should not and linked to `?month=none`.

The server-rendered path was always fine, since `{% if prev_month %}` treats `None` as falsy. Only the JSON payload feeding the AJAX path was wrong, which is why it only showed after a month navigation. `parse_month_param` falls back to the current month, so the arrow was cosmetic rather than broken.

The payload fix is the actual repair: an empty string is falsy, so the existing guard then behaves. Gating on `hasPrevMonth` as well keeps the back arrow symmetric with the forward arrow, which #186 already did correctly.

This is the same class as the earlier `default(value='')` regression already covered by `slots_template_links_without_reschedule_context`. I swept the other seven `default(value=)` sites in the templates: `guest_date` is a `String` and the rest resolve to `&str` via `unwrap_or`, so `prev_month` was the only `Option` reaching one.

## 2. A negative booking horizon failed open

`horizon_last_date()` derived the last bookable date with checked arithmetic, so a horizon large enough in magnitude ran off the representable calendar and returned `None`. Every caller reads `None` as "no limit", so a sufficiently negative horizon unlocked booking instead of blocking it.

Small negatives were never affected, since the arithmetic lands in the past on its own and that already blocks every date. Only the overflow case pointed the wrong way, and only from roughly -95,000,000 days.

`parse_optional_day_count()` rejects negatives, so the column can only hold one if written directly with SQL. This is defence in depth rather than a reachable bug, but "unlimited" is the wrong way for a spend-adjacent guard to fail.

Note that `compute_slots_from_rules` already broke out immediately for any negative horizon, because `start_offset` is clamped to `>= 0`. The slot list was therefore always empty, and it was only the POST guard, troubleshoot and month navigation that read the value as unlimited. The two now agree.

CodeRabbit suggested a `CHECK` constraint on the column instead. That is no longer available: migration 063 has shipped, SQLite cannot add a `CHECK` to an existing column without rebuilding `event_types`, and editing an already-applied migration is a no-op on any database that ran it, so deployments would diverge. Clamping on read covers the same ground at no schema risk.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `RUSTFLAGS="-D warnings" cargo clippy --profile=test --all-targets` | pass |
| `RUSTFLAGS="-D warnings" cargo test` | 882 passed, 0 failed |

Both commits were also verified green independently, so `git bisect` stays usable.

Each fix ships with a regression test, and each test was run against the un-fixed code to confirm it actually fails:

- Reverting the template fix makes the payload assertion fail with `"prevMonth": "none"` against the expected `"prevMonth": ""`.
- Reverting the horizon fix makes the contract assertion fail on `i32::MIN + 1`, and *only* there, which is the true scope of the change.

The template test also renders a month where `prev_month` **is** set, so it cannot pass by blanking `prevMonth` unconditionally.

## Not included

The CLI timezone point raised on #186 is real but not small: `event-type slots` derives everything from `Local::now()` plus the machine timezone, including busy-event conversion and `min_notice`, not only the horizon. Making it timezone-aware changes the whole command's output and deserves its own PR.

Credit to @iamthew4lrus789, who spotted the `prevMonth` bug while adding the booking horizon in #186 and correctly kept it out of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented negative booking horizons from incorrectly allowing unlimited availability.
  - Fixed calendar navigation when no previous month exists.
  - Ensured unavailable previous months render cleanly without undefined values.
  - Preserved valid previous-month navigation while correctly disabling the back control when unavailable.
- **Tests**
  - Added regression coverage for booking limits and previous-month calendar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->