### PR TITLE
docs: drop Weblate, document translating in the repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,7 +583,7 @@ When adding a new migration:
 1. Create `migrations/NNN_description.sql` with the DDL.
 2. **CRITICAL: Register it in `src/db.rs`** in the `migrations` array inside `migrate()`. Forgetting this step means the migration never runs on existing deployments, and any queries referencing the new table/column will fail silently (due to `unwrap_or_default()`). This has caused production bugs before — always verify the migration is registered.
 
-### Localization (Fluent + Weblate)
+### Localization (Fluent)
 
 calrs ships with translations for English, French, Spanish, Polish, German, Italian, Estonian and Brazilian Portuguese. Source files live under `i18n/{lang}/main.ftl` and are embedded in the binary via `include_str!` (no runtime files). The loader, language detection, and minijinja `t()` global are in `src/i18n.rs`. Templates use `{{ t("message-id", arg=value) }}` and the active language is injected into the rendering context as `lang` by the calling handler.
 
@@ -605,24 +605,26 @@ All locales address the reader informally, matching what the earliest translatio
 
 **Literal braces in a Fluent value** must be escaped as `{"{"}`: a bare `{` starts a placeable. This bites the meeting-pattern help, which documents `{username}` and `{random}` tokens.
 
-**Branch workflow (long-lived `i18n` branch).** The `i18n` branch is permanent. **Do not delete it after merging.** Translators commit through Hosted Weblate, which pushes to `i18n` via the Weblate GitHub App. Periodically (e.g. before each release) merge `i18n` into `main`, then continue using the same branch for the next round of translations. The branch never gets recreated.
+**Branch workflow (long-lived `i18n` branch).** The `i18n` branch is permanent. **Do not delete it after merging.** Translation contributions arrive as pull requests against it. Periodically (e.g. before each release) merge `i18n` into `main`, then continue using the same branch for the next round. The branch never gets recreated, and it normally sits exactly at `main`, so a round never starts stale.
+
+**There is no translation platform.** A Hosted Weblate project was applied for and never approved, so the account was closed and the links 404ed for months while the README still advertised them (#200). No commit in this repository's history was ever authored by Weblate. Every community translation calrs has received came in as an ordinary pull request. Do not reintroduce a platform reference without a working project behind it.
 
 **When you add or change a translatable string:**
-1. Land it on the `i18n` branch first, not `main`. This avoids half-translated UI on `main` and gives Weblate translators time to catch up before the next merge.
+1. Land it on the `i18n` branch first, not `main`. This keeps half-translated UI off `main` and gives contributors a window before the next merge.
 2. Add the new key to `i18n/en/main.ftl` (the source of truth), then to every other locale. The runtime still falls back to English per missing key, but the coverage test does not let you rely on it.
 3. If the change touches a template that wasn't translated yet, convert its hard-coded strings to `{{ t("...") }}` calls in the same commit, and add render-site context entries (`lang => crate::i18n::detect_from_headers(&headers)` for guest pages, `lang => auth_user.lang` for authenticated dashboard pages).
 4. Run `cargo test i18n::` before pushing: it checks coverage across all eight locales and the plural categories each language needs.
 
-**Adding a key now costs eight translations, not one.** The coverage test fails until every locale has a value. That is deliberate: a half-translated page is worse than an English one because nobody notices it is wrong. If you cannot supply all eight, land the key on `i18n` and let Weblate fill the rest before merging to `main`.
+**Adding a key now costs eight translations, not one.** The coverage test fails until every locale has a value. That is deliberate: a half-translated page is worse than an English one because nobody notices it is wrong. If you cannot supply all eight, land the key on `i18n` and leave it there until someone can.
 
-**When you add a new locale:**
-1. Create `i18n/{code}/main.ftl` (start empty, runtime falls back to English).
-2. Register it in `SUPPORTED_LANGS` in `src/i18n.rs`.
-3. Add a label to `supported_with_labels()` so it appears in the settings dropdown.
-4. Push to `i18n`. Weblate auto-detects the new language file on next pull.
+**When you add a new locale**, in this order:
+1. Create `i18n/{code}/main.ftl` and translate every key. **Not empty**: the moment the locale is registered, `every_locale_covers_every_english_key` demands all of them, so an empty file fails with over a thousand errors.
+2. Register it in `SUPPORTED_LANGS` in `src/i18n.rs`: code, the language's own name for itself, `include_str!`. `supported_with_labels()` derives the settings dropdown from this tuple, so there is no second place to edit.
+3. Add the locale's CLDR plural categories to the `required` table in `plural_messages_carry_the_locale_categories`. Most need `one, other`; Polish needs `one, few, many`.
+4. `cargo test i18n::`, then push to `i18n`.
 
 **Anti-patterns to avoid:**
-- Don't bypass `t()` and inline new English strings directly in templates that are already translated. Translators will silently drift out of date.
+- Don't bypass `t()` and inline new English strings directly in templates that are already translated. The other locales silently drift out of date.
 - Don't merge `main` into `i18n` to "sync"; the flow goes `i18n → main`. New features that touch UI text should branch off `i18n`, not `main`.
 
 ### Updating the GitHub Pages site

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ Each team member's CalDAV calendars are checked for conflicts. The availability 
 
 ### Localization
 
-- **Multi-language UI**: public booking flow available in English, French, Spanish, Polish, German, Italian, and Brazilian Portuguese. Strings are managed via [Fluent](https://projectfluent.org/) and embedded in the binary at compile time, so no runtime files to ship
+- **Multi-language UI**: the whole application, guest side and host side, in English, French, Spanish, Polish, German, Italian, Estonian and Brazilian Portuguese. Strings are managed via [Fluent](https://projectfluent.org/) and embedded in the binary at compile time, so no runtime files to ship
 - **Automatic language detection**: guests get their browser's language (RFC 7231 `Accept-Language` with q-weights). Authenticated users can override the choice in **Profile & Settings**
-- **Community-driven translations**: contribute via [Hosted Weblate](https://hosted.weblate.org/projects/calrs/) without needing to touch git or Rust. See [Contributing translations](#contributing-translations)
+- **Community-driven translations**: contributed by pull request, no separate platform to sign up for. See [Contributing a translation](#contributing-a-translation)
 
 ### Quality
 
@@ -638,9 +638,9 @@ calrs/
 
 ## Localization
 
-[![Translation status](https://hosted.weblate.org/widget/calrs/multi-auto.svg)](https://hosted.weblate.org/engage/calrs/)
+calrs ships with eight complete translations: English, French, Spanish, Polish, German, Italian, Estonian and Brazilian Portuguese. Strings live in [Fluent](https://projectfluent.org/) `.ftl` files under `i18n/` and are embedded in the binary at compile time, so there are no runtime translation files to deploy.
 
-calrs ships with translations for English, French, Spanish, Polish, German, Italian, and Brazilian Portuguese. Strings are stored in [Fluent](https://projectfluent.org/) `.ftl` files under `i18n/` and embedded in the binary at compile time.
+Every locale carries all 1043 message ids. A test holds them there, so a release cannot ship a half-translated language.
 
 ### Translation quality
 
@@ -648,10 +648,10 @@ calrs ships with translations for English, French, Spanish, Polish, German, Ital
 |---|---|
 | English | Source language |
 | French | Human-translated and reviewed |
-| Brazilian Portuguese | Community-contributed by a native speaker |
-| Spanish, Polish, German, Italian | AI-seeded as a starting point, awaiting native-speaker refinement |
+| Brazilian Portuguese | Contributed by a native speaker |
+| Spanish, Polish, German, Italian, Estonian | Complete, but machine-seeded. Native-speaker review very welcome |
 
-If you're a native speaker of one of the AI-seeded locales, your eyes are very welcome on [Hosted Weblate](https://hosted.weblate.org/projects/calrs/). No git or Rust knowledge required, everything happens in the browser. See [Contributing translations](#contributing-translations) below.
+Complete is not the same as good. The machine-seeded locales are grammatical and internally consistent, and they have been checked for the things automated translation usually gets wrong: the register stays informal throughout, Polish carries the plural categories its grammar needs rather than English's two, and sentences that interpolate a value avoid agreeing with it. What they have not had is a native speaker reading them in context, on the actual pages. If one of those is your language, the section below is for you.
 
 ### How language is selected
 
@@ -661,25 +661,53 @@ If you're a native speaker of one of the AI-seeded locales, your eyes are very w
 | Logged-in user with no preference set | Same as above |
 | Logged-in user with a preference set | The user's choice in **Profile & Settings** |
 
-Untranslated keys fall back to English at runtime, so a partial translation never breaks the page.
+Untranslated keys fall back to English at runtime, so a partial translation never breaks a page. Shipped locales are never partial, but the fallback keeps a work-in-progress branch usable.
 
-### Contributing translations
+### Contributing a translation
 
-Translators do not need to touch git, Rust, or even know the project structure. Everything happens in the browser:
+Everything happens in this repository through a pull request. There is no separate platform to sign up for, and the six people who have contributed translations so far all did it this way.
 
-1. Open the project on Hosted Weblate: <https://hosted.weblate.org/projects/calrs/>
-2. Pick your language (or click **Start new translation** if it isn't listed)
-3. Translate strings in the web editor
+Base your work on the **`i18n` branch**, not `main`. It is permanent, it normally sits exactly at `main`, and it exists so new strings can settle before a release picks them up.
 
-Saved translations flow back to the `i18n` branch automatically. Maintainers periodically merge that branch into `main`, and the next release ships with your work.
+#### Improving a language that already ships
 
-If you want a language that isn't yet listed, open an issue or just start translating it on Weblate. Adding a new locale on the calrs side is a one-line change.
+1. Fork the repo and branch off `i18n`
+2. Edit `i18n/{code}/main.ftl`. The message id is on the left of the `=` and never changes; only the text to its right gets translated
+3. Run `cargo test i18n::`
+4. Open a pull request against `i18n`
+
+You do not need to touch Rust, and you do not need to translate everything. A pull request fixing one awkward sentence is worth sending.
+
+#### Adding a new language
+
+Four steps, and the order matters. Doing them out of order fails the build in a way that looks like the project is broken:
+
+1. **Translate first.** Copy `i18n/en/main.ftl` to `i18n/{code}/main.ftl` and translate every value, keeping the ids exactly as they are.
+2. **Then register it.** Add one line to `SUPPORTED_LANGS` in `src/i18n.rs`: the code, the language's own name for itself (`Eesti`, not `Estonian`), and an `include_str!` of the new file.
+3. **Declare its plural categories.** Add the locale to the `required` table in `plural_messages_carry_the_locale_categories` in `src/i18n.rs`. Most languages need `one, other`; Polish needs `one, few, many`. The [CLDR plural rules chart](https://www.unicode.org/cldr/charts/47/supplemental/language_plural_rules.html) is the reference.
+4. Run `cargo test i18n::`
+
+Step 1 comes before step 2 for a reason: the coverage test demands every key the moment a locale appears in `SUPPORTED_LANGS`, so registering an empty file fails with 1043 errors at once.
+
+That is the whole change on the calrs side. The language then appears in the **Profile & Settings** dropdown and is matched against `Accept-Language` automatically.
+
+#### Using an LLM to help
+
+This is fine, and it is how five of the current locales started. It is also why native review matters more than volume. Three things a model reliably gets wrong here:
+
+- **Fluent syntax is easy to break.** A placeable such as `{ $count }` must survive verbatim, including the spaces. A literal brace has to be written `{"{"}`, because a bare `{` starts a placeable. There are no backslash escapes: a newline is `{"\u000A"}`, not `\n`.
+- **Plurals are not a translation of English plurals.** English selects two forms; Polish selects three for integers. Copying the English `one`/`other` shape into Polish produces text that reads wrong at 2 and at 5. Write the categories your language actually uses.
+- **Register drifts.** All locales here address the reader informally (du, tu, tú, ty, você, sa). Models default to the formal register in German and Spanish unless told otherwise, and the result is a page that switches politeness level halfway down.
+
+The test suite checks structure, not meaning. It will catch a missing key, a broken placeable and a missing plural category. It cannot tell you that a sentence is stilted, that a term is wrong for your industry, or that a word is right in Portugal and wrong in Brazil. Say in the pull request description if a translation is machine-seeded, so reviewers know what they are reading.
 
 ### For developers
 
-- Translation source lives in `i18n/{lang}/main.ftl` (one file per language, kebab-case message IDs)
-- Loader: `src/i18n.rs`. Strings are accessed in templates via `{{ t("message-id", arg=value) }}`
-- New translatable strings should land on the `i18n` branch first so translators see them on Weblate before the next merge into `main`
+- Translation source lives in `i18n/{lang}/main.ftl`, one file per language, kebab-case message ids
+- Loader and language detection: `src/i18n.rs`. Templates use `{{ t("message-id", arg=value) }}`; the active language reaches the template as `lang`
+- New translatable strings land on the `i18n` branch first, then merge into `main`. The flow is one-directional: never merge `main` into `i18n`
+- Adding a key costs eight translations, not one. The coverage test fails until every locale has a value, which is deliberate: a half-translated page is worse than an English one, because nobody notices it is wrong
+- Run `cargo test i18n::` before pushing. It checks key coverage across all eight locales, that every template still loads, and that plural messages carry the categories each language needs
 
 ## License
 


### PR DESCRIPTION
Closes the real problem behind #200.

## What I found

The Hosted Weblate project was applied for and never approved, so the account was closed. All three advertised URLs return 404, including `multi-auto.svg`, which meant the README rendered a **broken image at the top of its Localization section**.

Worth stating plainly: **the integration never worked.** No commit in this repository's history was ever authored by Weblate or carries "Translated using Weblate", and there is no `.weblate` config file. The CHANGELOG line crediting "Translation updates from Weblate (PR #131)" is mislabelled, that PR was a maintainer's own `i18n → main` merge.

Meanwhile six people have contributed translations by ordinary pull request: @GwenLg, @RafaelGrochoska, Mark Steele, Guil. Sperb Machado, Florian Seigle-Vatte and Arthur Perrot. The flow documented here is not a fallback, it is the only flow that has ever delivered a community translation to this project.

## What changes

**README** gets a real contributor guide in place of the dead links: how to improve a shipped language, how to add a new one, and a short section on what an LLM reliably gets wrong when seeding a locale (Fluent placeables and brace escaping, plural categories that are not English's two, and the formal register models default to in German and Spanish).

The locale list also said seven languages and omitted Estonian, and the quality table still described Spanish, Polish, German and Italian as awaiting refinement without noting they are now complete. Both corrected.

**CLAUDE.md** keeps the `i18n` branch, whose value never depended on Weblate, but its rationale no longer references a platform that does not exist.

## Two stale instructions fixed

Both would have sent a contributor into a wall:

- *"Create `i18n/{code}/main.ftl` (start empty, runtime falls back to English)"* is wrong now. Registering a locale in `SUPPORTED_LANGS` makes `every_locale_covers_every_english_key` demand all 1043 keys immediately, so an empty file fails with 1043 errors. The guide says translate first, register second, and says why.
- *"Add a label to `supported_with_labels()`"* is no longer a step. `SUPPORTED_LANGS` carries the label and that function maps over it.

And one step that was undocumented entirely: a new locale must declare its CLDR plural categories in `plural_messages_carry_the_locale_categories`, or the build fails with no hint as to why.

## Verification

Docs only, no code changes. `cargo test` 913 passing, `cargo fmt --check` clean. Every factual claim checked against the tree: 1043 keys, eight locales in `SUPPORTED_LANGS`, six non-maintainer contributors to `i18n/`, and all three Weblate URLs confirmed 404.

The site's own Weblate link on `gh-pages` is handled separately, since that branch is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgp4a7mJghkqcgJBji14yS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated localization guidance to describe pull-request-based translation contributions.
  * Documented support for eight complete translations, including Estonian.
  * Added translation quality details and instructions for improving or adding languages.
  * Expanded developer guidance, including testing requirements and responsible use of translation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->