### PR TITLE
ci: run on pull requests targeting i18n

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, i18n]
   pull_request:
-    branches: [main]
+    # i18n is a permanent branch, and CLAUDE.md tells contributors to target it
+    # for anything touching UI text. Without it here those PRs get no CI at all.
+    branches: [main, i18n]
 
 env:
   RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
ci: run on pull requests targeting i18n

CI triggers on `pull_request: branches: [main]` only, so a PR targeting
i18n runs no jobs at all. CLAUDE.md tells contributors that anything
touching UI text should branch off i18n rather than main, which makes
those exactly the PRs with no automated checks.

This is not hypothetical. #186 (rolling booking horizon, an outside
contribution) and #188 (phone country picker) both targeted i18n and both
merged with only CodeRabbit reporting. Their fmt, clippy, test and
coverage runs happened on a laptop, which is a thin thing to merge on for
a contribution from someone else.

All four jobs live in this one file, so widening the trigger covers fmt,
templates, check and coverage together. push is widened alongside
pull_request so the branch is checked after a Weblate push too.

publish.yml is deliberately left on main only: an i18n commit should not
publish a Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated quality checks now run for changes targeting both the main and internationalization branches.
  * Pull requests and updates to either branch receive consistent validation before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->