### PR TITLE
fix: ICS parameter escaping, env-forced runtime settings, copy-button gate

### DIFF
--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -129,7 +129,7 @@ Self-hosted deployments often run calrs and the CalDAV server on the same privat
    - Admin panel → **System settings** → *Private-host allowlist*
    - `calrs config general --allow-private-hosts radicale,nextcloud.local,127.0.0.1`
 
-When the environment variable is set it overrides the stored value (the admin panel shows a "set by environment" badge). Matching is case-insensitive and exact (no wildcards or subdomain matching). Only the listed hosts bypass the private-IP check; every other host is still validated. Keep this list as small as possible, scheme validation (http/https only) still applies.
+When the environment variable is set it overrides the stored value (the admin panel shows a "set by environment" badge), and neither the admin panel nor `calrs config general` will write that field to the database — they refuse and say so. That is deliberate: a value stored while the env var was set would sit dormant and then silently become the effective allowlist the day the variable is removed. Change it where it is set, or unset the variable first. Matching is case-insensitive and exact (no wildcards or subdomain matching). Only the listed hosts bypass the private-IP check; every other host is still validated. Keep this list as small as possible, scheme validation (http/https only) still applies.
 
 In a trusted multi-user deployment (e.g., behind OIDC) this is low risk. For public-registration instances, configure egress filtering at the network level.
 

--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -62,8 +62,10 @@ fn is_host_allowlisted(host: &str, allowlist: &[String]) -> bool {
 ///
 /// Self-hosted deployments (e.g. calrs and Radicale on the same docker network)
 /// can opt specific hostnames out of the private-IP check via the
-/// `CALRS_ALLOW_PRIVATE_HOSTS` env var (comma-separated hostnames). The check
-/// stays active for every other host.
+/// `CALRS_ALLOW_PRIVATE_HOSTS` env var or the DB-backed setting behind it
+/// (`calrs config general --allow-private-hosts`, or the admin panel); see
+/// [`crate::settings`] for which one wins. The check stays active for every
+/// other host.
 ///
 /// Limitation: this resolves the hostname once at validation time. A DNS
 /// rebinding attacker who returns a public IP for the initial lookup and a

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -835,6 +835,38 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                     }
                 );
             } else {
+                // Mirror `admin_update_general`: a field forced by an
+                // environment variable is not written to the database at all.
+                // The env wins at runtime either way, so the stored value only
+                // matters later — and an operator who sets one here, then
+                // removes the env var, would silently activate a value they
+                // configured for a machine that no longer exists. For the
+                // private-host allowlist that is an SSRF-relevant change
+                // happening with no action at that moment (#142).
+                if base_url.is_some() && crate::settings::base_url_from_env() {
+                    println!(
+                        "{} Base URL not saved: CALRS_BASE_URL is set in the environment and takes precedence.",
+                        "!".yellow()
+                    );
+                    println!(
+                        "  Change it there, or unset it first so the stored value can take effect."
+                    );
+                }
+                if allow_private_hosts.is_some() && crate::settings::allow_private_hosts_from_env()
+                {
+                    println!(
+                        "{} Allowed private hosts not saved: CALRS_ALLOW_PRIVATE_HOSTS is set in the environment and takes precedence.",
+                        "!".yellow()
+                    );
+                    println!(
+                        "  Change it there, or unset it first so the stored value can take effect."
+                    );
+                }
+
+                let base_url = base_url.filter(|_| !crate::settings::base_url_from_env());
+                let allow_private_hosts = allow_private_hosts
+                    .filter(|_| !crate::settings::allow_private_hosts_from_env());
+
                 if let Some(url) = base_url {
                     let value = {
                         let trimmed = url.trim().trim_end_matches('/');
@@ -872,18 +904,6 @@ pub async fn run(pool: &SqlitePool, key: &[u8; 32], cmd: ConfigCommands) -> Resu
                         Some(v) => println!("{} Allowed private hosts set to: {}", "✓".green(), v),
                         None => println!("{} Allowed private hosts cleared", "✓".green()),
                     }
-                }
-                if crate::settings::base_url_from_env() {
-                    println!(
-                        "{} CALRS_BASE_URL is set in the environment and overrides the stored value at runtime.",
-                        "note:".dimmed()
-                    );
-                }
-                if crate::settings::allow_private_hosts_from_env() {
-                    println!(
-                        "{} CALRS_ALLOW_PRIVATE_HOSTS is set in the environment and overrides the stored value at runtime.",
-                        "note:".dimmed()
-                    );
                 }
             }
         }
@@ -1257,6 +1277,79 @@ mod tests {
         .unwrap();
         assert!(base.is_none());
         assert!(hosts.is_none());
+    }
+
+    #[tokio::test]
+    async fn config_general_refuses_to_write_an_env_forced_field() {
+        // #142: the CLI used to write both fields unconditionally. The env
+        // wins at runtime, so nothing broke *then* — but unsetting the env var
+        // later silently activated whatever had been stored, which for the
+        // private-host allowlist is an SSRF-relevant change with no action at
+        // that moment. Refusing the write mirrors `admin_update_general`.
+        let _lock = GENERAL_ENV_LOCK.lock().await;
+        let _guard = GeneralEnvGuard::new();
+        let pool = setup_db().await;
+        let key = [0u8; 32];
+
+        std::env::set_var("CALRS_ALLOW_PRIVATE_HOSTS", "env.internal");
+
+        run(
+            &pool,
+            &key,
+            ConfigCommands::General {
+                base_url: Some("https://cal.example.com".to_string()),
+                allow_private_hosts: Some("cli.internal".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (base, hosts): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT base_url, allow_private_hosts FROM auth_config WHERE id = 'singleton'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // The field that is not env-forced is still written normally.
+        assert_eq!(base.as_deref(), Some("https://cal.example.com"));
+        // The env-forced one is left exactly as it was.
+        assert!(hosts.is_none(), "stored allowlist should be untouched");
+    }
+
+    /// Serialises the tests that touch the runtime-settings environment,
+    /// which is process-global. Async-aware so the guard can be held across
+    /// the `run()` await.
+    static GENERAL_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// Restores the runtime-settings env vars, so one test cannot leak an
+    /// override into the next.
+    struct GeneralEnvGuard {
+        old: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl GeneralEnvGuard {
+        fn new() -> Self {
+            let names = ["CALRS_BASE_URL", "CALRS_ALLOW_PRIVATE_HOSTS"];
+            let old = names
+                .iter()
+                .map(|n| (*n, std::env::var(n).ok()))
+                .collect::<Vec<_>>();
+            for n in names {
+                std::env::remove_var(n);
+            }
+            Self { old }
+        }
+    }
+
+    impl Drop for GeneralEnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.old {
+                match value {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/email.rs
+++ b/src/email.rs
@@ -316,6 +316,34 @@ fn sanitize_ics(value: &str) -> String {
         .replace(',', "\\,")
 }
 
+/// Sanitize a value for use in an ICS *parameter*, such as `CN=`.
+///
+/// A parameter value is not a TEXT value and takes no backslash escapes.
+/// RFC 5545 §3.1 defines it as either `paramtext`, which excludes `;`, `:`,
+/// `,` and DQUOTE, or a quoted-string. Escaping a semicolon as `\;` the way
+/// `sanitize_ics` does leaves the raw `;` in place, a strict parser reads it
+/// as the end of the parameter, and the whole VEVENT is rejected: Yandex 360
+/// answers 400 Bad Request to a booking whose guest name contains one, and
+/// the event never reaches the calendar (#163).
+///
+/// So quote the value when it carries a delimiter, and spell the characters a
+/// quoted-string cannot hold with the RFC 6868 caret escapes. The carets only
+/// appear for input containing `"`, `^` or a newline; a parser predating
+/// RFC 6868 renders those literally, which is a cosmetic loss in a display
+/// name rather than the parse failure this replaces.
+fn sanitize_ics_param(value: &str) -> String {
+    let escaped = value
+        .replace('^', "^^")
+        .replace('"', "^'")
+        .replace("\r\n", "^n")
+        .replace(['\r', '\n'], "^n");
+    if escaped.contains([';', ':', ',']) {
+        format!("\"{escaped}\"")
+    } else {
+        escaped
+    }
+}
+
 /// Convert date + start/end times from a guest timezone to UTC ICS format (YYYYMMDDTHHMMSSZ).
 /// Falls back to floating time (no Z) if timezone parsing fails.
 fn convert_to_utc(
@@ -482,8 +510,9 @@ fn generate_ics_impl(
         "{} \u{2014} {} & {}",
         details.event_title, guest_first, host_first
     ));
-    let host_name = sanitize_ics(&details.host_name);
-    let guest_name = sanitize_ics(&details.guest_name);
+    // CN= is a parameter, not a TEXT value: it needs quoting, not backslashes.
+    let host_name = sanitize_ics_param(&details.host_name);
+    let guest_name = sanitize_ics_param(&details.guest_name);
     let host_email = sanitize_ics(&details.host_email);
     let guest_email = sanitize_ics(&details.guest_email);
     let location_line = details
@@ -576,8 +605,9 @@ fn generate_cancel_ics(details: &CancellationDetails) -> String {
         "{} \u{2014} {} & {}",
         details.event_title, guest_first, host_first
     ));
-    let host_name = sanitize_ics(&details.host_name);
-    let guest_name = sanitize_ics(&details.guest_name);
+    // CN= is a parameter, not a TEXT value: it needs quoting, not backslashes.
+    let host_name = sanitize_ics_param(&details.host_name);
+    let guest_name = sanitize_ics_param(&details.guest_name);
     let host_email = sanitize_ics(&details.host_email);
     let guest_email = sanitize_ics(&details.guest_email);
     let dtstamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
@@ -3816,6 +3846,109 @@ mod tests {
     // --- generate_ics edge cases ---
 
     #[test]
+    fn sanitize_ics_param_quotes_delimiters() {
+        // A plain name is left exactly as it was: no quotes, no escapes.
+        assert_eq!(sanitize_ics_param("Jane Doe"), "Jane Doe");
+        // Non-ASCII is a legal parameter value and must survive untouched.
+        assert_eq!(
+            sanitize_ics_param("Test Guest \u{ab}quotes\u{bb}"),
+            "Test Guest \u{ab}quotes\u{bb}"
+        );
+        // The three delimiters that end a paramtext force a quoted-string.
+        assert_eq!(sanitize_ics_param("Jane; Doe"), "\"Jane; Doe\"");
+        assert_eq!(sanitize_ics_param("Doe, Jane"), "\"Doe, Jane\"");
+        assert_eq!(sanitize_ics_param("Jane: Doe"), "\"Jane: Doe\"");
+        // Never a backslash escape — that is TEXT syntax and is what #163 was.
+        assert!(!sanitize_ics_param("Jane; Doe").contains('\\'));
+    }
+
+    #[test]
+    fn sanitize_ics_param_uses_caret_escapes() {
+        // A quoted-string cannot hold a DQUOTE, so RFC 6868 spells it `^'`.
+        assert_eq!(sanitize_ics_param("Jane \"JD\" Doe"), "Jane ^'JD^' Doe");
+        // The caret itself doubles, and it must be escaped first so an input
+        // caret cannot be mistaken for one this function introduced.
+        assert_eq!(sanitize_ics_param("a^b"), "a^^b");
+        assert_eq!(sanitize_ics_param("a^'b"), "a^^'b");
+        // CR/LF becomes `^n` rather than being dropped, which also keeps the
+        // header-injection guard: no raw newline survives.
+        assert_eq!(sanitize_ics_param("a\r\nb"), "a^nb");
+        assert_eq!(sanitize_ics_param("a\nb"), "a^nb");
+        assert_eq!(sanitize_ics_param("a\rb"), "a^nb");
+    }
+
+    #[test]
+    fn caldav_ics_quotes_a_guest_name_with_a_semicolon() {
+        // #163: Yandex 360 answers 400 Bad Request to `CN=Test Guest \; and`,
+        // because a parameter takes no backslash escapes and the raw `;` ends
+        // the parameter. The booking was reported confirmed and never reached
+        // the calendar. Quoting is the RFC 5545 §3.1 spelling.
+        let details = BookingDetails {
+            event_title: "Call".to_string(),
+            date: "2026-04-01".to_string(),
+            start_time: "10:00".to_string(),
+            end_time: "10:30".to_string(),
+            guest_name: "Test Guest \u{ab}quotes\u{bb} ; and a semicolon".to_string(),
+            guest_email: "guest@test.com".to_string(),
+            guest_timezone: "UTC".to_string(),
+            host_name: "H\u{e9}lo\u{ef}se; Host".to_string(),
+            host_email: "host@test.com".to_string(),
+            uid: "uid-163".to_string(),
+            notes: None,
+            location: None,
+            reminder_minutes: None,
+            additional_attendees: vec![],
+            ..Default::default()
+        };
+        let ics = generate_ics_caldav(&details);
+
+        assert!(
+            ics.contains(
+                "ATTENDEE;SCHEDULE-AGENT=CLIENT;CN=\"Test Guest \u{ab}quotes\u{bb} ; and a semicolon\";RSVP=TRUE:mailto:guest@test.com"
+            ),
+            "{ics}"
+        );
+        assert!(
+            ics.contains("ORGANIZER;CN=\"H\u{e9}lo\u{ef}se; Host\":mailto:host@test.com"),
+            "{ics}"
+        );
+        // The SUMMARY is a TEXT value and keeps backslash escaping.
+        assert!(
+            ics.contains("SUMMARY:Call \u{2014} Test & H\u{e9}lo\u{ef}se\u{5c};"),
+            "{ics}"
+        );
+        // No `CN=` value may carry a backslash escape.
+        for line in ics.lines().filter(|l| l.contains("CN=")) {
+            assert!(!line.contains("\\;"), "backslash-escaped CN: {line}");
+            assert!(!line.contains("\\,"), "backslash-escaped CN: {line}");
+        }
+    }
+
+    #[test]
+    fn cancel_ics_quotes_a_guest_name_with_a_semicolon() {
+        // The cancellation ICS builds its own VEVENT and had the same bug, so
+        // a guest with a semicolon could book but never be un-booked either.
+        let details = CancellationDetails {
+            event_title: "Call".to_string(),
+            date: "2026-04-01".to_string(),
+            start_time: "10:00".to_string(),
+            end_time: "10:30".to_string(),
+            guest_name: "Doe, Jane; Ms".to_string(),
+            guest_email: "guest@test.com".to_string(),
+            guest_timezone: "UTC".to_string(),
+            host_name: "Host".to_string(),
+            host_email: "host@test.com".to_string(),
+            uid: "uid-163-cancel".to_string(),
+            ..Default::default()
+        };
+        let ics = generate_cancel_ics(&details);
+        assert!(
+            ics.contains("ATTENDEE;CN=\"Doe, Jane; Ms\":mailto:guest@test.com"),
+            "{ics}"
+        );
+    }
+
+    #[test]
     fn generate_ics_sanitizes_malicious_guest_name() {
         let details = BookingDetails {
             event_title: "Call".to_string(),
@@ -3837,7 +3970,13 @@ mod tests {
         let ics = generate_ics(&details, "REQUEST");
         // The injected ATTENDEE line must not appear as a separate field
         assert!(!ics.contains("\r\nATTENDEE:hacker@evil.com"));
-        assert!(ics.contains("Evil ATTENDEE:hacker@evil.com")); // newline replaced with space
+        // The newline becomes an RFC 6868 `^n`, and the `:` it was carrying
+        // forces the whole CN into a quoted-string, so the payload stays one
+        // parameter value instead of breaking out into a property.
+        assert!(
+            ics.contains("CN=\"Evil^nATTENDEE:hacker@evil.com\""),
+            "{ics}"
+        );
     }
 
     #[test]

--- a/templates/dashboard_event_types.html
+++ b/templates/dashboard_event_types.html
@@ -38,7 +38,12 @@
         </div>
       </div>
       <div class="et-actions">
-        <button type="button" class="slot-btn copy-link-btn" style="font-size: 0.8rem; cursor: pointer;" title="{{ t('dashboard-event-types-copy-title') }}" data-copy-label="{{ t('dashboard-event-types-copy') }}" data-copied-label="{{ t('dashboard-event-types-copied') }}" data-copy-failed-label="{{ t('dashboard-event-types-copy-failed') }}" data-path="/{% if et.is_team %}team/{{ et.team_slug }}{% else %}u/{{ username }}{% endif %}/{{ et.slug }}">{{ t('dashboard-event-types-copy') }}</button>
+        {# Only where a public URL actually resolves. A private event type is
+           reached through a tokenised invite, so copying its path would hand
+           out a link that 404s; the row offers "Send invites" instead. #}
+        {% if et.view_url %}
+        <button type="button" class="slot-btn copy-link-btn" style="font-size: 0.8rem; cursor: pointer;" title="{{ t('dashboard-event-types-copy-title') }}" data-copy-label="{{ t('dashboard-event-types-copy') }}" data-copied-label="{{ t('dashboard-event-types-copied') }}" data-copy-failed-label="{{ t('dashboard-event-types-copy-failed') }}" data-path="{{ et.view_url }}">{{ t('dashboard-event-types-copy') }}</button>
+        {% endif %}
         {% if et.can_manage %}
         <a href="{{ et.edit_url }}" class="slot-btn" style="text-decoration: none; font-size: 0.8rem;">Edit</a>
         <form method="post" action="{{ et.toggle_url }}" style="margin: 0;">


### PR DESCRIPTION
Three contained fixes ahead of the next release.

## `fix(ics)` — quote ICS parameters instead of backslash-escaping them

Closes #163. Thanks to the reporter for a repro that had already ruled out the href.

`CN=` carried a value run through `sanitize_ics()`, which is TEXT escaping: a semicolon came out as `\;`. A parameter is not a TEXT value and takes no backslash escapes (RFC 5545 §3.1), so the raw `;` stayed in place and a strict parser read it as the end of the parameter. Yandex 360 answers `400 Bad Request` to the whole VEVENT — and since a failed write-back is only logged (#162), the guest was told **"You're booked!"** while nothing reached the calendar.

`sanitize_ics_param()` quotes the value when it carries one of the three delimiters a `paramtext` cannot hold, and spells `"`, `^` and newlines with the RFC 6868 caret escapes a quoted-string has no other way to express. Both generators use it for `ORGANIZER;CN` and `ATTENDEE;CN` — the cancellation ICS had the same bug, so an affected guest could not have been un-booked either. `SUMMARY`, `DESCRIPTION` and `LOCATION` are genuine TEXT values and keep `sanitize_ics()`.

The injection guard is unchanged in substance and pinned by the same test: a CRLF in a guest name still cannot break out into its own property, it now becomes `^n` inside a quoted value rather than a space.

| Guest name | Before | After |
|---|---|---|
| `Jane Doe` | `CN=Jane Doe` | `CN=Jane Doe` (unchanged) |
| `Test Guest «quotes» ; and a semicolon` | `CN=Test Guest «quotes» \; and a semicolon` → 400 | `CN="Test Guest «quotes» ; and a semicolon"` |
| `Doe, Jane` | `CN=Doe\, Jane` | `CN="Doe, Jane"` |
| `Evil\r\nATTENDEE:hacker@evil.com` | `CN=Evil ATTENDEE:hacker@evil.com` | `CN="Evil^nATTENDEE:hacker@evil.com"` |

Four new tests, including the reported name end to end through `generate_ics_caldav`.

## `fix(config)` — do not store a runtime setting the environment is forcing

Closes #142.

`admin_update_general` skips writing a field when its env var is set; the CLI wrote both unconditionally and printed a note that the env var takes precedence. It does, so nothing was wrong at the time — the footgun is later. An operator who runs `calrs config general --allow-private-hosts host.internal` on a box where `CALRS_ALLOW_PRIVATE_HOSTS` is set, and who removes that variable months afterwards, silently activates a stored allowlist they configured for a different reason. For an SSRF guard, that is a change to the security posture with no action at that moment.

The CLI now mirrors the handler: an env-forced field is left alone, and the refusal is printed rather than the previous after-the-fact note, so it lands on the field the operator actually passed. A field that is not forced is written as before, including when the other one was refused.

Also picks up the cosmetic follow-up noted in the issue: `validate_caldav_url`'s doc comment still described the allowlist as env-only after #140 gave it a DB-backed setting. `docs/src/security.md` gains the reason for the refusal.

## `fix(dashboard)` — only offer the copy button where a public URL resolves

Follow-up to #183, merged this morning. The button rebuilt the path in the template and rendered on every row, including private event types — which are reached through a tokenised invite and have no working public URL, so copying one handed out a link that 404s. It now reuses `et.view_url`, the value the "View page" entry is already gated on, and is hidden with it.

## Verification

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (900 passing) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration updates now preserve environment-enforced settings and clearly report when values cannot be changed through the CLI.
  - Copy-link actions appear only when a valid public event page is available.

- **Bug Fixes**
  - Improved calendar invitation and cancellation files to safely handle special characters and prevent malformed or unsafe attendee details.

- **Documentation**
  - Clarified private-host allowlisting behavior, including environment and database setting precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->