### PR TITLE
fix(email): allow SMTP relays that advertise no AUTH

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -157,6 +157,13 @@ SMTP credentials, the environment still wins and calrs relays unauthenticated.
 It logs a warning once at startup when that happens, because the admin form
 locks itself whenever the environment governs.
 
+The two credential variables are not interchangeable when only one is present.
+`CALRS_SMTP_PASSWORD` without `CALRS_SMTP_USERNAME` is an error: the password
+can never be sent, so the configuration contradicts itself. A username without a
+password is accepted and only warns, since a permissive relay may still
+authenticate on the username alone, though in practice it usually means the
+password never reached the process.
+
 The equivalent from the CLI, with no prompts:
 
 ```

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -100,6 +100,7 @@ calrs config smtp [OPTIONS]
     --username <USERNAME>   SMTP username (omit for an unauthenticated relay)
     --from-email <EMAIL>    Sender email address
     --from-name <NAME>      Sender display name
+    --tls-mode <MODE>       starttls (default), tls, or none
 
 calrs config show           Display current configuration
 
@@ -149,6 +150,18 @@ CALRS_SMTP_HOST=localhost
 CALRS_SMTP_PORT=25
 CALRS_SMTP_TLS_MODE=none
 CALRS_SMTP_FROM_EMAIL=noreply@example.com
+```
+
+If the environment block sets no `CALRS_SMTP_USERNAME` while the database holds
+SMTP credentials, the environment still wins and calrs relays unauthenticated.
+It logs a warning once at startup when that happens, because the admin form
+locks itself whenever the environment governs.
+
+The equivalent from the CLI, with no prompts:
+
+```
+calrs config smtp --host localhost --port 25 --tls-mode none \
+  --username '' --from-email noreply@example.com --from-name calrs
 ```
 
 ### `calrs resource`

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -97,7 +97,7 @@ Configure SMTP, authentication, and OIDC.
 calrs config smtp [OPTIONS]
     --host <HOST>           SMTP server hostname
     --port <PORT>           SMTP port (default: 587)
-    --username <USERNAME>   SMTP username
+    --username <USERNAME>   SMTP username (omit for an unauthenticated relay)
     --from-email <EMAIL>    Sender email address
     --from-name <NAME>      Sender display name
 
@@ -115,6 +115,40 @@ calrs config oidc [OPTIONS]
     --client-secret <SECRET>  Client secret
     --enabled <BOOL>          Enable/disable OIDC
     --auto-register <BOOL>    Auto-create users on first login
+```
+
+#### Relaying through a local MTA
+
+Leaving the username empty configures an unauthenticated relay, which is how you
+send through a local MTA (Postfix, OpenSMTPD, Stalwart, Mailpit). calrs then
+attaches no credentials at all, rather than authenticating with an empty
+username, which such a relay rejects because it advertises no AUTH mechanism.
+
+The TLS mode prompt accepts three values:
+
+| Mode | Transport |
+|---|---|
+| `starttls` (default) | Plain connection upgraded with STARTTLS, typically port 587 |
+| `tls` | Implicit TLS from the first byte, typically port 465 |
+| `none` | No encryption, typically port 25 |
+
+Use `none` only for a relay on the same machine. calrs validates certificates
+against a compiled-in Mozilla root bundle rather than the system trust store, so
+a relay presenting a self-signed or private-CA certificate (Debian's Postfix
+default, for one) cannot be reached with `starttls` or `tls` either, and `none`
+over the loopback is the way through. Mail sent this way, and any credentials
+sent with it, cross the connection in the clear; calrs logs a warning if you
+combine `none` with a username, or point it at a host that is not loopback.
+
+The same applies to the `CALRS_SMTP_*` environment block, where only
+`CALRS_SMTP_HOST` and `CALRS_SMTP_FROM_EMAIL` are required. A full local-relay
+configuration is:
+
+```
+CALRS_SMTP_HOST=localhost
+CALRS_SMTP_PORT=25
+CALRS_SMTP_TLS_MODE=none
+CALRS_SMTP_FROM_EMAIL=noreply@example.com
 ```
 
 ### `calrs resource`

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -16,7 +16,7 @@ pub enum ConfigCommands {
         /// SMTP port (default: 587)
         #[arg(long)]
         port: Option<u16>,
-        /// SMTP username
+        /// SMTP username (omit for an unauthenticated relay)
         #[arg(long)]
         username: Option<String>,
         /// From email address
@@ -25,6 +25,9 @@ pub enum ConfigCommands {
         /// From display name
         #[arg(long)]
         from_name: Option<String>,
+        /// Transport security: starttls (default), tls, or none
+        #[arg(long)]
+        tls_mode: Option<String>,
     },
     /// Show current configuration
     Show,
@@ -535,6 +538,7 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
             username,
             from_email,
             from_name,
+            tls_mode,
         } => {
             let host = host.unwrap_or_else(|| prompt("SMTP host"));
             let port = port.unwrap_or_else(|| {
@@ -563,7 +567,10 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                 }
             });
             let tls_mode = {
-                let raw = prompt("TLS mode (starttls/tls/none, default starttls)");
+                let raw = match tls_mode {
+                    Some(value) => value,
+                    None => prompt("TLS mode (starttls/tls/none, default starttls)"),
+                };
                 let normalized = raw.trim().to_ascii_lowercase();
                 match normalized.as_str() {
                     "" | "starttls" => "starttls",

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -545,8 +545,14 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                     p.parse().unwrap_or(587)
                 }
             });
-            let username = username.unwrap_or_else(|| prompt("SMTP username"));
-            let password = prompt("SMTP password");
+            let username = username.unwrap_or_else(|| {
+                prompt("SMTP username (leave empty for an unauthenticated relay)")
+            });
+            let password = if username.trim().is_empty() {
+                String::new()
+            } else {
+                prompt("SMTP password")
+            };
             let from_email = from_email.unwrap_or_else(|| prompt("From email"));
             let from_name = from_name.or_else(|| {
                 let name = prompt("From name (optional, press Enter to skip)");
@@ -557,19 +563,26 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                 }
             });
             let tls_mode = {
-                let raw = prompt("TLS mode (starttls/tls, default starttls)");
+                let raw = prompt("TLS mode (starttls/tls/none, default starttls)");
                 let normalized = raw.trim().to_ascii_lowercase();
                 match normalized.as_str() {
                     "" | "starttls" => "starttls",
                     "tls" => "tls",
+                    "none" | "plaintext" => "none",
                     other => {
                         anyhow::bail!(
-                            "Invalid TLS mode '{}'. Use 'starttls' (default, port 587) or 'tls' (implicit TLS, port 465).",
+                            "Invalid TLS mode '{}'. Use 'starttls' (default, port 587), 'tls' (implicit TLS, port 465), or 'none' (no encryption, for a local MTA).",
                             other
                         );
                     }
                 }
             };
+            if tls_mode == "none" {
+                println!(
+                    "{} TLS mode 'none' sends mail unencrypted. Only use it for a relay on this machine.",
+                    "!".yellow()
+                );
+            }
 
             let password_enc = crate::crypto::encrypt_password(key, &password)?;
             let id = Uuid::new_v4().to_string();

--- a/src/email.rs
+++ b/src/email.rs
@@ -1997,12 +1997,40 @@ async fn warn_if_env_shadows_db_credentials(pool: &SqlitePool) {
     }
 }
 
+/// Warn once about a username configured with no password.
+///
+/// This is deliberately not the hard error that a password with no username
+/// gets. There, the config is provably self-contradictory: the password can
+/// never be transmitted, so the intent to authenticate cannot be honoured under
+/// any server behaviour. Here it is only suspicious. It is almost always a
+/// secret that never reached the process (an unmounted Docker secret, a
+/// misspelled variable), but AUTH PLAIN with an empty password is well-formed
+/// and some allowlist-style internal relays accept it, so refusing to send
+/// would be a guess.
+///
+/// Checked on the loaded config rather than per source, so the environment and
+/// the database, both of which can express this, behave the same way.
+fn warn_if_auth_without_password(config: &SmtpConfig) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    if config.uses_auth() && config.password.is_empty() {
+        WARNED.call_once(|| {
+            tracing::warn!(
+                host = %config.host,
+                "SMTP username is set with an empty password, so calrs will authenticate with an \
+                 empty password and most relays will reject that. Set the password, or clear the \
+                 username to relay without authentication."
+            );
+        });
+    }
+}
+
 /// Load SMTP config from environment or database.
 pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Option<SmtpConfig>> {
     if let Some(config) = load_smtp_config_from_env()? {
         if !config.uses_auth() {
             warn_if_env_shadows_db_credentials(pool).await;
         }
+        warn_if_auth_without_password(&config);
         return Ok(Some(config));
     }
 
@@ -2018,7 +2046,7 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
         Some((host, port, username, password_enc, from_email, from_name, tls_mode)) => {
             let password = crate::crypto::decrypt_password(key, &password_enc)?;
             let tls_mode = SmtpTlsMode::parse(&tls_mode).unwrap_or(SmtpTlsMode::StartTls);
-            Ok(Some(SmtpConfig {
+            let config = SmtpConfig {
                 host,
                 port: port as u16,
                 username,
@@ -2026,7 +2054,9 @@ pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Optio
                 from_email,
                 from_name,
                 tls_mode,
-            }))
+            };
+            warn_if_auth_without_password(&config);
+            Ok(Some(config))
         }
         None => Ok(None),
     }
@@ -3157,6 +3187,26 @@ mod tests {
         assert_eq!(config.port, 25);
         assert_eq!(config.tls_mode, SmtpTlsMode::Plaintext);
         assert!(!config.uses_auth());
+    }
+
+    /// The deliberate asymmetry with `smtp_env_password_without_username_errors`.
+    /// A password with no username is provably unusable, so it is fatal. A
+    /// username with no password might still authenticate against a permissive
+    /// relay, so it loads and only warns.
+    #[test]
+    fn smtp_env_username_without_password_is_allowed() {
+        let _env = SmtpEnvGuard::new();
+        std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+        std::env::set_var("CALRS_SMTP_USERNAME", "alice");
+
+        let config = load_smtp_config_from_env()
+            .expect("a username with no password must not be fatal")
+            .expect("the block is complete");
+
+        assert_eq!(config.username, "alice");
+        assert!(config.password.is_empty());
+        assert!(config.uses_auth(), "credentials must still be attached");
     }
 
     #[test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -1966,9 +1966,43 @@ pub fn smtp_env_active() -> bool {
     !matches!(load_smtp_config_from_env(), Ok(None))
 }
 
+/// The env block governs as soon as `HOST` and `FROM_EMAIL` are set, and
+/// `USERNAME`/`PASSWORD` are optional. That combination can take over from a
+/// database row that *does* carry credentials, turning working authenticated
+/// SMTP into unauthenticated sends that the relay then rejects. The operator
+/// has no other signal: the admin form locks itself when the env governs, and
+/// mail simply stops. Warn once per process, and only when there is something
+/// to lose.
+async fn warn_if_env_shadows_db_credentials(pool: &SqlitePool) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    if WARNED.is_completed() {
+        return;
+    }
+    let shadowed: Option<(String,)> = sqlx::query_as(
+        "SELECT username FROM smtp_config WHERE enabled = 1 AND TRIM(username) <> '' LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten();
+    if shadowed.is_some() {
+        WARNED.call_once(|| {
+            tracing::warn!(
+                "CALRS_SMTP_* sets no USERNAME, so calrs is relaying without authentication, but \
+                 the database holds SMTP credentials that the environment block now shadows. Set \
+                 CALRS_SMTP_USERNAME and CALRS_SMTP_PASSWORD, or unset the CALRS_SMTP_* block to \
+                 go back to the database config."
+            );
+        });
+    }
+}
+
 /// Load SMTP config from environment or database.
 pub async fn load_smtp_config(pool: &SqlitePool, key: &[u8; 32]) -> Result<Option<SmtpConfig>> {
     if let Some(config) = load_smtp_config_from_env()? {
+        if !config.uses_auth() {
+            warn_if_env_shadows_db_credentials(pool).await;
+        }
         return Ok(Some(config));
     }
 
@@ -2928,6 +2962,147 @@ mod tests {
         assert_eq!(config.host, "smtp.example.com");
         assert_eq!(config.port, 587);
         assert_eq!(config.tls_mode, SmtpTlsMode::StartTls);
+    }
+
+    /// A local MTA relaying anonymously from the loopback: it advertises no
+    /// AUTH and no STARTTLS, like the servers in issue #190. Handles exactly
+    /// one connection and returns the commands it saw, so a test can tell
+    /// "the message arrived" from "the client hung up after EHLO".
+    async fn fake_no_auth_mta(listener: tokio::net::TcpListener) -> Vec<String> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let (stream, _) = listener.accept().await.expect("accept");
+        let (read_half, mut write) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+        let mut seen = Vec::new();
+
+        macro_rules! say {
+            ($($arg:tt)*) => {{
+                let line = format!($($arg)*);
+                write.write_all(line.as_bytes()).await.expect("write");
+                write.write_all(b"\r\n").await.expect("write");
+            }};
+        }
+
+        say!("220 fake.local ESMTP");
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line).await {
+                Ok(0) | Err(_) => break, // client hung up
+                Ok(_) => {}
+            }
+            let line = line.trim_end().to_string();
+            let upper = line.to_ascii_uppercase();
+            seen.push(line);
+
+            if upper.starts_with("EHLO") {
+                say!("250-fake.local");
+                say!("250 8BITMIME"); // deliberately no AUTH, no STARTTLS
+            } else if upper.starts_with("MAIL FROM") || upper.starts_with("RCPT TO") {
+                say!("250 2.1.0 OK");
+            } else if upper == "DATA" {
+                say!("354 End data with <CR><LF>.<CR><LF>");
+                loop {
+                    let mut body = String::new();
+                    match reader.read_line(&mut body).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {}
+                    }
+                    if body.trim_end() == "." {
+                        break;
+                    }
+                }
+                say!("250 2.0.0 OK: queued");
+            } else if upper.starts_with("AUTH") {
+                say!("502 5.5.1 AUTH not supported");
+            } else if upper == "QUIT" {
+                say!("221 2.0.0 Bye");
+                break;
+            } else {
+                say!("250 OK");
+            }
+        }
+        seen
+    }
+
+    fn plaintext_config(port: u16, username: &str) -> SmtpConfig {
+        SmtpConfig {
+            host: "127.0.0.1".to_string(),
+            port,
+            username: username.to_string(),
+            password: if username.is_empty() {
+                String::new()
+            } else {
+                "secret".to_string()
+            },
+            from_name: None,
+            from_email: "noreply@example.com".to_string(),
+            tls_mode: SmtpTlsMode::Plaintext,
+        }
+    }
+
+    fn test_message() -> Message {
+        Message::builder()
+            .from("noreply@example.com".parse().unwrap())
+            .to("guest@example.com".parse().unwrap())
+            .subject("test")
+            .body("hello".to_string())
+            .unwrap()
+    }
+
+    /// Regression test for #190: with no username configured, the message must
+    /// actually reach a relay that advertises no AUTH mechanism.
+    #[tokio::test]
+    async fn unauthenticated_relay_receives_the_message() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(fake_no_auth_mta(listener));
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            send_email(&plaintext_config(port, ""), test_message()),
+        )
+        .await
+        .expect("send timed out");
+        result.expect("send should succeed against a no-auth relay");
+
+        let seen = tokio::time::timeout(std::time::Duration::from_secs(10), server)
+            .await
+            .expect("server timed out")
+            .unwrap();
+        assert!(seen.iter().any(|c| c.starts_with("MAIL FROM")), "{seen:?}");
+        assert!(seen.iter().any(|c| c.starts_with("RCPT TO")), "{seen:?}");
+        assert!(seen.iter().any(|c| c == "DATA"), "{seen:?}");
+        assert!(!seen.iter().any(|c| c.starts_with("AUTH")), "{seen:?}");
+    }
+
+    /// The other half of #190: a username must still mean authentication, so
+    /// the same relay fails the way it always did. Without this, "skip auth
+    /// when the username is empty" could regress into "never authenticate".
+    #[tokio::test]
+    async fn credentials_against_a_no_auth_relay_still_fail() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(fake_no_auth_mta(listener));
+
+        let err = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            send_email(&plaintext_config(port, "alice"), test_message()),
+        )
+        .await
+        .expect("send timed out")
+        .expect_err("a no-auth relay cannot satisfy configured credentials");
+        assert!(
+            err.to_string().contains("authentication mechanism"),
+            "unexpected error: {err}"
+        );
+
+        // The client aborts before the envelope: nothing reaches the MTA.
+        let seen = tokio::time::timeout(std::time::Duration::from_secs(10), server)
+            .await
+            .expect("server timed out")
+            .unwrap();
+        assert!(!seen.iter().any(|c| c.starts_with("MAIL FROM")), "{seen:?}");
     }
 
     #[test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -61,6 +61,12 @@ impl std::fmt::Debug for SmtpConfig {
 pub enum SmtpTlsMode {
     StartTls,
     Tls,
+    /// No encryption at all. Only sane for a relay reached over the loopback
+    /// (or a trusted private link): a local MTA that offers no STARTTLS, or one
+    /// whose certificate is self-signed. lettre validates certificates against
+    /// the compiled-in Mozilla root bundle, not the system trust store, so a
+    /// private CA cannot be trusted and this is the only way through.
+    Plaintext,
 }
 
 impl SmtpTlsMode {
@@ -68,8 +74,9 @@ impl SmtpTlsMode {
         match value.trim().to_ascii_lowercase().as_str() {
             "starttls" => Ok(Self::StartTls),
             "tls" => Ok(Self::Tls),
+            "none" | "plaintext" => Ok(Self::Plaintext),
             other => bail!(
-                "CALRS_SMTP_TLS_MODE must be 'starttls' or 'tls' (got '{}')",
+                "CALRS_SMTP_TLS_MODE must be 'starttls', 'tls' or 'none' (got '{}')",
                 other
             ),
         }
@@ -93,11 +100,30 @@ impl SmtpTlsMode {
         match self {
             Self::StartTls => "starttls",
             Self::Tls => "tls",
+            Self::Plaintext => "none",
         }
     }
 }
 
+/// Whether a host names the local machine, and so whether an unencrypted
+/// connection to it stays inside the box. Bare `localhost` and any address
+/// that parses as a loopback IP count; anything else is a network hop.
+fn is_loopback_host(host: &str) -> bool {
+    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
 impl SmtpConfig {
+    /// Whether to authenticate. An empty username means "no SMTP AUTH": lettre
+    /// only skips authentication when the transport carries no credentials at
+    /// all, so empty ones must not be attached. See `send_email`.
+    fn uses_auth(&self) -> bool {
+        !self.username.trim().is_empty()
+    }
+
     /// Get "from" Mailbox, compliant with RFC 5322
     fn mailbox_from(&self) -> Result<Mailbox> {
         Ok(Mailbox::new(
@@ -1865,13 +1891,16 @@ fn optional_smtp_env(name: &str) -> Option<String> {
 
 /// Load the SMTP config from the `CALRS_SMTP_*` environment block.
 ///
-/// Priority is "full block override": when the required block (host, username,
-/// password, from_email) is complete, the env wins over the database entirely.
-/// When no SMTP var is set, or the required block is only partially set, this
-/// returns `Ok(None)` so the caller falls back to the database config — a stray
-/// or incomplete env var no longer breaks SMTP. A required block that *is*
+/// Priority is "full block override": when the required block (host,
+/// from_email) is complete, the env wins over the database entirely. When no
+/// SMTP var is set, or the required block is only partially set, this returns
+/// `Ok(None)` so the caller falls back to the database config — a stray or
+/// incomplete env var no longer breaks SMTP. A required block that *is*
 /// complete but carries an invalid `PORT`/`TLS_MODE` still surfaces an error,
 /// since that is a genuine misconfiguration to fix rather than silently ignore.
+///
+/// `USERNAME`/`PASSWORD` are optional: omitting them configures an
+/// unauthenticated relay, which is how a container talks to a sidecar MTA.
 fn load_smtp_config_from_env() -> Result<Option<SmtpConfig>> {
     if !SMTP_ENV_VARS
         .iter()
@@ -1880,22 +1909,25 @@ fn load_smtp_config_from_env() -> Result<Option<SmtpConfig>> {
         return Ok(None);
     }
 
-    let (host, username, password, from_email) = match (
+    let (host, from_email) = match (
         optional_smtp_env("CALRS_SMTP_HOST"),
-        optional_smtp_env("CALRS_SMTP_USERNAME"),
-        optional_smtp_env("CALRS_SMTP_PASSWORD"),
         optional_smtp_env("CALRS_SMTP_FROM_EMAIL"),
     ) {
-        (Some(host), Some(username), Some(password), Some(from_email)) => {
-            (host, username, password, from_email)
-        }
+        (Some(host), Some(from_email)) => (host, from_email),
         _ => {
             tracing::warn!(
-                "partial CALRS_SMTP_* environment block (missing one of HOST/USERNAME/PASSWORD/FROM_EMAIL); falling back to database SMTP config"
+                "partial CALRS_SMTP_* environment block (missing HOST or FROM_EMAIL); falling back to database SMTP config"
             );
             return Ok(None);
         }
     };
+    // Both empty means "no SMTP AUTH", as in `send_email`. A username with no
+    // password is still authenticated, since some relays accept an empty one.
+    let username = optional_smtp_env("CALRS_SMTP_USERNAME").unwrap_or_default();
+    let password = optional_smtp_env("CALRS_SMTP_PASSWORD").unwrap_or_default();
+    if username.is_empty() && !password.is_empty() {
+        bail!("CALRS_SMTP_PASSWORD is set without CALRS_SMTP_USERNAME");
+    }
     let port = match std::env::var("CALRS_SMTP_PORT") {
         Ok(value) if value.trim().is_empty() => bail!("CALRS_SMTP_PORT must not be empty"),
         Ok(value) => value.trim().parse::<u16>().map_err(|_| {
@@ -2127,19 +2159,45 @@ pub async fn send_invite_email(
 }
 
 async fn send_email(config: &SmtpConfig, email: Message) -> Result<()> {
-    let creds = Credentials::new(config.username.clone(), config.password.clone());
-
-    let mailer = match config.tls_mode {
-        SmtpTlsMode::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)?
-            .port(config.port)
-            .credentials(creds)
-            .build(),
+    let builder = match config.tls_mode {
+        SmtpTlsMode::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)?,
         SmtpTlsMode::StartTls => {
             AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)?
-                .port(config.port)
-                .credentials(creds)
-                .build()
         }
+        // `builder_dangerous` is lettre's name for "no TLS", and the name is
+        // fair: the message, and any credentials, cross the wire in the clear.
+        SmtpTlsMode::Plaintext => {
+            if config.uses_auth() {
+                tracing::warn!(
+                    host = %config.host,
+                    "sending SMTP credentials over an unencrypted connection (tls_mode = none)"
+                );
+            } else if !is_loopback_host(&config.host) {
+                tracing::warn!(
+                    host = %config.host,
+                    "sending email over an unencrypted connection to a non-loopback host (tls_mode = none)"
+                );
+            }
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host)
+        }
+    }
+    .port(config.port);
+
+    // An empty username means "no SMTP AUTH". lettre only skips authentication
+    // when the transport carries no credentials at all: given empty ones it
+    // still looks for a mechanism, and a local MTA relaying anonymously from
+    // the loopback (Postfix, OpenSMTPD, Stalwart, Mailpit) advertises none, so
+    // every send aborts client-side with "No compatible authentication
+    // mechanism was found" before the message ever reaches the server.
+    let mailer = if !config.uses_auth() {
+        builder.build()
+    } else {
+        builder
+            .credentials(Credentials::new(
+                config.username.clone(),
+                config.password.clone(),
+            ))
+            .build()
     };
 
     let to_addrs: Vec<String> = email
@@ -2813,6 +2871,36 @@ mod tests {
             SmtpTlsMode::StartTls
         );
         assert_eq!(SmtpTlsMode::parse(" TLS ").unwrap(), SmtpTlsMode::Tls);
+        assert_eq!(SmtpTlsMode::parse("none").unwrap(), SmtpTlsMode::Plaintext);
+        assert_eq!(
+            SmtpTlsMode::parse("Plaintext").unwrap(),
+            SmtpTlsMode::Plaintext
+        );
+        // Round-trips through the string stored in the DB and the env.
+        for mode in [
+            SmtpTlsMode::StartTls,
+            SmtpTlsMode::Tls,
+            SmtpTlsMode::Plaintext,
+        ] {
+            assert_eq!(SmtpTlsMode::parse(mode.as_str()).unwrap(), mode);
+        }
+    }
+
+    #[test]
+    fn loopback_hosts_are_recognised() {
+        for host in [
+            "localhost",
+            "LOCALHOST",
+            " 127.0.0.1 ",
+            "127.1.2.3",
+            "::1",
+            "[::1]",
+        ] {
+            assert!(is_loopback_host(host), "{host} should be loopback");
+        }
+        for host in ["smtp.example.com", "10.0.0.1", "192.168.1.10", "", "::2"] {
+            assert!(!is_loopback_host(host), "{host} should not be loopback");
+        }
     }
 
     #[test]
@@ -2840,6 +2928,72 @@ mod tests {
         assert_eq!(config.host, "smtp.example.com");
         assert_eq!(config.port, 587);
         assert_eq!(config.tls_mode, SmtpTlsMode::StartTls);
+    }
+
+    #[test]
+    fn smtp_config_without_username_skips_auth() {
+        // An unauthenticated local relay: attaching empty credentials makes
+        // lettre hunt for a mechanism the server never advertises, and every
+        // send aborts client-side before DATA.
+        let mut config = SmtpConfig {
+            host: "localhost".to_string(),
+            port: 25,
+            username: String::new(),
+            password: String::new(),
+            from_name: None,
+            from_email: "noreply@example.com".to_string(),
+            tls_mode: SmtpTlsMode::StartTls,
+        };
+        assert!(!config.uses_auth());
+
+        config.username = "   ".to_string();
+        assert!(!config.uses_auth());
+
+        config.username = "user".to_string();
+        assert!(config.uses_auth());
+    }
+
+    #[test]
+    fn smtp_env_without_credentials_is_unauthenticated() {
+        let _env = SmtpEnvGuard::new();
+        // A container pointed at a sidecar MTA: host and sender are enough.
+        std::env::set_var("CALRS_SMTP_HOST", "localhost");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+
+        let config = load_smtp_config_from_env().unwrap().unwrap();
+
+        assert_eq!(config.host, "localhost");
+        assert!(config.username.is_empty());
+        assert!(config.password.is_empty());
+        assert!(!config.uses_auth());
+    }
+
+    #[test]
+    fn smtp_env_accepts_plaintext_tls_mode() {
+        let _env = SmtpEnvGuard::new();
+        // The whole unauthenticated-loopback-MTA setup, from the environment.
+        std::env::set_var("CALRS_SMTP_HOST", "localhost");
+        std::env::set_var("CALRS_SMTP_PORT", "25");
+        std::env::set_var("CALRS_SMTP_TLS_MODE", "none");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+
+        let config = load_smtp_config_from_env().unwrap().unwrap();
+
+        assert_eq!(config.port, 25);
+        assert_eq!(config.tls_mode, SmtpTlsMode::Plaintext);
+        assert!(!config.uses_auth());
+    }
+
+    #[test]
+    fn smtp_env_password_without_username_errors() {
+        let _env = SmtpEnvGuard::new();
+        std::env::set_var("CALRS_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("CALRS_SMTP_FROM_EMAIL", "noreply@example.com");
+        std::env::set_var("CALRS_SMTP_PASSWORD", "secret");
+
+        let err = smtp_env_error();
+
+        assert!(err.contains("CALRS_SMTP_USERNAME"));
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -27941,6 +27941,54 @@ mod tests {
         }
     }
 
+    /// The TLS mode `<select>` marks exactly one option `selected`. Two would
+    /// be worse than none: a browser honours the last one, so an operator on
+    /// STARTTLS would be shown "None, unencrypted" and silently downgrade the
+    /// transport by saving the form untouched.
+    #[tokio::test]
+    async fn admin_smtp_tls_mode_select_marks_one_option() {
+        for (stored, expected_label) in [
+            ("starttls", "STARTTLS (port 587)"),
+            ("tls", "Implicit TLS (port 465)"),
+            ("none", "None, unencrypted (local MTA only)"),
+        ] {
+            let (app, pool, session, _) = setup_test_app().await;
+            sqlx::query(
+                "INSERT INTO smtp_config (id, host, port, username, password_enc, from_email, tls_mode, enabled) \
+                 VALUES (?, 'smtp.test', 587, '', '', 'noreply@test.com', ?, 1)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(stored)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            let response = app
+                .oneshot(get_authed("/dashboard/admin", &session))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 200);
+            let body = body_string(response).await;
+
+            let selected: Vec<&str> = [
+                "STARTTLS (port 587)",
+                "Implicit TLS (port 465)",
+                "None, unencrypted (local MTA only)",
+            ]
+            .into_iter()
+            .filter(|label| {
+                body.split("<option")
+                    .any(|opt| opt.contains(label) && opt.contains("selected"))
+            })
+            .collect();
+            assert_eq!(
+                selected,
+                vec![expected_label],
+                "tls_mode {stored} should select exactly {expected_label}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn overrides_page_returns_200() {
         let (app, _, session, _) = setup_test_app().await;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -17093,8 +17093,9 @@ async fn admin_update_smtp(
 
     let tls_mode = match form.tls_mode.as_deref().map(str::trim) {
         Some("tls") => "tls",
+        Some("none") => "none",
         Some("starttls") | Some("") | None => "starttls",
-        Some(_) => return redirect_err("TLS mode must be 'starttls' or 'tls'."),
+        Some(_) => return redirect_err("TLS mode must be 'starttls', 'tls' or 'none'."),
     };
 
     let username = form.username.unwrap_or_default().trim().to_string();

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -696,12 +696,14 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
     <div class="form-group">
       <label>TLS mode</label>
       <select name="tls_mode">
-        <option value="starttls" {% if smtp_tls_mode != "tls" %}selected{% endif %}>STARTTLS (port 587)</option>
+        <option value="starttls" {% if smtp_tls_mode != "tls" and smtp_tls_mode != "none" %}selected{% endif %}>STARTTLS (port 587)</option>
         <option value="tls" {% if smtp_tls_mode == "tls" %}selected{% endif %}>Implicit TLS (port 465)</option>
+        <option value="none" {% if smtp_tls_mode == "none" %}selected{% endif %}>None, unencrypted (local MTA only)</option>
       </select>
+      <p class="hint" style="margin-top: 0.35rem;">Pick <strong>None</strong> only for a relay on this machine that offers no STARTTLS, or whose certificate is self-signed. Mail, and any credentials, cross the wire in the clear.</p>
     </div>
     <div class="form-group">
-      <label>Username</label>
+      <label>Username <span class="hint">(leave empty for an unauthenticated relay)</span></label>
       <input type="text" name="username" value="{{ smtp_username }}" placeholder="user@example.com">
     </div>
     <div class="form-group">
@@ -732,7 +734,7 @@ document.querySelectorAll('input[type="color"]').forEach(function(picker) {
   </form>
   {% endif %}
 
-  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 1rem;">Alternatively, configure via environment variables (which override this): <code>CALRS_SMTP_HOST</code>, <code>CALRS_SMTP_PORT</code>, <code>CALRS_SMTP_TLS_MODE</code> (<code>starttls</code> or <code>tls</code>), <code>CALRS_SMTP_USERNAME</code>, <code>CALRS_SMTP_PASSWORD</code>, <code>CALRS_SMTP_FROM_EMAIL</code>, <code>CALRS_SMTP_FROM_NAME</code>.</p>
+  <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 1rem;">Alternatively, configure via environment variables (which override this): <code>CALRS_SMTP_HOST</code>, <code>CALRS_SMTP_PORT</code>, <code>CALRS_SMTP_TLS_MODE</code> (<code>starttls</code>, <code>tls</code> or <code>none</code>), <code>CALRS_SMTP_USERNAME</code>, <code>CALRS_SMTP_PASSWORD</code>, <code>CALRS_SMTP_FROM_EMAIL</code>, <code>CALRS_SMTP_FROM_NAME</code>. Only <code>CALRS_SMTP_HOST</code> and <code>CALRS_SMTP_FROM_EMAIL</code> are required; omit the username and password to relay through a local MTA without authentication.</p>
   {% endif %}
 </div>
 


### PR DESCRIPTION
Closes #190. Thanks @ManUtopiK for the report, which was accurate down to the line number and shipped its own fix.

## The bug

`send_email()` attached credentials to the lettre transport unconditionally, so a configured-but-empty username still put the transport into the authenticating path. lettre gates on presence, not emptiness:

```rust
// lettre-0.11.19 src/transport/smtp/async_transport.rs:495
if let Some(credentials) = &self.info.credentials {
    conn.auth(&self.info.authentication, credentials).await?;
}
```

Given `Credentials::new("", "")` it goes looking for a mechanism, a local MTA relaying anonymously from the loopback advertises none, and `get_auth_mechanism` returns `None` — the reported error, raised client-side before the envelope ever reaches the server. The configuration was representable through both `calrs config smtp` and the admin form. It simply could never send.

## What changed

Credentials are attached only when the username is non-empty, keyed on a new `SmtpConfig::uses_auth()`. Authenticated setups keep exactly today's behaviour.

Two adjacent gaps are closed alongside it, because neither left a working path for the deployment this is about:

**The env block could not express "no auth".** `CALRS_SMTP_USERNAME` and `CALRS_SMTP_PASSWORD` were part of the mandatory set, so omitting them made the block partial and silently fell back to the database. Only `CALRS_SMTP_HOST` and `CALRS_SMTP_FROM_EMAIL` are required now. A password with no username is a hard error, matching how an invalid `PORT`/`TLS_MODE` is treated in an otherwise-complete block.

**TLS was still mandatory.** `starttls_relay()` sets `Tls::Required`, and calrs builds lettre with `tokio1-rustls-tls`, whose roots come from `webpki-roots` — the compiled-in Mozilla bundle, not the system trust store. So a relay offering no STARTTLS (Mailpit's default) or presenting a self-signed certificate (Debian's Postfix default snakeoil) stayed unreachable in every mode, and the auth fix alone would have moved those users from an auth error to a TLS error. A third `tls_mode`, `none`, sends unencrypted. It warns when combined with a username, or aimed at a host that is not loopback.

Surfaced in all three places the reporter noted were silent: the CLI prompt (which now also skips the password prompt when the username is empty), the admin form, and the docs.

No migration: `smtp_config.tls_mode` is unconstrained `TEXT`.

## Verification

End to end against a local MTA advertising neither AUTH nor STARTTLS, driving the real `calrs config smtp-test` through the env block:

| | Result | Server saw |
|---|---|---|
| No username | `✓ Test email sent!` | `EHLO \| MAIL FROM \| RCPT TO \| DATA \| QUIT` |
| Username set | `No compatible authentication mechanism was found` | `EHLO`, then the client hung up |

The second row reproduces the issue exactly, including the reporter's observation that nothing reaches the MTA. Plus 7 new unit tests over the auth decision, the relaxed env block, the new TLS mode round-trip, and loopback-host detection. 891 tests green, clippy clean.

## Note for the reporter

@ManUtopiK your Stalwart setup should be fixed by the credentials change alone, since it advertises STARTTLS. If the certificate is publicly trusted, leave `tls_mode` at `starttls` and just clear the username. `none` is there for the Postfix-snakeoil and Mailpit cases you mentioned. Field reports welcome either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMTP configuration now supports unauthenticated relays without requiring a username or password.
  * Added an unencrypted SMTP transport option (`none`/`plaintext`) for compatible relay setups.
  * SMTP settings can now be configured with only a server host and sender address.
* **Bug Fixes**
  * Improved validation for incomplete or invalid SMTP authentication settings.
  * Added warnings when plaintext SMTP could expose credentials, especially over non-local connections.
* **Documentation**
  * Expanded CLI, web settings, and environment-variable guidance for relay configuration, TLS modes, and certificate trust limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->