### PR TITLE
fix(settings): confirm a language change in the language just saved

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3443,16 +3443,15 @@ async fn settings_save(
             let updated_user = crate::auth::get_user_by_id(&state.pool, &user.id)
                 .await
                 .unwrap_or_else(|| user.clone());
+            // auth_user.lang was resolved before the UPDATE, so a language
+            // change would confirm in the old language without this.
+            let lang = crate::i18n::resolve(updated_user.language.as_deref(), &headers);
             let sidebar = sidebar_context(&auth_user, "settings");
             settings_render(
                 &state,
                 &updated_user,
-                auth_user.lang,
-                Some(&crate::i18n::translate(
-                    auth_user.lang,
-                    "settings-saved",
-                    None,
-                )),
+                lang,
+                Some(&crate::i18n::translate(lang, "settings-saved", None)),
                 None,
                 sidebar,
                 imp,
@@ -29970,6 +29969,27 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(name.unwrap(), "Updated Name");
+    }
+
+    #[tokio::test]
+    async fn settings_save_confirms_language_change_in_the_new_language() {
+        let (app, _pool, session, _) = setup_test_app().await;
+        let csrf = "test-csrf-settings-lang";
+        let body = format!("_csrf={}&name=Test+User&booking_email=&language=fr", csrf);
+        let response = app
+            .oneshot(post_form("/dashboard/settings", &session, csrf, &body))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let resp_body = body_string(response).await;
+        assert!(
+            resp_body.contains("Paramètres enregistrés"),
+            "confirmation should render in the language that was just saved"
+        );
+        assert!(
+            !resp_body.contains("Settings saved"),
+            "confirmation should not render in the pre-save language"
+        );
     }
 
     // --- Admin actions ---


### PR DESCRIPTION
Closes #204.

## The bug

Saving "Français" from an English session returns an English page, "Settings saved" included. Only a reload shows the French one. The preference itself is stored correctly, so every later page is right; it is the confirmation that lags.

## Cause

`settings_save` re-fetches the user row after the UPDATE to show the new values, but renders with `auth_user.lang`, which the extractor resolved from the pre-save row. The success and error flashes translate against the same stale value. The one request where the language changes is the one request that cannot see it.

## Fix

Resolve the language a second time after the re-fetch, from the fresh row and the request headers already in the handler's scope:

```rust
let lang = crate::i18n::resolve(updated_user.language.as_deref(), &headers);
```

I considered a post/redirect/get instead, which would fix it structurally, but it drags the flash message along and that is more change than this bug needs.

Nothing else is affected: `settings_save` is the only handler that writes `users.language`, and every other page resolves on its own request, after the preference is stored.

## Test

`settings_save_confirms_language_change_in_the_new_language` drives a real POST with `language=fr` under an English session and asserts the French confirmation is present and the English one is not.

Mutation-checked, per the standard the 1.17.1 notes set: restoring `auth_user.lang` on the render fails it with "confirmation should render in the language that was just saved". The negative assertion matters on its own, since a page carrying both strings would otherwise pass.

## Checks

- `cargo test`: 914 passed, 0 failed
- `cargo clippy --all-targets`: clean
- `cargo fmt --check`: clean
- Manually on a local build, all eight locales available: en to fr, fr back to en, and "Auto" falling through to `Accept-Language`

No new Fluent keys, so this targets `main` rather than `i18n`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings changes are now confirmed in the newly selected language.
  * Added coverage to verify that French language selections display confirmation messages in French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->